### PR TITLE
fix: resolve visual, accessibility, logic, and deployment issues from full audit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,3 +39,6 @@ logs/
 tmp/
 temp/
 
+# Desktop app (NeutralinoJS) - not needed in web container
+desktop-app/
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha

--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
         </div>
 
         <!-- Reset Confirmation Modal -->
-        <div id="reset-confirm-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reset-modal-title" style="display:none;">
+        <div id="reset-confirm-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reset-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="reset-modal-title" class="reset-modal-message">Are you sure you want to delete all files?</p>
             <div class="reset-modal-actions">
@@ -527,7 +527,7 @@
         </div>
 
         <!-- Rename Modal -->
-        <div id="rename-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="rename-modal-title" style="display:none;">
+        <div id="rename-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="rename-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="rename-modal-title" class="reset-modal-message">Rename file</p>
             <input type="text" id="rename-modal-input" class="rename-modal-input" placeholder="File name" />
@@ -539,7 +539,7 @@
         </div>
 
         <!-- Link Modal -->
-        <div id="link-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="link-modal-title" style="display:none;">
+        <div id="link-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="link-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="link-modal-title" class="reset-modal-message">Insert link</p>
             <div class="reset-modal-field">
@@ -558,7 +558,7 @@
         </div>
 
         <!-- Reference Modal -->
-        <div id="reference-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reference-modal-title" style="display:none;">
+        <div id="reference-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reference-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="reference-modal-title" class="reset-modal-message">Insert reference</p>
             <div class="reset-modal-field">
@@ -581,7 +581,7 @@
         </div>
 
         <!-- Image Modal -->
-        <div id="image-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="image-modal-title" style="display:none;">
+        <div id="image-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="image-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="image-modal-title" class="reset-modal-message">Insert image</p>
             <div class="reset-modal-toggle-group">
@@ -615,7 +615,7 @@
         </div>
 
         <!-- Table Modal -->
-        <div id="table-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="table-modal-title" style="display:none;">
+        <div id="table-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="table-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="table-modal-title" class="reset-modal-message">Insert table</p>
             <div class="reset-modal-field">
@@ -634,7 +634,7 @@
         </div>
 
         <!-- Emoji Modal -->
-        <div id="emoji-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="emoji-modal-title" style="display:none;">
+        <div id="emoji-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="emoji-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide reset-modal-box--xl">
             <p id="emoji-modal-title" class="reset-modal-message">GitHub Emojis</p>
             <div class="reset-modal-field">
@@ -651,7 +651,7 @@
         </div>
 
         <!-- Symbols Modal -->
-        <div id="symbols-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="symbols-modal-title" style="display:none;">
+        <div id="symbols-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="symbols-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide reset-modal-box--xl">
             <p id="symbols-modal-title" class="reset-modal-message">Symbols &amp; HTML Entities</p>
             <div class="reset-modal-field">
@@ -668,7 +668,7 @@
         </div>
 
         <!-- Markdown Alert Modal -->
-        <div id="alert-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="alert-modal-title" style="display:none;">
+        <div id="alert-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="alert-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="alert-modal-title" class="reset-modal-message">Markdown alerts</p>
             <div id="alert-modal-grid" class="alert-grid" role="listbox" aria-label="Markdown alert types"></div>
@@ -680,7 +680,7 @@
         </div>
 
         <!-- GitHub Import Modal -->
-        <div id="github-import-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="github-import-title" style="display:none;">
+        <div id="github-import-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="github-import-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box">
             <p id="github-import-title" class="reset-modal-message">Import Markdown from GitHub</p>
             <input type="url" id="github-import-url" class="rename-modal-input" placeholder="https://github.com/owner/repo/blob/main/README.md" />
@@ -727,7 +727,7 @@
     </div>
 
     <!-- Mermaid Zoom Modal -->
-    <div id="mermaid-zoom-modal" role="dialog" aria-modal="true" aria-label="Diagram zoom view">
+    <div id="mermaid-zoom-modal" role="dialog" aria-modal="true" aria-label="Diagram zoom view" aria-hidden="true">
         <div class="mermaid-modal-content">
             <div class="mermaid-modal-header">
                 <span>Diagram</span>

--- a/script.js
+++ b/script.js
@@ -3769,7 +3769,7 @@ This is a fully client-side application. Your content never leaves your browser 
     if (!query) return;
     const replacement = findReplaceWith ? findReplaceWith.value : '';
     const regex = new RegExp(escapeRegExp(query), 'gi');
-    markdownEditor.value = markdownEditor.value.replace(regex, replacement);
+    markdownEditor.value = markdownEditor.value.replace(regex, () => replacement);
     markdownEditor.dispatchEvent(new Event('input', { bubbles: true }));
     refreshFindMatches({ resetIndex: true });
     if (findMatches.length) {
@@ -4330,7 +4330,7 @@ This is a fully client-side application. Your content never leaves your browser 
       };
   </script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.min.js"></script>
   <style>
       body {
           background-color: ${isDarkTheme ? "#0d1117" : "#ffffff"};

--- a/styles.css
+++ b/styles.css
@@ -957,7 +957,6 @@ a:focus {
 
 /* translucent overlay behind panel */
 .mobile-menu-overlay {
-  display: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -966,14 +965,15 @@ a:focus {
   background-color: rgba(0, 0, 0, 0.5);
   opacity: 0;
   visibility: hidden;
+  pointer-events: none;
   transition: opacity 0.3s ease, visibility 0.3s ease;
   z-index: 1000;
 }
 
 .mobile-menu-overlay.active {
-  display: block;
   opacity: 1;
   visibility: visible;
+  pointer-events: auto;
 }
 
 /* header inside mobile menu */
@@ -1667,7 +1667,7 @@ a:focus {
   max-width: 180px;
   background-color: var(--button-bg);
   border: 1px solid var(--border-color);
-  border-bottom: none;
+  border-bottom: 1px solid transparent;
   border-radius: 6px 6px 0 0;
   cursor: pointer;
   font-size: 13px;


### PR DESCRIPTION
## Summary

This PR addresses **6 bugs** across **5 files** discovered during a comprehensive audit of the `main` branch. Changes span frontend visuals, accessibility compliance, application logic, and deployment configuration.

**5 files changed** Â· **20 insertions** Â· **17 deletions**

---

## Changes

### ðŸŽ¨ Visual Fixes â€” `styles.css`

#### Fix 1: Active Tab Vertical Jump
- **Problem**: Switching between document tabs caused a 1px vertical shift because `.tab-item` used `border-bottom: none` while `.tab-item.active` applied a 1px solid bottom border, creating inconsistent box sizing.
- **Solution**: Changed `.tab-item` to `border-bottom: 1px solid transparent` so the space is always reserved, eliminating the jump.

```diff
- border-bottom: none;
+ border-bottom: 1px solid transparent;
```

#### Fix 2: Mobile Menu Overlay Transition
- **Problem**: The mobile sidebar backdrop used `display: none` / `display: block` toggling, which prevented CSS `transition` animations from firing (instant flash instead of smooth fade).
- **Solution**: Replaced `display` toggling with `opacity` + `visibility` + `pointer-events` for a smooth 300ms fade transition.

```diff
  .mobile-menu-overlay {
-   display: none;
    opacity: 0;
    visibility: hidden;
+   pointer-events: none;
    transition: opacity 0.3s ease, visibility 0.3s ease;
  }
  .mobile-menu-overlay.active {
-   display: block;
    opacity: 1;
    visibility: visible;
+   pointer-events: auto;
  }
```

---

### â™¿ Accessibility â€” `index.html`

#### Fix 3: Missing Modal `aria-hidden` Attributes
- **Problem**: 11 modal dialogs lacked `aria-hidden="true"` on their initially-hidden wrapper elements, causing screen readers to announce off-screen content to users.
- **Solution**: Added `aria-hidden="true"` to all 11 affected modals:

| Modal | Element ID |
|---|---|
| Reset Confirm | `reset-confirm-modal` |
| Rename | `rename-modal` |
| Insert Link | `link-modal` |
| Insert Reference | `reference-modal` |
| Insert Image | `image-modal` |
| Insert Table | `table-modal` |
| Emoji Picker | `emoji-modal` |
| Symbols Picker | `symbols-modal` |
| Markdown Alert | `alert-modal` |
| GitHub Import | `github-import-modal` |
| Mermaid Zoom | `mermaid-zoom-modal` |

---

### ðŸ”§ Logic Fixes â€” `script.js`

#### Fix 4: Find & Replace Capture Group Corruption
- **Problem**: The `replaceAllMatches()` function passed the replacement string directly to `String.prototype.replace()`, causing regex special sequences (`$1`, `$&`, `$$`, etc.) typed by users as literal text to be interpreted as capture group references â€” silently corrupting editor content.
- **Solution**: Wrapped the replacement in an arrow function `() => replacement` to ensure literal string substitution.

```diff
- markdownEditor.value = markdownEditor.value.replace(regex, replacement);
+ markdownEditor.value = markdownEditor.value.replace(regex, () => replacement);
```

#### Fix 5: HTML Export Mermaid Version Drift
- **Problem**: The HTML export template embedded Mermaid `v10.9.1` via CDN while the main application loads `v11.6.0`, causing rendering inconsistencies (different syntax support, theme behavior) in exported files.
- **Solution**: Updated the CDN reference in the export template to `mermaid@11.6.0`.

```diff
- <script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.min.js"></script>
```

---

### ðŸ³ Deployment Hardening

#### Fix 6a: Docker Build Context â€” `.dockerignore`
- **Problem**: The `desktop-app/` directory (NeutralinoJS native binaries, logs, developer configs) was being copied into the Nginx web container via the overly broad `COPY .` instruction, bloating the image size and exposing developer artifacts in the web root.
- **Solution**: Appended `desktop-app/` exclusion to `.dockerignore`.

#### Fix 6b: CI/CD Push Guard â€” `.github/workflows/docker-publish.yml`
- **Problem**: `push: true` unconditionally attempted to push container images to GHCR on all trigger events, including `pull_request` from forks â€” which would fail due to missing write permissions and produce confusing CI failures.
- **Solution**: Changed to conditional push `${{ github.event_name != 'pull_request' }}`.

```diff
- push: true
+ push: ${{ github.event_name != 'pull_request' }}
```

---

## Testing

| Check | Method | Result |
|---|---|---|
| All `role="dialog"` have `aria-hidden` | grep for dialogs missing attribute | âœ… 0 remaining |
| Replace uses literal callback | grep for `() => replacement` | âœ… Confirmed |
| Mermaid export version = 11.6.0 | grep for `mermaid@11.6.0` | âœ… Confirmed |
| No old Mermaid in export | grep for `mermaid@10.9.1` | âœ… None found |
| `desktop-app/` in `.dockerignore` | grep for `desktop-app/` | âœ… Present |
| PR push guard in CI/CD | grep for conditional push | âœ… Conditional |

## Impact

- **Zero breaking changes** â€” all modifications are backwards-compatible
- **No new dependencies** â€” only existing code is adjusted
- **Minimal diff** â€” 20 insertions, 17 deletions across 5 files

---

> Fixes identified via comprehensive multi-agent audit of the `main` branch covering frontend, logic, accessibility, and deployment layers.