### PR TITLE
Fix pane widths not resetting when switching tabs across view modes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1552,8 +1552,8 @@ This is a fully client-side application. Your content never leaves your browser 
     if (mode === 'split') {
       // Restore preserved pane widths when entering split mode
       applyPaneWidths();
-    } else if (previousMode === 'split') {
-      // Reset pane widths when leaving split mode
+    } else {
+      // Reset inline pane widths when not in split mode
       resetPaneWidths();
     }
 


### PR DESCRIPTION
## Bug

  1. Set Tab A to **Preview** mode
  2. Set Tab B to **Split** mode
  3. Switch back to Tab A

  **Expected:** Full-width Preview mode.
  **Actual:** Preview renders at 50% width, leaving the right half empty.

  ## Root Cause

  `restoreViewMode()` sets `currentViewMode = null` before calling `setViewMode()`, so `previousMode` is always `null` inside
  `setViewMode()`. The `previousMode === 'split'` check never passes, `resetPaneWidths()` is never called, and the inline flex styles
  from Split mode persist and override the CSS.

  ## Fix

  Changed `else if (previousMode === 'split')` to `else` so inline flex styles are always cleared when entering a non-split mode.

  ```diff
      if (mode === 'split') {
          applyPaneWidths();
  -   } else if (previousMode === 'split') {
  +   } else {
          resetPaneWidths();
      }

  resetPaneWidths() only sets style.flex = '', which is a no-op when no inline styles exist. No side effects for other mode transitions.
  ```