### PR TITLE
Add Built with Markdown Viewer section: Markdown Desk  (macOS native wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin amazing-feature`)
 5. Open a Pull Request
 
+## 🖥️ Built with Markdown Viewer
+
+| Project | Description |
+|---------|-------------|
+| [Markdown Desk](https://github.com/jhrepo/markdown-desk) | A native macOS desktop wrapper built with [Tauri](https://tauri.app/), adding live reload and native file open/save (`Cmd+O`/`Cmd+S`). Tracks upstream via Git submodule. |
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Hi Baivab Sarkar 👋

I built [Markdown Desk](https://github.com/jhrepo/markdown-desk), a native macOS desktop app that wraps Markdown Viewer using Tauri.

It adds a few desktop-specific features on top of your excellent web app:
- **Live Reload** — watches the opened file and refreshes on external edits
- **Native file open/save** — Cmd+O / Cmd+S
- **Tracks upstream** — includes your source as a Git submodule  and periodically merges updates into new app releases

The original Markdown Viewer source is included as a Git submodule and will not be modified — all customizations are applied through a separate bridge script.

This PR simply adds a small "Built with Markdown Viewer" section to the README so users who prefer a native experience can discover it.

Thank you for creating Markdown Viewer — it's a great project! 🙏
