### PR TITLE
feat: implement CSS-variable based syntax highlighting for dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
     <!-- Updated libraries to latest versions -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.3.0/github-markdown.min.css">
-    <link rel="stylesheet" id="highlight-theme" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/emoji-toolkit@9.0.1/extras/css/joypixels.min.css">
     <link rel="stylesheet" href="styles.css">

--- a/script.js
+++ b/script.js
@@ -121,11 +121,6 @@ document.addEventListener("DOMContentLoaded", function () {
   marked.setOptions({
     ...markedOptions,
     renderer: renderer,
-    highlight: function (code, language) {
-      if (language === 'mermaid') return code;
-      const validLanguage = hljs.getLanguage(language) ? language : "plaintext";
-      return hljs.highlight(code, { language: validLanguage }).value;
-    },
   });
 
   const sampleMarkdown = `# Welcome to Markdown Viewer
@@ -145,10 +140,9 @@ document.addEventListener("DOMContentLoaded", function () {
     const sanitizedHtml = DOMPurify.sanitize(html);
     markdownPreview.innerHTML = sanitizedHtml;
     
-    // Apply syntax highlighting to code blocks
-    markdownPreview.querySelectorAll('pre code').forEach((block) => {
-        hljs.highlightElement(block);
-    });
+    // Syntax highlighting is handled automatically
+    // during the parsing phase by the marked renderer.
+    // Themes are applied instantly via CSS variables.
   }
 \`\`\`
 
@@ -301,16 +295,6 @@ This is a fully client-side application. Your content never leaves your browser 
         ADD_ATTR: ['id', 'class', 'style']
       });
       markdownPreview.innerHTML = sanitizedHtml;
-
-      markdownPreview.querySelectorAll("pre code").forEach((block) => {
-        try {
-          if (!block.classList.contains('mermaid') && !block.classList.contains('hljs')) {
-            hljs.highlightElement(block);
-          }
-        } catch (e) {
-          console.warn("Syntax highlighting failed for a code block:", e);
-        }
-      });
 
       processEmojis(markdownPreview);
       
@@ -813,9 +797,6 @@ This is a fully client-side application. Your content never leaves your browser 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Markdown Export</title>
   <link rel="stylesheet" href="${cssTheme}">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/${
-    isDarkTheme ? "github-dark" : "github"
-  }.min.css">
   <style>
       body {
           background-color: ${isDarkTheme ? "#0d1117" : "#ffffff"};
@@ -830,6 +811,23 @@ This is a fully client-side application. Your content never leaves your browser 
           background-color: ${isDarkTheme ? "#0d1117" : "#ffffff"};
           color: ${isDarkTheme ? "#c9d1d9" : "#24292e"};
       }
+
+      /* Syntax Highlighting */
+      .hljs-doctag, .hljs-keyword, .hljs-template-tag, .hljs-template-variable, .hljs-type, .hljs-variable.language_ { color: ${isDarkTheme ? "#ff7b72" : "#d73a49"}; }
+      .hljs-title, .hljs-title.class_, .hljs-title.class_.inherited__, .hljs-title.function_ { color: ${isDarkTheme ? "#d2a8ff" : "#6f42c1"}; }
+      .hljs-attr, .hljs-attribute, .hljs-literal, .hljs-meta, .hljs-number, .hljs-operator, .hljs-variable, .hljs-selector-attr, .hljs-selector-class, .hljs-selector-id { color: ${isDarkTheme ? "#79c0ff" : "#005cc5"}; }
+      .hljs-regexp, .hljs-string, .hljs-meta .hljs-string { color: ${isDarkTheme ? "#a5d6ff" : "#032f62"}; }
+      .hljs-built_in, .hljs-symbol { color: ${isDarkTheme ? "#ffa657" : "#e36209"}; }
+      .hljs-comment, .hljs-code, .hljs-formula { color: ${isDarkTheme ? "#8b949e" : "#6a737d"}; }
+      .hljs-name, .hljs-quote, .hljs-selector-tag, .hljs-selector-pseudo { color: ${isDarkTheme ? "#7ee787" : "#22863a"}; }
+      .hljs-subst { color: ${isDarkTheme ? "#c9d1d9" : "#24292e"}; }
+      .hljs-section { color: ${isDarkTheme ? "#1f6feb" : "#005cc5"}; font-weight: bold; }
+      .hljs-bullet { color: ${isDarkTheme ? "#79c0ff" : "#005cc5"}; }
+      .hljs-emphasis { font-style: italic; }
+      .hljs-strong { font-weight: bold; }
+      .hljs-addition { color: ${isDarkTheme ? "#aff5b4" : "#22863a"}; background-color: ${isDarkTheme ? "#033a16" : "#f0fff4"}; }
+      .hljs-deletion { color: ${isDarkTheme ? "#ffdcd7" : "#b31d28"}; background-color: ${isDarkTheme ? "#67060c" : "#ffeef0"}; }
+
       @media (max-width: 767px) {
           .markdown-body {
               padding: 15px;

--- a/styles.css
+++ b/styles.css
@@ -413,8 +413,82 @@ a:focus {
   background-color: var(--code-bg);
 }
 
-[data-theme="dark"] .hljs {
-  color: #e8eaed;
+/* Syntax Highlighting Mapping to GitHub Variables */
+.hljs {
+  color: var(--color-fg-default);
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: var(--color-prettylights-syntax-keyword);
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: var(--color-prettylights-syntax-entity);
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: var(--color-prettylights-syntax-constant);
+}
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  color: var(--color-prettylights-syntax-string);
+}
+.hljs-built_in,
+.hljs-symbol {
+  color: var(--color-prettylights-syntax-variable);
+}
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  color: var(--color-prettylights-syntax-comment);
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: var(--color-prettylights-syntax-entity-tag);
+}
+.hljs-subst {
+  color: var(--color-fg-default);
+}
+.hljs-section {
+  color: var(--color-prettylights-syntax-markup-heading);
+  font-weight: bold;
+}
+.hljs-bullet {
+  color: var(--color-prettylights-syntax-constant);
+}
+.hljs-emphasis {
+  color: var(--color-fg-default);
+  font-style: italic;
+}
+.hljs-strong {
+  color: var(--color-fg-default);
+  font-weight: bold;
+}
+.hljs-addition {
+  color: var(--color-prettylights-syntax-markup-inserted-text);
+  background-color: var(--color-prettylights-syntax-markup-inserted-bg);
+}
+.hljs-deletion {
+  color: var(--color-prettylights-syntax-markup-deleted-text);
+  background-color: var(--color-prettylights-syntax-markup-deleted-bg);
 }
 
 .stats-container {
@@ -1105,3 +1179,4 @@ a:focus {
 .mermaid-modal-controls .mermaid-toolbar-btn {
   opacity: 1;
 }
+


### PR DESCRIPTION
This pull request refactors how syntax highlighting is handled in the Markdown Viewer application. It removes the use of external Highlight.js theme stylesheets and manual highlighting logic in favor of CSS-based theming mapped to GitHub's color variables. This results in a more consistent appearance across light and dark themes and simplifies the codebase by relying on CSS for styling and automatic highlighting during Markdown parsing.

Syntax Highlighting Refactor:

* Removed external Highlight.js theme stylesheets from `index.html` and export HTML generation, and replaced them with custom CSS rules for syntax highlighting. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L35) [[2]](diffhunk://#diff-ed3ee7e0beea2498ff3b8ca85973d122fc6fa3d585d62b5807ec034d0cf076b3L816-L818)
* Replaced manual code block highlighting in `script.js` with automatic highlighting during Markdown parsing, removing related code and comments. [[1]](diffhunk://#diff-ed3ee7e0beea2498ff3b8ca85973d122fc6fa3d585d62b5807ec034d0cf076b3L124-L128) [[2]](diffhunk://#diff-ed3ee7e0beea2498ff3b8ca85973d122fc6fa3d585d62b5807ec034d0cf076b3L148-R145) [[3]](diffhunk://#diff-ed3ee7e0beea2498ff3b8ca85973d122fc6fa3d585d62b5807ec034d0cf076b3L305-L314)
* Added detailed syntax highlighting rules to `styles.css`, mapping Highlight.js classes to GitHub color variables for both light and dark themes.

Theme Consistency Improvements:

* Ensured syntax highlighting colors adapt to theme changes by using CSS variables and dynamic color assignments in exported HTML.

Minor Changes:

* Added a newline at the end of `styles.css` for formatting consistency.