### PR TITLE
fix(export): resolve frontmatter table styling and parsing in HTML an…

### DIFF
--- a/desktop-app/resources/index.html
+++ b/desktop-app/resources/index.html
@@ -315,7 +315,7 @@
         </div>
 
         <!-- Reset Confirmation Modal -->
-        <div id="reset-confirm-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reset-modal-title" style="display:none;">
+        <div id="reset-confirm-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reset-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="reset-modal-title" class="reset-modal-message">Are you sure you want to delete all files?</p>
             <div class="reset-modal-actions">
@@ -530,7 +530,7 @@
         </div>
 
         <!-- Rename Modal -->
-        <div id="rename-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="rename-modal-title" style="display:none;">
+        <div id="rename-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="rename-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="rename-modal-title" class="reset-modal-message">Rename file</p>
             <input type="text" id="rename-modal-input" class="rename-modal-input" placeholder="File name" />
@@ -542,7 +542,7 @@
         </div>
 
         <!-- Link Modal -->
-        <div id="link-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="link-modal-title" style="display:none;">
+        <div id="link-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="link-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="link-modal-title" class="reset-modal-message">Insert link</p>
             <div class="reset-modal-field">
@@ -561,7 +561,7 @@
         </div>
 
         <!-- Reference Modal -->
-        <div id="reference-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reference-modal-title" style="display:none;">
+        <div id="reference-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="reference-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="reference-modal-title" class="reset-modal-message">Insert reference</p>
             <div class="reset-modal-field">
@@ -584,7 +584,7 @@
         </div>
 
         <!-- Image Modal -->
-        <div id="image-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="image-modal-title" style="display:none;">
+        <div id="image-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="image-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="image-modal-title" class="reset-modal-message">Insert image</p>
             <div class="reset-modal-toggle-group">
@@ -618,7 +618,7 @@
         </div>
 
         <!-- Table Modal -->
-        <div id="table-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="table-modal-title" style="display:none;">
+        <div id="table-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="table-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="table-modal-title" class="reset-modal-message">Insert table</p>
             <div class="reset-modal-field">
@@ -637,7 +637,7 @@
         </div>
 
         <!-- Emoji Modal -->
-        <div id="emoji-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="emoji-modal-title" style="display:none;">
+        <div id="emoji-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="emoji-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide reset-modal-box--xl">
             <p id="emoji-modal-title" class="reset-modal-message">GitHub Emojis</p>
             <div class="reset-modal-field">
@@ -654,7 +654,7 @@
         </div>
 
         <!-- Symbols Modal -->
-        <div id="symbols-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="symbols-modal-title" style="display:none;">
+        <div id="symbols-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="symbols-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide reset-modal-box--xl">
             <p id="symbols-modal-title" class="reset-modal-message">Symbols &amp; HTML Entities</p>
             <div class="reset-modal-field">
@@ -671,7 +671,7 @@
         </div>
 
         <!-- Markdown Alert Modal -->
-        <div id="alert-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="alert-modal-title" style="display:none;">
+        <div id="alert-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="alert-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide">
             <p id="alert-modal-title" class="reset-modal-message">Markdown alerts</p>
             <div id="alert-modal-grid" class="alert-grid" role="listbox" aria-label="Markdown alert types"></div>
@@ -683,7 +683,7 @@
         </div>
 
         <!-- GitHub Import Modal -->
-        <div id="github-import-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="github-import-title" style="display:none;">
+        <div id="github-import-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="github-import-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box">
             <p id="github-import-title" class="reset-modal-message">Import Markdown from GitHub</p>
             <input type="url" id="github-import-url" class="rename-modal-input" placeholder="https://github.com/owner/repo/blob/main/README.md" />
@@ -730,7 +730,7 @@
     </div>
 
     <!-- Mermaid Zoom Modal -->
-    <div id="mermaid-zoom-modal" role="dialog" aria-modal="true" aria-label="Diagram zoom view">
+    <div id="mermaid-zoom-modal" role="dialog" aria-modal="true" aria-label="Diagram zoom view" aria-hidden="true">
         <div class="mermaid-modal-content">
             <div class="mermaid-modal-header">
                 <span>Diagram</span>

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -767,15 +767,31 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function parseFrontmatter(markdown) {
-    const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
-    if (!match) return { frontmatter: null, body: markdown };
-    try {
-      const data = jsyaml.load(match[1]) || {};
-      return { frontmatter: data, body: markdown.slice(match[0].length) };
-    } catch (e) {
-      console.warn('Frontmatter YAML parse error:', e);
-      return { frontmatter: null, body: markdown };
+    if (markdown.startsWith('\ufeff')) {
+      markdown = markdown.slice(1);
     }
+    const regex = /(?:^|\r?\n)[ \t]*---[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*---[ \t]*(?:\r?\n|$)/g;
+    let match;
+    while ((match = regex.exec(markdown)) !== null) {
+      try {
+        const data = jsyaml.load(match[1]);
+        if (data !== null && typeof data === 'object' && !Array.isArray(data)) {
+          let prefixLength = 0;
+          if (match[0].startsWith('\r\n')) {
+            prefixLength = 2;
+          } else if (match[0].startsWith('\n')) {
+            prefixLength = 1;
+          }
+          const startIdx = match.index + prefixLength;
+          const endIdx = match.index + match[0].length;
+          const body = markdown.slice(0, startIdx) + markdown.slice(endIdx);
+          return { frontmatter: data, body: body };
+        }
+      } catch (e) {
+        console.warn('Frontmatter YAML parse error:', e);
+      }
+    }
+    return { frontmatter: null, body: markdown };
   }
 
   function renderFrontmatterValue(value) {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -3769,7 +3769,7 @@ This is a fully client-side application. Your content never leaves your browser 
     if (!query) return;
     const replacement = findReplaceWith ? findReplaceWith.value : '';
     const regex = new RegExp(escapeRegExp(query), 'gi');
-    markdownEditor.value = markdownEditor.value.replace(regex, replacement);
+    markdownEditor.value = markdownEditor.value.replace(regex, () => replacement);
     markdownEditor.dispatchEvent(new Event('input', { bubbles: true }));
     refreshFindMatches({ resetIndex: true });
     if (findMatches.length) {
@@ -4330,7 +4330,7 @@ This is a fully client-side application. Your content never leaves your browser 
       };
   </script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.min.js"></script>
   <style>
       body {
           background-color: ${isDarkTheme ? "#0d1117" : "#ffffff"};
@@ -4397,21 +4397,59 @@ This is a fully client-side application. Your content never leaves your browser 
       .markdown-alert > *:not(.markdown-alert-title) { color: ${isDarkTheme ? "#c9d1d9" : "#24292e"}; }
 
       .frontmatter-table {
-          width: 100%;
           border-collapse: collapse;
           margin-bottom: 24px;
           font-size: 14px;
+          width: auto;
+          max-width: 100%;
       }
       .frontmatter-table th,
       .frontmatter-table td {
           border: 1px solid ${isDarkTheme ? "#30363d" : "#e1e4e8"};
-          padding: 8px 12px;
-          text-align: left;
+          padding: 6px 13px;
+          vertical-align: top;
+          color: ${isDarkTheme ? "#c9d1d9" : "#24292e"};
+      }
+      .frontmatter-table tr:nth-child(odd) th,
+      .frontmatter-table tr:nth-child(odd) td {
+          background-color: ${isDarkTheme ? "#161b22" : "#f6f8fa"};
+      }
+      .frontmatter-table tr:nth-child(even) th,
+      .frontmatter-table tr:nth-child(even) td {
+          background-color: ${isDarkTheme ? "#0d1117" : "#ffffff"};
       }
       .frontmatter-table th {
           font-weight: 600;
-          background-color: ${isDarkTheme ? "#161b22" : "#f6f8fa"};
+          text-align: right;
+          white-space: nowrap;
+          vertical-align: middle;
           width: 150px;
+      }
+      .frontmatter-table td {
+          text-align: left;
+      }
+      .fm-complex {
+          margin: 0;
+          padding: 4px 6px;
+          font-size: 0.8em;
+          font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+          white-space: pre-wrap;
+          word-break: break-word;
+          background: transparent;
+          border: none;
+          color: ${isDarkTheme ? "#c9d1d9" : "#24292e"};
+      }
+      .fm-tag {
+          display: inline-block;
+          padding: 2px 8px;
+          margin: 2px 3px 2px 0;
+          border: 1px solid ${isDarkTheme ? "#30363d" : "#e1e4e8"};
+          border-radius: 2em;
+          font-size: 0.8em;
+          font-weight: 500;
+          color: ${isDarkTheme ? "#58a6ff" : "#0969da"};
+          background-color: ${isDarkTheme ? "#21262d" : "#f6f8fa"};
+          white-space: nowrap;
       }
 
       @media (max-width: 767px) {
@@ -4933,8 +4971,9 @@ This is a fully client-side application. Your content never leaves your browser 
       progressContainer.appendChild(statusText);
       document.body.appendChild(progressContainer);
 
-      const markdown = markdownEditor.value;
-      const html = marked.parse(markdown);
+      const { frontmatter, body } = parseFrontmatter(markdownEditor.value);
+      const tableHtml = frontmatter ? renderFrontmatterTable(frontmatter) : '';
+      const html = tableHtml + marked.parse(body);
       const sanitizedHtml = DOMPurify.sanitize(html, {
         ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
         ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled']

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -770,28 +770,15 @@ document.addEventListener("DOMContentLoaded", function () {
     if (markdown.startsWith('\ufeff')) {
       markdown = markdown.slice(1);
     }
-    const regex = /(?:^|\r?\n)[ \t]*---[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*---[ \t]*(?:\r?\n|$)/g;
-    let match;
-    while ((match = regex.exec(markdown)) !== null) {
-      try {
-        const data = jsyaml.load(match[1]);
-        if (data !== null && typeof data === 'object' && !Array.isArray(data)) {
-          let prefixLength = 0;
-          if (match[0].startsWith('\r\n')) {
-            prefixLength = 2;
-          } else if (match[0].startsWith('\n')) {
-            prefixLength = 1;
-          }
-          const startIdx = match.index + prefixLength;
-          const endIdx = match.index + match[0].length;
-          const body = markdown.slice(0, startIdx) + markdown.slice(endIdx);
-          return { frontmatter: data, body: body };
-        }
-      } catch (e) {
-        console.warn('Frontmatter YAML parse error:', e);
-      }
+    const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+    if (!match) return { frontmatter: null, body: markdown };
+    try {
+      const data = jsyaml.load(match[1]) || {};
+      return { frontmatter: data, body: markdown.slice(match[0].length) };
+    } catch (e) {
+      console.warn('Frontmatter YAML parse error:', e);
+      return { frontmatter: null, body: markdown };
     }
-    return { frontmatter: null, body: markdown };
   }
 
   function renderFrontmatterValue(value) {

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -957,7 +957,6 @@ a:focus {
 
 /* translucent overlay behind panel */
 .mobile-menu-overlay {
-  display: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -966,14 +965,15 @@ a:focus {
   background-color: rgba(0, 0, 0, 0.5);
   opacity: 0;
   visibility: hidden;
+  pointer-events: none;
   transition: opacity 0.3s ease, visibility 0.3s ease;
   z-index: 1000;
 }
 
 .mobile-menu-overlay.active {
-  display: block;
   opacity: 1;
   visibility: visible;
+  pointer-events: auto;
 }
 
 /* header inside mobile menu */
@@ -1667,7 +1667,7 @@ a:focus {
   max-width: 180px;
   background-color: var(--button-bg);
   border: 1px solid var(--border-color);
-  border-bottom: none;
+  border-bottom: 1px solid transparent;
   border-radius: 6px 6px 0 0;
   cursor: pointer;
   font-size: 13px;

--- a/script.js
+++ b/script.js
@@ -767,15 +767,31 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function parseFrontmatter(markdown) {
-    const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
-    if (!match) return { frontmatter: null, body: markdown };
-    try {
-      const data = jsyaml.load(match[1]) || {};
-      return { frontmatter: data, body: markdown.slice(match[0].length) };
-    } catch (e) {
-      console.warn('Frontmatter YAML parse error:', e);
-      return { frontmatter: null, body: markdown };
+    if (markdown.startsWith('\ufeff')) {
+      markdown = markdown.slice(1);
     }
+    const regex = /(?:^|\r?\n)[ \t]*---[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*---[ \t]*(?:\r?\n|$)/g;
+    let match;
+    while ((match = regex.exec(markdown)) !== null) {
+      try {
+        const data = jsyaml.load(match[1]);
+        if (data !== null && typeof data === 'object' && !Array.isArray(data)) {
+          let prefixLength = 0;
+          if (match[0].startsWith('\r\n')) {
+            prefixLength = 2;
+          } else if (match[0].startsWith('\n')) {
+            prefixLength = 1;
+          }
+          const startIdx = match.index + prefixLength;
+          const endIdx = match.index + match[0].length;
+          const body = markdown.slice(0, startIdx) + markdown.slice(endIdx);
+          return { frontmatter: data, body: body };
+        }
+      } catch (e) {
+        console.warn('Frontmatter YAML parse error:', e);
+      }
+    }
+    return { frontmatter: null, body: markdown };
   }
 
   function renderFrontmatterValue(value) {

--- a/script.js
+++ b/script.js
@@ -770,28 +770,15 @@ document.addEventListener("DOMContentLoaded", function () {
     if (markdown.startsWith('\ufeff')) {
       markdown = markdown.slice(1);
     }
-    const regex = /(?:^|\r?\n)[ \t]*---[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*---[ \t]*(?:\r?\n|$)/g;
-    let match;
-    while ((match = regex.exec(markdown)) !== null) {
-      try {
-        const data = jsyaml.load(match[1]);
-        if (data !== null && typeof data === 'object' && !Array.isArray(data)) {
-          let prefixLength = 0;
-          if (match[0].startsWith('\r\n')) {
-            prefixLength = 2;
-          } else if (match[0].startsWith('\n')) {
-            prefixLength = 1;
-          }
-          const startIdx = match.index + prefixLength;
-          const endIdx = match.index + match[0].length;
-          const body = markdown.slice(0, startIdx) + markdown.slice(endIdx);
-          return { frontmatter: data, body: body };
-        }
-      } catch (e) {
-        console.warn('Frontmatter YAML parse error:', e);
-      }
+    const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+    if (!match) return { frontmatter: null, body: markdown };
+    try {
+      const data = jsyaml.load(match[1]) || {};
+      return { frontmatter: data, body: markdown.slice(match[0].length) };
+    } catch (e) {
+      console.warn('Frontmatter YAML parse error:', e);
+      return { frontmatter: null, body: markdown };
     }
-    return { frontmatter: null, body: markdown };
   }
 
   function renderFrontmatterValue(value) {

--- a/script.js
+++ b/script.js
@@ -4397,21 +4397,59 @@ This is a fully client-side application. Your content never leaves your browser 
       .markdown-alert > *:not(.markdown-alert-title) { color: ${isDarkTheme ? "#c9d1d9" : "#24292e"}; }
 
       .frontmatter-table {
-          width: 100%;
           border-collapse: collapse;
           margin-bottom: 24px;
           font-size: 14px;
+          width: auto;
+          max-width: 100%;
       }
       .frontmatter-table th,
       .frontmatter-table td {
           border: 1px solid ${isDarkTheme ? "#30363d" : "#e1e4e8"};
-          padding: 8px 12px;
-          text-align: left;
+          padding: 6px 13px;
+          vertical-align: top;
+          color: ${isDarkTheme ? "#c9d1d9" : "#24292e"};
+      }
+      .frontmatter-table tr:nth-child(odd) th,
+      .frontmatter-table tr:nth-child(odd) td {
+          background-color: ${isDarkTheme ? "#161b22" : "#f6f8fa"};
+      }
+      .frontmatter-table tr:nth-child(even) th,
+      .frontmatter-table tr:nth-child(even) td {
+          background-color: ${isDarkTheme ? "#0d1117" : "#ffffff"};
       }
       .frontmatter-table th {
           font-weight: 600;
-          background-color: ${isDarkTheme ? "#161b22" : "#f6f8fa"};
+          text-align: right;
+          white-space: nowrap;
+          vertical-align: middle;
           width: 150px;
+      }
+      .frontmatter-table td {
+          text-align: left;
+      }
+      .fm-complex {
+          margin: 0;
+          padding: 4px 6px;
+          font-size: 0.8em;
+          font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+          white-space: pre-wrap;
+          word-break: break-word;
+          background: transparent;
+          border: none;
+          color: ${isDarkTheme ? "#c9d1d9" : "#24292e"};
+      }
+      .fm-tag {
+          display: inline-block;
+          padding: 2px 8px;
+          margin: 2px 3px 2px 0;
+          border: 1px solid ${isDarkTheme ? "#30363d" : "#e1e4e8"};
+          border-radius: 2em;
+          font-size: 0.8em;
+          font-weight: 500;
+          color: ${isDarkTheme ? "#58a6ff" : "#0969da"};
+          background-color: ${isDarkTheme ? "#21262d" : "#f6f8fa"};
+          white-space: nowrap;
       }
 
       @media (max-width: 767px) {
@@ -4933,8 +4971,9 @@ This is a fully client-side application. Your content never leaves your browser 
       progressContainer.appendChild(statusText);
       document.body.appendChild(progressContainer);
 
-      const markdown = markdownEditor.value;
-      const html = marked.parse(markdown);
+      const { frontmatter, body } = parseFrontmatter(markdownEditor.value);
+      const tableHtml = frontmatter ? renderFrontmatterTable(frontmatter) : '';
+      const html = tableHtml + marked.parse(body);
       const sanitizedHtml = DOMPurify.sanitize(html, {
         ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
         ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled']


### PR DESCRIPTION
### Description
This pull request addresses YAML Frontmatter parsing and styling issues in both the web and desktop app versions for both HTML and PDF exports.

### Changes Included
1. **HTML Export Styling (Web & Desktop)**:
   - Added support for `.fm-tag` in the inline styles of exported HTML documents so tags/lists render as pill tags matching the main viewer interface's light and dark themes.
   - Added support for `.fm-complex` to properly style nested JSON/YAML objects in monospace blocks.
   - Improved `.frontmatter-table` rules (vertical alignments, text alignments, borders, and background zebra-striping).

2. **PDF Export Parsing (Web & Desktop)**:
   - Updated the `exportPdf` listener to run the frontmatter parser (`parseFrontmatter`) and render the frontmatter table (`renderFrontmatterTable()`), prepending it to the document body prior to PDF generation.

3. **Desktop App Build Assets**:
   - Executed the build preparation script to copy updated scripts/styles and regenerate the desktop resources.