### PR TITLE
fix toolbar markdown preservation

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -2788,7 +2788,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const currentValue = markdownEditor.value;
     if (currentValue === lastPushedValue) return;
     
-    const inputType = e ? e.inputType : '';
+    const inputType = e && typeof e.inputType === 'string' ? e.inputType : '';
     
     if (!pendingState) {
       pendingState = {

--- a/script.js
+++ b/script.js
@@ -2788,7 +2788,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const currentValue = markdownEditor.value;
     if (currentValue === lastPushedValue) return;
     
-    const inputType = e ? e.inputType : '';
+    const inputType = e && typeof e.inputType === 'string' ? e.inputType : '';
     
     if (!pendingState) {
       pendingState = {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'markdown-viewer-cache-v3.7.2';
+const CACHE_NAME = 'markdown-viewer-cache-v3.7.3';
 
 // PERF-011: Split precache into critical (local files) and lazy (CDN libraries)
 // Critical assets are precached during SW install for instant offline startup
@@ -18,6 +18,14 @@ const CDN_ORIGINS = [
   'cdnjs.cloudflare.com',
   'cdn.jsdelivr.net'
 ];
+
+const NETWORK_FIRST_LOCAL_PATHS = new Set([
+  '/',
+  '/index.html',
+  '/script.js',
+  '/styles.css',
+  '/sw.js'
+]);
 
 self.addEventListener('install', event => {
   event.waitUntil(
@@ -45,7 +53,25 @@ self.addEventListener('fetch', event => {
   const isCDN = CDN_ORIGINS.some(origin => url.hostname.includes(origin));
 
   if (isLocal) {
-    // Stale-While-Revalidate strategy for local code assets
+    const localPath = url.pathname.endsWith('/') ? '/' : url.pathname;
+    const shouldUseNetworkFirst =
+      event.request.mode === 'navigate' || NETWORK_FIRST_LOCAL_PATHS.has(localPath);
+
+    if (shouldUseNetworkFirst) {
+      event.respondWith(
+        caches.open(CACHE_NAME).then(cache => {
+          return fetch(event.request).then(networkResponse => {
+            if (networkResponse && networkResponse.status === 200) {
+              cache.put(event.request, networkResponse.clone());
+            }
+            return networkResponse;
+          }).catch(() => cache.match(event.request));
+        })
+      );
+      return;
+    }
+
+    // Stale-While-Revalidate strategy for non-code local assets
     event.respondWith(
       caches.open(CACHE_NAME).then(cache => {
         return cache.match(event.request).then(cachedResponse => {


### PR DESCRIPTION
## Summary

- Fixes toolbar formatting actions so markdown source is preserved, rendered, and autosaved correctly.
- Updates the desktop app’s prepared script with the same fix.
- Updates service worker caching so users do not keep running stale toolbar code.

## Root Cause

Toolbar actions dispatch plain `Event('input')` events. These events do not include `inputType`, but `handleKeystrokeHistory()` assumed `e.inputType` was always a string and later called `.startsWith(...)`.

That threw an error before preview rendering and autosave ran. As a result, the editor could show markdown like `# Hello`, while preview and persisted tab storage stayed on the previous plain-text value.

## Validation

- `node --check script.js`
- `node --check desktop-app/resources/js/script.js`
- `node --check sw.js`
- Verified toolbar formatting for headings, bold, italic, lists, tables, code blocks, preview rendering, refresh persistence, and saved markdown preservation.