### PR TITLE
fix: resolve onboarding welcome template empty content bug (BUG-ONBOARD-001)

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -866,7 +866,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // PERF-012: Inlined default template to eliminate network request, FOUC, and layout shifts
   const defaultMarkdownTemplate = document.getElementById('default-markdown');
-  const sampleMarkdown = defaultMarkdownTemplate ? defaultMarkdownTemplate.textContent.trim() : '# Welcome to Markdown Viewer\n\nStart typing your markdown here...';
+  let templateText = '';
+  if (defaultMarkdownTemplate) {
+    if (defaultMarkdownTemplate.content && typeof defaultMarkdownTemplate.content.textContent === 'string') {
+      templateText = defaultMarkdownTemplate.content.textContent.trim();
+    } else {
+      templateText = defaultMarkdownTemplate.textContent ? defaultMarkdownTemplate.textContent.trim() : '';
+    }
+  }
+  const sampleMarkdown = templateText || '# Welcome to Markdown Viewer\n\nStart typing your markdown here...';
 
   if (!markdownEditor.value) {
     markdownEditor.value = sampleMarkdown;

--- a/script.js
+++ b/script.js
@@ -866,7 +866,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // PERF-012: Inlined default template to eliminate network request, FOUC, and layout shifts
   const defaultMarkdownTemplate = document.getElementById('default-markdown');
-  const sampleMarkdown = defaultMarkdownTemplate ? defaultMarkdownTemplate.textContent.trim() : '# Welcome to Markdown Viewer\n\nStart typing your markdown here...';
+  let templateText = '';
+  if (defaultMarkdownTemplate) {
+    if (defaultMarkdownTemplate.content && typeof defaultMarkdownTemplate.content.textContent === 'string') {
+      templateText = defaultMarkdownTemplate.content.textContent.trim();
+    } else {
+      templateText = defaultMarkdownTemplate.textContent ? defaultMarkdownTemplate.textContent.trim() : '';
+    }
+  }
+  const sampleMarkdown = templateText || '# Welcome to Markdown Viewer\n\nStart typing your markdown here...';
 
   if (!markdownEditor.value) {
     markdownEditor.value = sampleMarkdown;


### PR DESCRIPTION
## Overview
This PR resolves the critical onboarding bug **BUG-ONBOARD-001**, where first-time users see a blank editor and preview panel despite the "Welcome to Markdown" tab being successfully created.

## Root Cause Analysis
1. **PWA Cache Mismatch (Stale-While-Revalidate)**: The PWA service worker caches `index.html` using a stale-while-revalidate strategy. If a user receives the cached version of `index.html` from a previous release (which defines the template as `<template id="default-markdown">`) but loads the new `script.js` (which expects `<script type="text/markdown" id="default-markdown">` and accesses its `textContent`), the resulting retrieval evaluates to `""` since a `<template>` tag's contents reside inside its `.content` document fragment.
2. **Brittle Fallback Check**: Because the DOM element is found (non-null), the ternary operator selected the `textContent` branch. Evaluating `"".trim()` yielded an empty string `""` and completely bypassed the hardcoded welcome markdown fallback.

## Remediation Details
- **Resilient Template Extraction**: Updated `script.js` to dynamically inspect the template element. It now safely extracts text content from both modern `<script type="text/markdown">` and older cached `<template>` tags.
- **Robust Fallback**: Switched the ternary assignment to a logical OR (`||`) condition. This guarantees that if retrieved text is empty or missing, the application automatically falls back to the hardcoded welcome markdown string rather than hydrating an empty editor.
- **Desktop Application Sync**: Rebuilt the Neutralino desktop resources (`node prepare.js`) to sync the `script.js` changes to `desktop-app/resources/js/script.js` and update the offline-first `resources/index.html`.

## Verification & Testing
1. **Hydration Verification**:
   - Simulated standard `<script>` tag: **PASS** (retrieved full welcome markdown)
   - Simulated stale cached `<template>` tag: **PASS** (retrieved full welcome markdown)
   - Simulated null/missing element: **PASS** (fell back to hardcoded default)
   - Simulated empty element: **PASS** (fell back to hardcoded default)
2. **Web Regression Testing**: Verified in Incognito mode and with cleared `localStorage` that the editor and preview hydrate perfectly. Existing saved tabs continue to load exactly as before.
3. **Desktop Regression Testing**: Verified that fresh Neutralino client launches successfully hydrate the editor and preview.