### PR TITLE
fix(desktop): open file passed as CLI argument on launch

### DIFF
--- a/desktop-app/neutralino.config.json
+++ b/desktop-app/neutralino.config.json
@@ -13,7 +13,7 @@
     "enabled": true,
     "writeToLogFile": true
   },
-  "nativeAllowList": ["app.*", "os.*", "debug.log"],
+  "nativeAllowList": ["app.*", "os.*", "filesystem.readFile", "debug.log"],
   "globalVariables": {},
   "modes": {
     "window": {

--- a/desktop-app/resources/js/main.js
+++ b/desktop-app/resources/js/main.js
@@ -97,3 +97,31 @@ if (NL_OS != "Darwin") {
   // TODO: Fix https://github.com/neutralinojs/neutralinojs/issues/615
   setTray();
 }
+
+// Open file passed as command-line argument (e.g. when double-clicking a .md file)
+(async function loadInitialFile() {
+  const args = Array.isArray(NL_ARGS) ? NL_ARGS : (() => { try { return JSON.parse(NL_ARGS); } catch(e) { return []; } })();
+  const filePath = args.find(a => typeof a === 'string' && /\.(md|markdown)$/i.test(a));
+  if (!filePath) return;
+
+  try {
+    const content = await Neutralino.filesystem.readFile(filePath);
+
+    function applyContent() {
+      const editor = document.getElementById('markdown-editor');
+      const dropzone = document.getElementById('dropzone');
+      if (!editor) return;
+      editor.value = content;
+      editor.dispatchEvent(new Event('input'));
+      if (dropzone) dropzone.style.display = 'none';
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', applyContent);
+    } else {
+      setTimeout(applyContent, 0);
+    }
+  } catch (e) {
+    console.warn('Could not open initial file:', e);
+  }
+})();


### PR DESCRIPTION
## Problem

When a .md file is associated with the desktop app and double-clicked, the OS passes the file path as a command-line argument. The app was ignoring this and always showed the landing page, forcing the user to manually drag-and-drop or import the file.

## Solution

In main.js, added a loadInitialFile function that reads NL_ARGS to find any .md or .markdown file path, uses Neutralino.filesystem.readFile to load its content, then injects it into the editor on startup.

In neutralino.config.json, added filesystem.readFile to nativeAllowList to permit the API call.

## Testing

1. Build the app: npm run build
2. Set the .exe as default app for .md files
3. Double-click a .md file - it opens directly in the viewer without any manual import step