### PR TITLE
Replace Canvas-Based PDF Export with Print/Pagination Architecture

### DIFF
--- a/desktop-app/extensions/pdf-exporter/index.js
+++ b/desktop-app/extensions/pdf-exporter/index.js
@@ -54,8 +54,23 @@ function generatePdf(html, outputPath, callback) {
 
   const tempHtmlPath = path.join(__dirname, `temp_export_${Date.now()}.html`);
   
+  // Resolve absolute path to resources folder
+  const resourcesDir = path.resolve(__dirname, "..", "..", "resources");
+  const resourcesUrl = "file:///" + resourcesDir.replace(/\\/g, "/");
+
+  // Rewrite relative/absolute root-relative resource paths to absolute file:/// URLs
+  const processedHtml = html
+    .replace(/(src|href)="\/assets\//g, `$1="${resourcesUrl}/assets/`)
+    .replace(/(src|href)="\/libs\//g, `$1="${resourcesUrl}/libs/`)
+    .replace(/(src|href)="\/js\//g, `$1="${resourcesUrl}/js/`)
+    .replace(/(src|href)="\/styles\.css"/g, `$1="${resourcesUrl}/styles.css"`)
+    .replace(/(src|href)="assets\//g, `$1="${resourcesUrl}/assets/`)
+    .replace(/(src|href)="libs\//g, `$1="${resourcesUrl}/libs/`)
+    .replace(/(src|href)="js\//g, `$1="${resourcesUrl}/js/`)
+    .replace(/(src|href)="styles\.css"/g, `$1="${resourcesUrl}/styles.css"`);
+
   // Write html content to temp file
-  fs.writeFile(tempHtmlPath, html, "utf8", (err) => {
+  fs.writeFile(tempHtmlPath, processedHtml, "utf8", (err) => {
     if (err) return callback(err);
 
     const args = [

--- a/desktop-app/extensions/pdf-exporter/index.js
+++ b/desktop-app/extensions/pdf-exporter/index.js
@@ -59,15 +59,13 @@ function generatePdf(html, outputPath, callback) {
   const resourcesUrl = "file:///" + resourcesDir.replace(/\\/g, "/");
 
   // Rewrite relative/absolute root-relative resource paths to absolute file:/// URLs
-  const processedHtml = html
-    .replace(/(src|href)="\/assets\//g, `$1="${resourcesUrl}/assets/`)
-    .replace(/(src|href)="\/libs\//g, `$1="${resourcesUrl}/libs/`)
-    .replace(/(src|href)="\/js\//g, `$1="${resourcesUrl}/js/`)
-    .replace(/(src|href)="\/styles\.css"/g, `$1="${resourcesUrl}/styles.css"`)
-    .replace(/(src|href)="assets\//g, `$1="${resourcesUrl}/assets/`)
-    .replace(/(src|href)="libs\//g, `$1="${resourcesUrl}/libs/`)
-    .replace(/(src|href)="js\//g, `$1="${resourcesUrl}/js/`)
-    .replace(/(src|href)="styles\.css"/g, `$1="${resourcesUrl}/styles.css"`);
+  const processedHtml = html.replace(
+    /\b(src|href)(\s*=\s*)(["'])(?:\/)?(assets|libs|js|styles\.css)(?:\/|(?=\3))/gi,
+    (match, attr, spacing, quote, dir) => {
+      const suffix = dir === "styles.css" ? "" : "/";
+      return `${attr}${spacing}${quote}${resourcesUrl}/${dir}${suffix}`;
+    }
+  );
 
   // Write html content to temp file
   fs.writeFile(tempHtmlPath, processedHtml, "utf8", (err) => {

--- a/desktop-app/extensions/pdf-exporter/index.js
+++ b/desktop-app/extensions/pdf-exporter/index.js
@@ -1,0 +1,160 @@
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const { execFile } = require("child_process");
+
+const PORT_FILE = path.join(__dirname, "..", "..", ".pdf_exporter_port");
+
+// Helper to find Chrome or Edge installation path
+function findChromeOrEdge() {
+  const platform = process.platform;
+  let paths = [];
+
+  if (platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || "";
+    const programFiles = process.env.PROGRAMFILES || "C:\\Program Files";
+    const programFilesX86 = process.env["PROGRAMFILES(X86)"] || "C:\\Program Files (x86)";
+    
+    paths = [
+      path.join(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(localAppData, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
+      path.join(programFiles, "Microsoft", "Edge", "Application", "msedge.exe"),
+    ];
+  } else if (platform === "darwin") {
+    paths = [
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    ];
+  } else {
+    // Linux
+    paths = [
+      "/usr/bin/google-chrome",
+      "/usr/bin/chrome",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+    ];
+  }
+
+  for (const p of paths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return null;
+}
+
+// Write the temp HTML file, execute Chrome/Edge to generate PDF, and delete temp HTML
+function generatePdf(html, outputPath, callback) {
+  const chromePath = findChromeOrEdge();
+  if (!chromePath) {
+    return callback(new Error("Chromium-compatible browser (Chrome or Edge) not found. Please install Chrome or Edge."));
+  }
+
+  const tempHtmlPath = path.join(__dirname, `temp_export_${Date.now()}.html`);
+  
+  // Write html content to temp file
+  fs.writeFile(tempHtmlPath, html, "utf8", (err) => {
+    if (err) return callback(err);
+
+    const args = [
+      "--headless",
+      "--disable-gpu",
+      "--no-pdf-header-footer",
+      `--print-to-pdf=${outputPath}`,
+      tempHtmlPath
+    ];
+
+    execFile(chromePath, args, (execErr, stdout, stderr) => {
+      // Clean up temp HTML file
+      fs.unlink(tempHtmlPath, () => {});
+
+      if (execErr) {
+        return callback(new Error(`Browser execution failed: ${execErr.message}\nStderr: ${stderr}`));
+      }
+      callback(null);
+    });
+  });
+}
+
+// Start HTTP server on a random port
+const server = http.createServer((req, res) => {
+  // Set CORS headers
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/export") {
+    let body = "";
+    req.on("data", chunk => {
+      body += chunk.toString();
+    });
+
+    req.on("end", () => {
+      try {
+        const payload = JSON.parse(body);
+        const { html, outputPath } = payload;
+
+        if (!html || !outputPath) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Missing required fields: html and outputPath" }));
+          return;
+        }
+
+        generatePdf(html, outputPath, (err) => {
+          if (err) {
+            console.error("PDF generation error:", err);
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: err.message }));
+          } else {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ success: true }));
+          }
+        });
+      } catch (parseErr) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid JSON payload" }));
+      }
+    });
+  } else {
+    res.writeHead(444);
+    res.end();
+  }
+});
+
+// Bind to random port
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  const port = address.port;
+  console.log(`PDF Exporter Extension listening on port ${port}`);
+
+  // Write port to file
+  try {
+    fs.writeFileSync(PORT_FILE, String(port), "utf8");
+    console.log(`Port written to ${PORT_FILE}`);
+  } catch (err) {
+    console.error(`Failed to write port file: ${err.message}`);
+  }
+});
+
+// Clean up port file on exit
+function cleanup() {
+  try {
+    if (fs.existsSync(PORT_FILE)) {
+      fs.unlinkSync(PORT_FILE);
+      console.log("Port file cleaned up.");
+    }
+  } catch (e) {}
+  process.exit();
+}
+
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);
+process.on("exit", cleanup);

--- a/desktop-app/neutralino.config.json
+++ b/desktop-app/neutralino.config.json
@@ -21,7 +21,14 @@
     "os.open",
     "os.setTray",
     "filesystem.readFile",
-    "filesystem.writeFile"
+    "filesystem.writeFile",
+    "extensions.*"
+  ],
+  "extensions": [
+    {
+      "id": "com.markdownviewer.pdfexporter",
+      "command": "node extensions/pdf-exporter/index.js"
+    }
   ],
   "globalVariables": {},
   "modes": {

--- a/desktop-app/resources/index.html
+++ b/desktop-app/resources/index.html
@@ -752,35 +752,15 @@
 
         <!-- PDF Export Modal -->
         <div id="pdf-export-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="pdf-export-modal-title" aria-hidden="true" style="display:none;">
-          <div class="reset-modal-box reset-modal-box--wide modal-box">
+          <div class="reset-modal-box modal-box">
             <div class="modal-header">
-              <p id="pdf-export-modal-title" class="reset-modal-message">PDF Export Settings</p>
+              <p id="pdf-export-modal-title" class="reset-modal-message">Vector PDF Export</p>
               <button type="button" class="modal-close-btn" id="pdf-export-modal-close-icon" aria-label="Close export dialog">
                 <i class="bi bi-x-lg"></i>
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Select your preferred PDF export engine:</p>
-              <div class="share-mode-cards">
-                <label class="share-mode-card is-selected" id="pdf-card-print" for="pdf-engine-print">
-                  <input type="radio" id="pdf-engine-print" name="pdf-engine" value="print" checked />
-                  <span class="share-card-icon"><i class="bi bi-printer"></i></span>
-                  <span class="share-card-body">
-                    <span class="share-card-title">Browser Print (Recommended)</span>
-                    <span class="share-card-desc">Searchable vector text, hyperlinks, vector SVGs, and browser-native pagination.</span>
-                  </span>
-                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
-                </label>
-                <label class="share-mode-card" id="pdf-card-legacy" for="pdf-engine-legacy">
-                  <input type="radio" id="pdf-engine-legacy" name="pdf-engine" value="legacy" />
-                  <span class="share-card-icon"><i class="bi bi-image"></i></span>
-                  <span class="share-card-body">
-                    <span class="share-card-title">Legacy Raster PDF</span>
-                    <span class="share-card-desc">Slices screenshots of the rendered page. Recommended only for offline/compatibility fallback.</span>
-                  </span>
-                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
-                </label>
-              </div>
+              <p class="share-modal-description">Export your Markdown document to a high-fidelity vector PDF with searchable text, functional links, scalable diagrams, and standard page formatting.</p>
             </div>
             <div class="reset-modal-actions">
               <button class="reset-modal-btn reset-modal-cancel" id="pdf-export-modal-close">Cancel</button>

--- a/desktop-app/resources/index.html
+++ b/desktop-app/resources/index.html
@@ -750,6 +750,45 @@
           </div>
         </div>
 
+        <!-- PDF Export Modal -->
+        <div id="pdf-export-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="pdf-export-modal-title" aria-hidden="true" style="display:none;">
+          <div class="reset-modal-box reset-modal-box--wide modal-box">
+            <div class="modal-header">
+              <p id="pdf-export-modal-title" class="reset-modal-message">PDF Export Settings</p>
+              <button type="button" class="modal-close-btn" id="pdf-export-modal-close-icon" aria-label="Close export dialog">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p class="share-modal-description">Select your preferred PDF export engine:</p>
+              <div class="share-mode-cards">
+                <label class="share-mode-card is-selected" id="pdf-card-print" for="pdf-engine-print">
+                  <input type="radio" id="pdf-engine-print" name="pdf-engine" value="print" checked />
+                  <span class="share-card-icon"><i class="bi bi-printer"></i></span>
+                  <span class="share-card-body">
+                    <span class="share-card-title">Browser Print (Recommended)</span>
+                    <span class="share-card-desc">Searchable vector text, hyperlinks, vector SVGs, and browser-native pagination.</span>
+                  </span>
+                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
+                </label>
+                <label class="share-mode-card" id="pdf-card-legacy" for="pdf-engine-legacy">
+                  <input type="radio" id="pdf-engine-legacy" name="pdf-engine" value="legacy" />
+                  <span class="share-card-icon"><i class="bi bi-image"></i></span>
+                  <span class="share-card-body">
+                    <span class="share-card-title">Legacy Raster PDF</span>
+                    <span class="share-card-desc">Slices screenshots of the rendered page. Recommended only for offline/compatibility fallback.</span>
+                  </span>
+                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
+                </label>
+              </div>
+            </div>
+            <div class="reset-modal-actions">
+              <button class="reset-modal-btn reset-modal-cancel" id="pdf-export-modal-close">Cancel</button>
+              <button class="reset-modal-btn reset-modal-confirm" id="pdf-export-modal-confirm">Export</button>
+            </div>
+          </div>
+        </div>
+
         <!-- GitHub Import Modal -->
         <div id="github-import-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="github-import-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box">

--- a/desktop-app/resources/js/preview-worker.js
+++ b/desktop-app/resources/js/preview-worker.js
@@ -343,7 +343,13 @@ function configureMarked() {
 
 function ensureLibraries(urls) {
   if (!librariesLoaded) {
-    importScripts(urls.marked, urls.highlight);
+    const scripts = [];
+    if (urls.marked) scripts.push(urls.marked);
+    if (urls.highlight) scripts.push(urls.highlight);
+    if (urls.purify) scripts.push(urls.purify);
+    if (scripts.length > 0) {
+      importScripts(...scripts);
+    }
     librariesLoaded = true;
   }
   configureMarked();
@@ -461,6 +467,34 @@ function renderSegmentedMarkdown(markdown, options) {
 
 self.onmessage = function(event) {
   const data = event.data || {};
+  if (data.type === "render-full") {
+    try {
+      const options = data.options || {};
+      ensureLibraries(options.libraryUrls || {});
+      mermaidIdCounter = 0;
+      const html = marked.parse(data.markdown || "");
+      let sanitized = html;
+      if (typeof DOMPurify !== "undefined") {
+        sanitized = DOMPurify.sanitize(html, {
+          ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
+          ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled', 'data-original-code']
+        });
+      }
+      self.postMessage({
+        type: "render-full-result",
+        requestId: data.requestId,
+        html: sanitized
+      });
+    } catch (error) {
+      self.postMessage({
+        type: "render-full-error",
+        requestId: data.requestId,
+        error: error && error.message ? error.message : "Full worker render failed."
+      });
+    }
+    return;
+  }
+
   if (data.type !== "render") return;
 
   try {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -7065,13 +7065,16 @@ document.addEventListener("DOMContentLoaded", function () {
     const graphics = [];
 
     // Query all targeting elements in precise DOM layout flow order
-    container.querySelectorAll('img, svg, pre, table, mjx-container[display="true"]').forEach(el => {
+    container.querySelectorAll('.pdf-export-block').forEach(el => {
+      const child = el.firstElementChild;
       let type = 'img';
-      const tag = el.tagName.toLowerCase();
-      if (tag === 'svg') type = 'svg';
-      else if (tag === 'pre') type = 'pre';
-      else if (tag === 'table') type = 'table';
-      else if (tag === 'mjx-container') type = 'math';
+      if (child) {
+        const tag = child.tagName.toLowerCase();
+        if (tag === 'svg') type = 'svg';
+        else if (tag === 'pre') type = 'pre';
+        else if (tag === 'table') type = 'table';
+        else if (tag === 'mjx-container') type = 'math';
+      }
       
       graphics.push({ element: el, type: type });
     });
@@ -7540,6 +7543,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
         await PdfExportEngine.AssetReadinessGate.awaitReady(tempElement, markdown, state);
         throwIfPdfExportAborted(state.signal);
+
+        // Wrap target elements in block-level wrappers to ensure layout shifts and page breaks render reliably
+        tempElement.querySelectorAll('img, svg, pre, table, mjx-container[display="true"]').forEach(el => {
+          if (el.closest('.pdf-export-block')) return;
+
+          const wrapper = document.createElement('div');
+          wrapper.className = 'pdf-export-block';
+          el.parentNode.insertBefore(wrapper, el);
+          wrapper.appendChild(el);
+        });
 
         const pageHeightPx = tempElement.offsetWidth * (PAGE_CONFIG.contentHeight / PAGE_CONFIG.contentWidth);
         tempElement.querySelectorAll("pre").forEach(pre => {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -29,8 +29,6 @@ document.addEventListener("DOMContentLoaded", function () {
   const CDN = {
     mermaid: 'https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js',
     mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js',
-    jspdf: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',
-    html2canvas: 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js',
     pako: 'https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js',
     joypixels: 'https://cdn.jsdelivr.net/npm/emoji-toolkit@9.0.1/lib/js/joypixels.min.js',
     joypixels_css: 'https://cdn.jsdelivr.net/npm/emoji-toolkit@9.0.1/extras/css/joypixels.min.css'
@@ -6832,22 +6830,6 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  // ============================================
-  // Page-Break Detection Functions (Story 1.1)
-  // ============================================
-
-  // Page configuration constants for A4 PDF export
-  const PAGE_CONFIG = {
-    a4Width: 210,           // mm
-    a4Height: 297,          // mm
-    margin: 15,             // mm each side
-    contentWidth: 180,      // 210 - 30 (margins)
-    contentHeight: 267,     // 297 - 30 (margins)
-    windowWidth: 1000,      // html2canvas config
-    scale: 2                // html2canvas scale factor
-  };
-
-  const PDF_EXPORT_DEBUG = false;
   let activePdfExport = null;
 
   class PdfExportCancelledError extends Error {
@@ -6855,10 +6837,6 @@ document.addEventListener("DOMContentLoaded", function () {
       super("PDF generation cancelled.");
       this.name = "PdfExportCancelledError";
     }
-  }
-
-  function logPdfExportDebug(...args) {
-    if (PDF_EXPORT_DEBUG) console.log(...args);
   }
 
   function throwIfPdfExportAborted(signal) {
@@ -7024,383 +7002,6 @@ document.addEventListener("DOMContentLoaded", function () {
     return /(^|[^\\])\$\$|\\\[|\\\(|(^|[^\\])\$[^$\n]+\$/.test(markdown);
   }
 
-  function choosePdfCanvasScale(element) {
-    const pixelArea = element.offsetWidth * element.scrollHeight;
-    if (pixelArea > 14000000) return 1.25;
-    if (pixelArea > 8000000) return 1.5;
-    return PAGE_CONFIG.scale;
-  }
-
-  function readPixelStyle(element, propertyName) {
-    const value = window.getComputedStyle(element).getPropertyValue(propertyName);
-    return parseFloat(value) || 0;
-  }
-
-  function fitExportElementToContent(element) {
-    if (!element) return false;
-
-    const overflow = element.scrollWidth - element.clientWidth;
-    if (overflow <= 1) return false;
-
-    const paddingLeft = readPixelStyle(element, 'padding-left');
-    const paddingRight = readPixelStyle(element, 'padding-right');
-    const borderLeft = readPixelStyle(element, 'border-left-width');
-    const borderRight = readPixelStyle(element, 'border-right-width');
-    const boxSizing = window.getComputedStyle(element).boxSizing;
-
-    const requiredWidth = boxSizing === 'border-box'
-      ? Math.ceil(element.scrollWidth + paddingRight + borderLeft + borderRight)
-      : Math.ceil(element.scrollWidth - paddingLeft + paddingRight);
-
-    element.style.width = `${requiredWidth}px`;
-    return true;
-  }
-
-  /**
-   * Task 1: Identifies all graphic elements that may need page-break handling
-   * @param {HTMLElement} container - The container element to search within
-   * @returns {Array} Array of {element, type} objects
-   */
-  function identifyGraphicElements(container) {
-    const graphics = [];
-
-    // Query all targeting elements in precise DOM layout flow order
-    container.querySelectorAll('.pdf-export-block').forEach(el => {
-      const child = el.firstElementChild;
-      let type = 'img';
-      if (child) {
-        const tag = child.tagName.toLowerCase();
-        if (tag === 'svg') type = 'svg';
-        else if (tag === 'pre') type = 'pre';
-        else if (tag === 'table') type = 'table';
-        else if (tag === 'mjx-container') type = 'math';
-      }
-      
-      graphics.push({ element: el, type: type });
-    });
-
-    return graphics;
-  }
-
-  /**
-   * Task 2: Calculates element positions relative to the container
-   * @param {Array} elements - Array of {element, type} objects
-   * @param {HTMLElement} container - The container element
-   * @returns {Array} Array with position data added
-   */
-  function calculateElementPositions(elements, container) {
-    const containerRect = container.getBoundingClientRect();
-
-    return elements.map(item => {
-      const rect = item.element.getBoundingClientRect();
-      const top = rect.top - containerRect.top;
-      const height = rect.height;
-      const bottom = top + height;
-
-      return {
-        element: item.element,
-        type: item.type,
-        top: top,
-        height: height,
-        bottom: bottom
-      };
-    });
-  }
-
-  /**
-   * Task 3: Calculates page boundary positions
-   * @param {number} totalHeight - Total height of content in pixels
-   * @param {number} elementWidth - Actual width of the rendered element in pixels
-   * @param {Object} pageConfig - Page configuration object
-   * @returns {Array} Array of y-coordinates where pages end
-   */
-  function calculatePageBoundaries(totalHeight, elementWidth, pageConfig) {
-    // Calculate pixel height per page based on the element's actual width
-    // This must match how PDF pagination will split the canvas
-    // The aspect ratio of content area determines page height relative to width
-    const aspectRatio = pageConfig.contentHeight / pageConfig.contentWidth;
-    const pageHeightPx = elementWidth * aspectRatio;
-
-    const boundaries = [];
-    let y = pageHeightPx;
-
-    while (y < totalHeight) {
-      boundaries.push(y);
-      y += pageHeightPx;
-    }
-
-    return { boundaries, pageHeightPx };
-  }
-
-  /**
-   * Task 4: Detects which elements would be split across page boundaries
-   * @param {Array} elements - Array of elements with position data
-   * @param {Array} pageBoundaries - Array of page break y-coordinates
-   * @returns {Array} Array of split elements with additional split info
-   */
-  function detectSplitElements(elements, pageBoundaries) {
-    // Handle edge case: empty elements array
-    if (!elements || elements.length === 0) {
-      return [];
-    }
-
-    // Handle edge case: no page boundaries (single page)
-    if (!pageBoundaries || pageBoundaries.length === 0) {
-      return [];
-    }
-
-    const splitElements = [];
-
-    for (const item of elements) {
-      // Find which page the element starts on
-      let startPage = 0;
-      for (let i = 0; i < pageBoundaries.length; i++) {
-        if (item.top >= pageBoundaries[i]) {
-          startPage = i + 1;
-        } else {
-          break;
-        }
-      }
-
-      // Find which page the element ends on
-      let endPage = 0;
-      for (let i = 0; i < pageBoundaries.length; i++) {
-        if (item.bottom > pageBoundaries[i]) {
-          endPage = i + 1;
-        } else {
-          break;
-        }
-      }
-
-      // Element is split if it spans multiple pages
-      if (endPage > startPage) {
-        // Calculate overflow amount (how much crosses into next page)
-        const boundaryY = pageBoundaries[startPage] || pageBoundaries[0];
-        const overflowAmount = item.bottom - boundaryY;
-
-        splitElements.push({
-          element: item.element,
-          type: item.type,
-          top: item.top,
-          height: item.height,
-          splitPageIndex: startPage,
-          overflowAmount: overflowAmount
-        });
-      }
-    }
-
-    return splitElements;
-  }
-
-  /**
-   * Task 5: Main entry point for analyzing graphics for page breaks
-   * @param {HTMLElement} tempElement - The rendered content container
-   * @returns {Object} Analysis result with totalElements, splitElements, pageCount
-   */
-  function analyzeGraphicsForPageBreaks(tempElement, signal) {
-    try {
-      throwIfPdfExportAborted(signal);
-
-      // Step 1: Identify all graphic elements
-      const graphics = identifyGraphicElements(tempElement);
-      logPdfExportDebug('Step 1 - Graphics found:', graphics.length, graphics.map(g => g.type));
-
-      // Step 2: Calculate positions for each element
-      const elementsWithPositions = calculateElementPositions(graphics, tempElement);
-      logPdfExportDebug('Step 2 - Element positions:', elementsWithPositions.map(e => ({
-        type: e.type,
-        top: Math.round(e.top),
-        height: Math.round(e.height),
-        bottom: Math.round(e.bottom)
-      })));
-
-      throwIfPdfExportAborted(signal);
-
-      // Step 3: Calculate page boundaries using the element's ACTUAL width
-      const totalHeight = tempElement.scrollHeight;
-      const elementWidth = tempElement.offsetWidth;
-      const { boundaries: pageBoundaries, pageHeightPx } = calculatePageBoundaries(
-        totalHeight,
-        elementWidth,
-        PAGE_CONFIG
-      );
-
-      logPdfExportDebug('Step 3 - Page boundaries:', {
-        elementWidth,
-        totalHeight,
-        pageHeightPx: Math.round(pageHeightPx),
-        boundaries: pageBoundaries.map(b => Math.round(b))
-      });
-
-      // Step 4: Detect split elements
-      const splitElements = detectSplitElements(elementsWithPositions, pageBoundaries);
-      logPdfExportDebug('Step 4 - Split elements detected:', splitElements.length);
-
-      // Calculate page count
-      const pageCount = pageBoundaries.length + 1;
-
-      return {
-        totalElements: graphics.length,
-        splitElements: splitElements,
-        pageCount: pageCount,
-        pageBoundaries: pageBoundaries,
-        pageHeightPx: pageHeightPx
-      };
-    } catch (error) {
-      if (error instanceof PdfExportCancelledError) throw error;
-      console.error('Page-break analysis failed:', error);
-      return {
-        totalElements: 0,
-        splitElements: [],
-        pageCount: 1,
-        pageBoundaries: [],
-        pageHeightPx: 0
-      };
-    }
-  }
-
-  // ============================================
-  // End Page-Break Detection Functions
-  // ============================================
-
-  // ============================================
-  // Page-Break Insertion Functions (Story 1.2)
-  // ============================================
-
-  // Threshold for whitespace optimization (30% of page height)
-  const PAGE_BREAK_THRESHOLD = 0.3;
-
-  /**
-   * Task 3: Categorizes split elements by whether they fit on a single page
-   * @param {Array} splitElements - Array of split elements from detection
-   * @param {number} pageHeightPx - Page height in pixels
-   * @returns {Object} { fittingElements, oversizedElements }
-   */
-  function categorizeBySize(splitElements, pageHeightPx) {
-    const fittingElements = [];
-    const oversizedElements = [];
-
-    for (const item of splitElements) {
-      if (item.height <= pageHeightPx) {
-        fittingElements.push(item);
-      } else {
-        oversizedElements.push(item);
-      }
-    }
-
-    return { fittingElements, oversizedElements };
-  }
-
-  /**
-   * Task 1: Inserts page breaks by adjusting margins for fitting elements
-   * @param {Array} fittingElements - Elements that fit on a single page
-   * @param {number} pageHeightPx - Page height in pixels
-   */
-  function insertPageBreaks(fittingElements, pageHeightPx, signal) {
-    for (const item of fittingElements) {
-      throwIfPdfExportAborted(signal);
-
-      // Calculate where the current page ends
-      const currentPageBottom = (item.splitPageIndex + 1) * pageHeightPx;
-
-      // Calculate remaining space on current page
-      const remainingSpace = currentPageBottom - item.top;
-      const remainingRatio = remainingSpace / pageHeightPx;
-
-      logPdfExportDebug('Processing split element:', {
-        type: item.type,
-        top: Math.round(item.top),
-        height: Math.round(item.height),
-        splitPageIndex: item.splitPageIndex,
-        currentPageBottom: Math.round(currentPageBottom),
-        remainingSpace: Math.round(remainingSpace),
-        remainingRatio: remainingRatio.toFixed(2)
-      });
-
-      // Element is pushed to the next page to prevent splitting across page boundaries.
-
-      // Calculate margin needed to push element to next page
-      const marginNeeded = currentPageBottom - item.top + 5; // 5px buffer
-
-      logPdfExportDebug('  -> Applying marginTop:', marginNeeded, 'px');
-
-      // Determine which element to apply margin to
-      // For SVG elements (Mermaid diagrams), apply to parent container for proper layout
-      let targetElement = item.element;
-      if (item.type === 'svg' && item.element.parentElement) {
-        targetElement = item.element.parentElement;
-        logPdfExportDebug('  -> Using parent element:', targetElement.tagName, targetElement.className);
-      }
-
-      // Apply margin to push element to next page
-      const currentMargin = parseFloat(targetElement.style.marginTop) || 0;
-      targetElement.style.marginTop = `${currentMargin + marginNeeded}px`;
-
-      logPdfExportDebug('  -> Element after margin:', targetElement.tagName, 'marginTop =', targetElement.style.marginTop);
-    }
-  }
-
-  /**
-   * Task 2: Applies page breaks with cascading adjustment handling
-   * @param {HTMLElement} tempElement - The rendered content container
-   * @param {Object} pageConfig - Page configuration object (unused, kept for API compatibility)
-   * @param {number} maxIterations - Maximum iterations to prevent infinite loops
-   * @returns {Object} Final analysis result
-   */
-  function applyPageBreaksWithCascade(tempElement, pageConfig, maxIterations = 10, signal) {
-    let iteration = 0;
-    let analysis;
-    let previousSplitCount = -1;
-
-    do {
-      throwIfPdfExportAborted(signal);
-
-      // Re-analyze after each adjustment
-      analysis = analyzeGraphicsForPageBreaks(tempElement, signal);
-
-      // Use pageHeightPx from analysis (calculated from actual element width)
-      const pageHeightPx = analysis.pageHeightPx;
-
-      // Categorize elements by size
-      const { fittingElements, oversizedElements } = categorizeBySize(
-        analysis.splitElements,
-        pageHeightPx
-      );
-
-      // Store oversized elements for Story 1.3
-      analysis.oversizedElements = oversizedElements;
-
-      // If no fitting elements need adjustment, we're done
-      if (fittingElements.length === 0) {
-        break;
-      }
-
-      // Check if we're making progress (prevent infinite loops)
-      if (fittingElements.length === previousSplitCount) {
-        console.warn('Page-break adjustment not making progress, stopping');
-        break;
-      }
-      previousSplitCount = fittingElements.length;
-
-      // Apply page breaks to fitting elements
-      insertPageBreaks(fittingElements, pageHeightPx, signal);
-      iteration++;
-
-    } while (iteration < maxIterations);
-
-    if (iteration >= maxIterations) {
-      console.warn('Page-break stabilization reached max iterations:', maxIterations);
-    }
-
-    logPdfExportDebug('Page-break cascade complete:', {
-      iterations: iteration,
-      finalSplitCount: analysis.splitElements.length,
-      oversizedCount: analysis.oversizedElements ? analysis.oversizedElements.length : 0
-    });
-
-    return analysis;
-  }
-
   // ============================================
   // End Page-Break Insertion Functions
   // ============================================
@@ -7554,7 +7155,8 @@ document.addEventListener("DOMContentLoaded", function () {
           wrapper.appendChild(el);
         });
 
-        const pageHeightPx = tempElement.offsetWidth * (PAGE_CONFIG.contentHeight / PAGE_CONFIG.contentWidth);
+        // A4 page content aspect ratio (contentHeight 267mm / contentWidth 180mm)
+        const pageHeightPx = tempElement.offsetWidth * (267 / 180);
         tempElement.querySelectorAll("pre").forEach(pre => {
           if (pre.offsetHeight > pageHeightPx) {
             pre.classList.add("oversized");
@@ -7846,95 +7448,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
         return outputPath;
       }
-    },
-
-    LegacyRasterBackend: {
-      print: async function(tempElement, state) {
-        throwIfPdfExportAborted(state.signal);
-
-        if (typeof jspdf === 'undefined' || typeof html2canvas === 'undefined') {
-          updatePdfProgress(state, 62, "Loading PDF libraries");
-          await runPdfAbortable(state, Promise.all([loadScript(CDN.jspdf), loadScript(CDN.html2canvas)]));
-          throwIfPdfExportAborted(state.signal);
-        }
-
-        updatePdfProgress(state, 65, "Calculating legacy page breaks");
-        // Pass 1: Scale oversized elements first to stabilize their heights
-        const initialAnalysis = analyzeGraphicsForPageBreaks(tempElement, state.signal);
-        throwIfPdfExportAborted(state.signal);
-
-        const pageHeightPx = initialAnalysis.pageHeightPx;
-        if (initialAnalysis.splitElements && pageHeightPx) {
-          const { oversizedElements } = categorizeBySize(initialAnalysis.splitElements, pageHeightPx);
-          if (oversizedElements.length > 0) {
-            handleOversizedElements(oversizedElements, pageHeightPx, state.signal);
-          }
-        }
-
-        // Pass 2: Apply page breaks with cascade on the final scaled layout
-        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
-        throwIfPdfExportAborted(state.signal);
-        await waitForPdfFrame(state);
-
-        const pdfOptions = {
-          orientation: 'portrait',
-          unit: 'mm',
-          format: 'a4',
-          compress: true,
-          hotfixes: ["px_scaling"]
-        };
-
-        const pdf = new jspdf.jsPDF(pdfOptions);
-        const pageWidth = pdf.internal.pageSize.getWidth();
-        const pageHeight = pdf.internal.pageSize.getHeight();
-        const margin = 15;
-        const contentWidth = pageWidth - (margin * 2);
-        const captureScale = choosePdfCanvasScale(tempElement);
-
-        updatePdfProgress(state, 75, "Capturing document");
-        const canvas = await runPdfAbortable(state, html2canvas(tempElement, {
-          scale: captureScale,
-          useCORS: true,
-          allowTaint: false,
-          logging: false,
-          windowWidth: Math.max(PAGE_CONFIG.windowWidth, Math.ceil(tempElement.getBoundingClientRect().width)),
-          windowHeight: tempElement.scrollHeight
-        }));
-        await waitForPdfFrame(state);
-        throwIfPdfExportAborted(state.signal);
-
-        const scaleFactor = canvas.width / contentWidth;
-        const imgHeight = canvas.height / scaleFactor;
-        const pagesCount = Math.ceil(imgHeight / (pageHeight - margin * 2));
-
-        updatePdfProgress(state, 80, "Rendering pages");
-        for (let page = 0; page < pagesCount; page++) {
-          throwIfPdfExportAborted(state.signal);
-          const pageProgress = 80 + ((page + 1) / pagesCount) * 18;
-          updatePdfProgress(state, pageProgress, `Rendering page ${page + 1} of ${pagesCount}`);
-
-          if (page > 0) pdf.addPage();
-
-          const sourceY = page * (pageHeight - margin * 2) * scaleFactor;
-          const sourceHeight = Math.min(canvas.height - sourceY, (pageHeight - margin * 2) * scaleFactor);
-          const destHeight = sourceHeight / scaleFactor;
-
-          const pageCanvas = document.createElement('canvas');
-          pageCanvas.width = canvas.width;
-          pageCanvas.height = sourceHeight;
-
-          const ctx = pageCanvas.getContext('2d');
-          ctx.drawImage(canvas, 0, sourceY, canvas.width, sourceHeight, 0, 0, canvas.width, sourceHeight);
-
-          const imgData = pageCanvas.toDataURL('image/png');
-          pdf.addImage(imgData, 'PNG', margin, margin, contentWidth, destHeight);
-          await waitForPdfFrame(state);
-        }
-
-        throwIfPdfExportAborted(state.signal);
-        updatePdfProgress(state, 98, "Saving document");
-        pdf.save("document.pdf");
-      }
     }
   };
 
@@ -7943,29 +7456,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const pdfExportConfirmBtn = document.getElementById("pdf-export-modal-confirm");
   const pdfExportCancelBtn = document.getElementById("pdf-export-modal-close");
   const pdfExportCloseIcon = document.getElementById("pdf-export-modal-close-icon");
-  const pdfCardPrint = document.getElementById("pdf-card-print");
-  const pdfCardLegacy = document.getElementById("pdf-card-legacy");
-  const pdfEnginePrintInput = document.getElementById("pdf-engine-print");
-  const pdfEngineLegacyInput = document.getElementById("pdf-engine-legacy");
-
-  function syncPdfCardStyles() {
-    if (pdfEnginePrintInput.checked) {
-      pdfCardPrint.classList.add("is-selected");
-      pdfCardLegacy.classList.remove("is-selected");
-    } else {
-      pdfCardLegacy.classList.add("is-selected");
-      pdfCardPrint.classList.remove("is-selected");
-    }
-  }
-
-  if (pdfEnginePrintInput && pdfEngineLegacyInput) {
-    pdfEnginePrintInput.addEventListener("change", syncPdfCardStyles);
-    pdfEngineLegacyInput.addEventListener("change", syncPdfCardStyles);
-  }
 
   function openPdfExportModal() {
-    pdfEnginePrintInput.checked = true;
-    syncPdfCardStyles();
     pdfExportModal.style.display = "";
     requestAnimationFrame(() => {
       pdfExportModal.classList.add("is-visible");
@@ -8004,20 +7496,15 @@ document.addEventListener("DOMContentLoaded", function () {
       progressState.overlay.querySelector(".pdf-progress-cancel")?.focus();
 
       try {
-        const isLegacy = pdfEngineLegacyInput.checked;
         const markdown = markdownEditor.value;
 
-        const { fullHtml, tempElement } = await PdfExportEngine.ExportDocumentBuilder.build(markdown, progressState);
+        const { fullHtml } = await PdfExportEngine.ExportDocumentBuilder.build(markdown, progressState);
 
-        if (isLegacy) {
-          await PdfExportEngine.LegacyRasterBackend.print(tempElement, progressState);
+        updatePdfProgress(progressState, 75, "Generating PDF");
+        if (typeof Neutralino !== 'undefined') {
+          await PdfExportEngine.DesktopChromiumSidecarBackend.print(fullHtml, progressState);
         } else {
-          updatePdfProgress(progressState, 75, "Generating PDF");
-          if (typeof Neutralino !== 'undefined') {
-            await PdfExportEngine.DesktopChromiumSidecarBackend.print(fullHtml, progressState);
-          } else {
-            await PdfExportEngine.WebPrintBackend.print(fullHtml, progressState);
-          }
+          await PdfExportEngine.WebPrintBackend.print(fullHtml, progressState);
         }
 
         updatePdfProgress(progressState, 100, "Complete");

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -551,6 +551,11 @@ document.addEventListener("DOMContentLoaded", function () {
         if (data.type === "render-result") {
           previewWorkerFailureCount = 0;
           pending.resolve(data.result);
+        } else if (data.type === "render-full-result") {
+          previewWorkerFailureCount = 0;
+          pending.resolve(data.html);
+        } else if (data.type === "render-full-error") {
+          pending.reject(new Error(data.error || "Preview worker render-full failed."));
         } else {
           recordPreviewWorkerRenderFailure();
           pending.reject(new Error(data.error || "Preview worker render failed."));
@@ -592,6 +597,54 @@ document.addEventListener("DOMContentLoaded", function () {
         },
       });
     });
+  }
+
+  function requestFullWorkerRender(rawVal) {
+    const worker = getPreviewWorker();
+    if (!worker) return Promise.reject(new Error("Worker unavailable"));
+
+    const requestId = ++previewWorkerRequestCounter;
+    return new Promise(function(resolve, reject) {
+      const timeoutId = setTimeout(function() {
+        previewWorkerRequests.delete(requestId);
+        reject(new Error("Full render worker timeout."));
+      }, 30000); // 30s timeout for full document render
+
+      previewWorkerRequests.set(requestId, { resolve, reject, timeoutId });
+
+      try {
+        worker.postMessage({
+          type: "render-full",
+          requestId: requestId,
+          markdown: rawVal,
+          options: {
+            libraryUrls: getPreviewWorkerLibraryUrls()
+          },
+        });
+      } catch (e) {
+        previewWorkerRequests.delete(requestId);
+        clearTimeout(timeoutId);
+        reject(e);
+      }
+    });
+  }
+
+  async function parseMarkdownFull(markdown) {
+    try {
+      const html = await requestFullWorkerRender(markdown);
+      return html;
+    } catch (e) {
+      console.warn("Full worker render failed, falling back to main thread:", e);
+      const { frontmatter, body } = parseFrontmatter(markdown);
+      const tableHtml = frontmatter ? renderFrontmatterTable(frontmatter) : '';
+      const referenceData = extractReferenceDefinitions(body);
+      const parsedHtml = tableHtml + marked.parse(referenceData.cleanedMarkdown);
+      const sanitizedHtml = DOMPurify.sanitize(parsedHtml, {
+        ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
+        ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled', 'data-original-code']
+      });
+      return sanitizedHtml;
+    }
   }
 
   function parseInlineWithoutFootnotes(text) {
@@ -7458,195 +7511,411 @@ document.addEventListener("DOMContentLoaded", function () {
   // End Oversized Graphics Scaling Functions
   // ============================================
 
-  exportPdf.addEventListener("click", async function (event) {
-    event.preventDefault();
-    if (activePdfExport) return;
+  // ============================================
+  // New Modular PDF Export Engine
+  // ============================================
+  const PdfExportEngine = {
+    ExportDocumentBuilder: {
+      build: async function(markdown, state) {
+        updatePdfProgress(state, 15, "Parsing markdown");
+        await waitForPdfFrame(state);
+        
+        const sanitizedHtml = await parseMarkdownFull(markdown);
+        throwIfPdfExportAborted(state.signal);
 
-    const progressState = createPdfProgressState();
-    activePdfExport = progressState;
-    setPdfExportTriggersBusy(progressState, true);
-    document.body.appendChild(progressState.overlay);
-    updatePdfProgress(progressState, 3, "Starting");
-    progressState.overlay.querySelector(".pdf-progress-cancel")?.focus();
+        updatePdfProgress(state, 24, "Preparing document");
+        await waitForPdfFrame(state);
+        
+        const tempElement = document.createElement("div");
+        state.tempElement = tempElement;
+        tempElement.className = "markdown-body pdf-export";
+        tempElement.innerHTML = sanitizedHtml;
+        enhanceGitHubAlerts(tempElement);
+        tempElement.style.padding = "20px";
+        tempElement.style.width = "210mm";
+        tempElement.style.margin = "0 auto";
+        tempElement.style.fontSize = "14px";
+        tempElement.style.position = "fixed";
+        tempElement.style.left = "-9999px";
+        tempElement.style.top = "0";
 
-    try {
-      // PERF-002: Lazy-load PDF libraries on first export
-      if (typeof jspdf === 'undefined' || typeof html2canvas === 'undefined') {
-        updatePdfProgress(progressState, 8, "Loading PDF libraries");
-        await runPdfAbortable(progressState, Promise.all([loadScript(CDN.jspdf), loadScript(CDN.html2canvas)]));
-        throwIfPdfExportAborted(progressState.signal);
-      }
+        const currentTheme = document.documentElement.getAttribute("data-theme");
+        tempElement.style.backgroundColor = currentTheme === "dark" ? "#0d1117" : "#ffffff";
+        tempElement.style.color = currentTheme === "dark" ? "#c9d1d9" : "#24292e";
 
-      updatePdfProgress(progressState, 15, "Parsing markdown");
-      await waitForPdfFrame(progressState);
-      const markdown = markdownEditor.value;
-      const html = marked.parse(markdown);
-      const sanitizedHtml = DOMPurify.sanitize(html, {
-        ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
-        ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled', 'data-original-code']
-      });
-      throwIfPdfExportAborted(progressState.signal);
+        document.body.appendChild(tempElement);
+        await waitForPdfFrame(state);
 
-      updatePdfProgress(progressState, 24, "Preparing document");
-      await waitForPdfFrame(progressState);
-      const tempElement = document.createElement("div");
-      progressState.tempElement = tempElement;
-      tempElement.className = "markdown-body pdf-export";
-      tempElement.innerHTML = sanitizedHtml;
-      enhanceGitHubAlerts(tempElement);
-      tempElement.style.padding = "20px";
-      tempElement.style.width = "210mm";
-      tempElement.style.margin = "0 auto";
-      tempElement.style.fontSize = "14px";
-      tempElement.style.position = "fixed";
-      tempElement.style.left = "-9999px";
-      tempElement.style.top = "0";
+        await PdfExportEngine.AssetReadinessGate.awaitReady(tempElement, markdown, state);
+        throwIfPdfExportAborted(state.signal);
 
-      const currentTheme = document.documentElement.getAttribute("data-theme");
-      tempElement.style.backgroundColor = currentTheme === "dark" ? "#0d1117" : "#ffffff";
-      tempElement.style.color = currentTheme === "dark" ? "#c9d1d9" : "#24292e";
-
-      document.body.appendChild(tempElement);
-      await waitForPdfFrame(progressState);
-
-      const mermaidNodes = tempElement.querySelectorAll('.mermaid');
-      if (mermaidNodes.length > 0) {
-        updatePdfProgress(progressState, 34, "Rendering diagrams");
-        try {
-          if (typeof mermaid === 'undefined') {
-            await runPdfAbortable(progressState, loadScript(CDN.mermaid));
+        const pageHeightPx = tempElement.offsetWidth * (PAGE_CONFIG.contentHeight / PAGE_CONFIG.contentWidth);
+        tempElement.querySelectorAll("pre").forEach(pre => {
+          if (pre.offsetHeight > pageHeightPx) {
+            pre.classList.add("oversized");
           }
-          throwIfPdfExportAborted(progressState.signal);
-          initMermaid(true);
-          await runPdfAbortable(progressState, mermaid.init(undefined, mermaidNodes));
-          tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
-            container.classList.remove('is-loading');
-          });
-        } catch (mermaidError) {
-          if (mermaidError instanceof PdfExportCancelledError) throw mermaidError;
-          console.warn("Mermaid rendering issue:", mermaidError);
-          tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
-            container.classList.remove('is-loading');
-          });
-        }
-        throwIfPdfExportAborted(progressState.signal);
-        await waitForPdfFrame(progressState);
-      }
-
-      if (window.MathJax && markdownLikelyContainsMath(markdown)) {
-        updatePdfProgress(progressState, 44, "Rendering math");
-        try {
-          await runPdfAbortable(progressState, MathJax.typesetPromise([tempElement]));
-        } catch (mathJaxError) {
-          if (mathJaxError instanceof PdfExportCancelledError) throw mathJaxError;
-          console.warn("MathJax rendering issue:", mathJaxError);
-        }
-        throwIfPdfExportAborted(progressState.signal);
-
-        // Hide MathJax assistive elements that cause duplicate text in PDF
-        // These are screen reader elements that html2canvas captures as visible
-        // Use multiple CSS properties to ensure html2canvas doesn't render them
-        const assistiveElements = tempElement.querySelectorAll('mjx-assistive-mml');
-        assistiveElements.forEach(el => {
-          el.style.display = 'none';
-          el.style.visibility = 'hidden';
-          el.style.position = 'absolute';
-          el.style.width = '0';
-          el.style.height = '0';
-          el.style.overflow = 'hidden';
-          el.remove(); // Remove entirely from DOM
         });
 
-        // Also hide any MathJax script elements that might contain source
-        const mathScripts = tempElement.querySelectorAll('script[type*="math"], script[type*="tex"]');
-        mathScripts.forEach(el => el.remove());
+        const parentStyles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
+          .map(el => el.outerHTML)
+          .join("\n");
+
+        const fullHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Export Document</title>
+  ${parentStyles}
+</head>
+<body class="${currentTheme === 'dark' ? 'dark-theme' : 'light-theme'}" data-theme="${currentTheme}">
+  <div class="markdown-body pdf-export" style="padding: 20px; width: 100%; box-shadow: none;">
+    ${tempElement.innerHTML}
+  </div>
+</body>
+</html>`;
+
+        return { fullHtml, tempElement };
       }
+    },
 
-      await waitForPdfFrame(progressState);
-      fitExportElementToContent(tempElement);
-      await waitForPdfFrame(progressState);
+    AssetReadinessGate: {
+      awaitReady: async function(tempElement, markdown, state) {
+        if (window.MathJax && markdownLikelyContainsMath(markdown)) {
+          updatePdfProgress(state, 30, "Rendering math");
+          try {
+            await runPdfAbortable(state, MathJax.typesetPromise([tempElement]));
+          } catch (err) {
+            console.warn("MathJax rendering issue:", err);
+          }
+          throwIfPdfExportAborted(state.signal);
+          
+          tempElement.querySelectorAll('mjx-assistive-mml').forEach(el => el.remove());
+          tempElement.querySelectorAll('script[type*="math"], script[type*="tex"]').forEach(el => el.remove());
+        }
 
-      // Analyze and apply page-breaks for graphics (Story 1.1 + 1.2)
-      updatePdfProgress(progressState, 55, "Optimizing page breaks");
-      const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, progressState.signal);
-      throwIfPdfExportAborted(progressState.signal);
+        const mermaidNodes = tempElement.querySelectorAll('.mermaid');
+        if (mermaidNodes.length > 0) {
+          updatePdfProgress(state, 40, "Rendering diagrams");
+          try {
+            if (typeof mermaid === 'undefined') {
+              await runPdfAbortable(state, loadScript(CDN.mermaid));
+            }
+            throwIfPdfExportAborted(state.signal);
+            initMermaid(true);
+            await runPdfAbortable(state, mermaid.init(undefined, mermaidNodes));
+            tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
+              container.classList.remove('is-loading');
+            });
+          } catch (err) {
+            console.warn("Mermaid rendering issue:", err);
+            tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
+              container.classList.remove('is-loading');
+            });
+          }
+          throwIfPdfExportAborted(state.signal);
+        }
 
-      // Scale oversized graphics that can't fit on a single page (Story 1.3)
-      if (pageBreakAnalysis.oversizedElements && pageBreakAnalysis.pageHeightPx) {
-        handleOversizedElements(pageBreakAnalysis.oversizedElements, pageBreakAnalysis.pageHeightPx, progressState.signal);
+        const images = Array.from(tempElement.querySelectorAll("img"));
+        if (images.length > 0) {
+          updatePdfProgress(state, 50, "Loading images");
+          await Promise.all(images.map(img => {
+            if (img.complete) return Promise.resolve();
+            return new Promise(resolve => {
+              img.addEventListener("load", resolve, { once: true });
+              img.addEventListener("error", resolve, { once: true });
+            });
+          }));
+          await Promise.all(images.map(img => {
+            if (typeof img.decode === "function") {
+              return img.decode().catch(() => {});
+            }
+            return Promise.resolve();
+          }));
+          throwIfPdfExportAborted(state.signal);
+        }
+
+        if (document.fonts && typeof document.fonts.ready === "object") {
+          updatePdfProgress(state, 55, "Loading fonts");
+          await document.fonts.ready;
+          throwIfPdfExportAborted(state.signal);
+        }
+
+        updatePdfProgress(state, 60, "Stabilizing layout");
+        await waitForPdfFrame(state);
+        await waitForPdfFrame(state);
       }
-      await waitForPdfFrame(progressState);
+    },
 
-      const pdfOptions = {
-        orientation: 'portrait',
-        unit: 'mm',
-        format: 'a4',
-        compress: true,
-        hotfixes: ["px_scaling"]
-      };
+    WebPrintBackend: {
+      print: function(fullHtml, state) {
+        return new Promise((resolve, reject) => {
+          try {
+            throwIfPdfExportAborted(state.signal);
+            
+            const iframe = document.createElement("iframe");
+            iframe.style.position = "fixed";
+            iframe.style.left = "-9999px";
+            iframe.style.top = "0";
+            iframe.style.width = "100%";
+            iframe.style.height = "100%";
+            document.body.appendChild(iframe);
+            
+            const doc = iframe.contentDocument || iframe.contentWindow.document;
+            doc.open();
+            doc.write(fullHtml);
+            doc.close();
 
-      const pdf = new jspdf.jsPDF(pdfOptions);
-      const pageWidth = pdf.internal.pageSize.getWidth();
-      const pageHeight = pdf.internal.pageSize.getHeight();
-      const margin = 15;
-      const contentWidth = pageWidth - (margin * 2);
-      const captureScale = choosePdfCanvasScale(tempElement);
+            const cleanup = () => {
+              if (iframe.parentNode) {
+                iframe.parentNode.removeChild(iframe);
+              }
+            };
 
-      updatePdfProgress(progressState, 65, "Capturing document");
-      const canvas = await runPdfAbortable(progressState, html2canvas(tempElement, {
-        scale: captureScale,
-        useCORS: true,
-        allowTaint: false,
-        logging: false,
-        windowWidth: Math.max(PAGE_CONFIG.windowWidth, Math.ceil(tempElement.getBoundingClientRect().width)),
-        windowHeight: tempElement.scrollHeight
-      }));
-      await waitForPdfFrame(progressState);
-      throwIfPdfExportAborted(progressState.signal);
-
-      const scaleFactor = canvas.width / contentWidth;
-      const imgHeight = canvas.height / scaleFactor;
-      const pagesCount = Math.ceil(imgHeight / (pageHeight - margin * 2));
-
-      updatePdfProgress(progressState, 76, "Rendering pages");
-      for (let page = 0; page < pagesCount; page++) {
-        throwIfPdfExportAborted(progressState.signal);
-        const pageProgress = 76 + ((page + 1) / pagesCount) * 18;
-        updatePdfProgress(progressState, pageProgress, `Rendering page ${page + 1} of ${pagesCount}`);
-
-        if (page > 0) pdf.addPage();
-
-        const sourceY = page * (pageHeight - margin * 2) * scaleFactor;
-        const sourceHeight = Math.min(canvas.height - sourceY, (pageHeight - margin * 2) * scaleFactor);
-        const destHeight = sourceHeight / scaleFactor;
-
-        const pageCanvas = document.createElement('canvas');
-        pageCanvas.width = canvas.width;
-        pageCanvas.height = sourceHeight;
-
-        const ctx = pageCanvas.getContext('2d');
-        ctx.drawImage(canvas, 0, sourceY, canvas.width, sourceHeight, 0, 0, canvas.width, sourceHeight);
-
-        const imgData = pageCanvas.toDataURL('image/png');
-        pdf.addImage(imgData, 'PNG', margin, margin, contentWidth, destHeight);
-        await waitForPdfFrame(progressState);
+            iframe.contentWindow.focus();
+            
+            iframe.contentWindow.addEventListener("afterprint", () => {
+              cleanup();
+              resolve();
+            }, { once: true });
+            
+            iframe.contentWindow.print();
+            
+            setTimeout(() => {
+              cleanup();
+              resolve();
+            }, 5000);
+          } catch (err) {
+            reject(err);
+          }
+        });
       }
+    },
 
-      throwIfPdfExportAborted(progressState.signal);
-      updatePdfProgress(progressState, 98, "Preparing download");
-      pdf.save("document.pdf");
-      updatePdfProgress(progressState, 100, "Complete");
+    DesktopChromiumSidecarBackend: {
+      print: async function(fullHtml, state) {
+        throwIfPdfExportAborted(state.signal);
 
-    } catch (error) {
-      if (error instanceof PdfExportCancelledError || progressState.signal.aborted) {
-        console.info("PDF export cancelled");
-      } else {
-        console.error("PDF export failed:", error);
-        alert("PDF export failed: " + error.message);
+        const outputPath = await Neutralino.os.showSaveDialog("Save PDF Document", {
+          filters: [{ name: "PDF files", extensions: ["pdf"] }]
+        });
+
+        if (!outputPath) {
+          throw new Error("Export cancelled by user.");
+        }
+
+        throwIfPdfExportAborted(state.signal);
+
+        let port;
+        try {
+          port = await Neutralino.filesystem.readFile(".pdf_exporter_port");
+          port = port.trim();
+        } catch (err) {
+          throw new Error("Local PDF exporter extension is not running. Please make sure the desktop application is running properly.");
+        }
+
+        throwIfPdfExportAborted(state.signal);
+
+        const response = await fetch(`http://127.0.0.1:${port}/export`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            html: fullHtml,
+            outputPath: outputPath
+          }),
+          signal: state.signal
+        });
+
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({}));
+          throw new Error(errData.error || `HTTP error ${response.status}`);
+        }
+
+        return outputPath;
       }
-    } finally {
-      cleanupPdfExport(progressState);
+    },
+
+    LegacyRasterBackend: {
+      print: async function(tempElement, state) {
+        throwIfPdfExportAborted(state.signal);
+
+        if (typeof jspdf === 'undefined' || typeof html2canvas === 'undefined') {
+          updatePdfProgress(state, 62, "Loading PDF libraries");
+          await runPdfAbortable(state, Promise.all([loadScript(CDN.jspdf), loadScript(CDN.html2canvas)]));
+          throwIfPdfExportAborted(state.signal);
+        }
+
+        updatePdfProgress(state, 65, "Calculating legacy page breaks");
+        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
+        throwIfPdfExportAborted(state.signal);
+
+        if (pageBreakAnalysis.oversizedElements && pageBreakAnalysis.pageHeightPx) {
+          handleOversizedElements(pageBreakAnalysis.oversizedElements, pageBreakAnalysis.pageHeightPx, state.signal);
+        }
+        await waitForPdfFrame(state);
+
+        const pdfOptions = {
+          orientation: 'portrait',
+          unit: 'mm',
+          format: 'a4',
+          compress: true,
+          hotfixes: ["px_scaling"]
+        };
+
+        const pdf = new jspdf.jsPDF(pdfOptions);
+        const pageWidth = pdf.internal.pageSize.getWidth();
+        const pageHeight = pdf.internal.pageSize.getHeight();
+        const margin = 15;
+        const contentWidth = pageWidth - (margin * 2);
+        const captureScale = choosePdfCanvasScale(tempElement);
+
+        updatePdfProgress(state, 75, "Capturing document");
+        const canvas = await runPdfAbortable(state, html2canvas(tempElement, {
+          scale: captureScale,
+          useCORS: true,
+          allowTaint: false,
+          logging: false,
+          windowWidth: Math.max(PAGE_CONFIG.windowWidth, Math.ceil(tempElement.getBoundingClientRect().width)),
+          windowHeight: tempElement.scrollHeight
+        }));
+        await waitForPdfFrame(state);
+        throwIfPdfExportAborted(state.signal);
+
+        const scaleFactor = canvas.width / contentWidth;
+        const imgHeight = canvas.height / scaleFactor;
+        const pagesCount = Math.ceil(imgHeight / (pageHeight - margin * 2));
+
+        updatePdfProgress(state, 80, "Rendering pages");
+        for (let page = 0; page < pagesCount; page++) {
+          throwIfPdfExportAborted(state.signal);
+          const pageProgress = 80 + ((page + 1) / pagesCount) * 18;
+          updatePdfProgress(state, pageProgress, `Rendering page ${page + 1} of ${pagesCount}`);
+
+          if (page > 0) pdf.addPage();
+
+          const sourceY = page * (pageHeight - margin * 2) * scaleFactor;
+          const sourceHeight = Math.min(canvas.height - sourceY, (pageHeight - margin * 2) * scaleFactor);
+          const destHeight = sourceHeight / scaleFactor;
+
+          const pageCanvas = document.createElement('canvas');
+          pageCanvas.width = canvas.width;
+          pageCanvas.height = sourceHeight;
+
+          const ctx = pageCanvas.getContext('2d');
+          ctx.drawImage(canvas, 0, sourceY, canvas.width, sourceHeight, 0, 0, canvas.width, sourceHeight);
+
+          const imgData = pageCanvas.toDataURL('image/png');
+          pdf.addImage(imgData, 'PNG', margin, margin, contentWidth, destHeight);
+          await waitForPdfFrame(state);
+        }
+
+        throwIfPdfExportAborted(state.signal);
+        updatePdfProgress(state, 98, "Saving document");
+        pdf.save("document.pdf");
+      }
     }
+  };
+
+  // PDF Export Modal Elements
+  const pdfExportModal = document.getElementById("pdf-export-modal");
+  const pdfExportConfirmBtn = document.getElementById("pdf-export-modal-confirm");
+  const pdfExportCancelBtn = document.getElementById("pdf-export-modal-close");
+  const pdfExportCloseIcon = document.getElementById("pdf-export-modal-close-icon");
+  const pdfCardPrint = document.getElementById("pdf-card-print");
+  const pdfCardLegacy = document.getElementById("pdf-card-legacy");
+  const pdfEnginePrintInput = document.getElementById("pdf-engine-print");
+  const pdfEngineLegacyInput = document.getElementById("pdf-engine-legacy");
+
+  function syncPdfCardStyles() {
+    if (pdfEnginePrintInput.checked) {
+      pdfCardPrint.classList.add("is-selected");
+      pdfCardLegacy.classList.remove("is-selected");
+    } else {
+      pdfCardLegacy.classList.add("is-selected");
+      pdfCardPrint.classList.remove("is-selected");
+    }
+  }
+
+  if (pdfEnginePrintInput && pdfEngineLegacyInput) {
+    pdfEnginePrintInput.addEventListener("change", syncPdfCardStyles);
+    pdfEngineLegacyInput.addEventListener("change", syncPdfCardStyles);
+  }
+
+  function openPdfExportModal() {
+    pdfEnginePrintInput.checked = true;
+    syncPdfCardStyles();
+    pdfExportModal.style.display = "";
+    requestAnimationFrame(() => {
+      pdfExportModal.classList.add("is-visible");
+      pdfExportModal.setAttribute("aria-hidden", "false");
+    });
+  }
+
+  function closePdfExportModal() {
+    pdfExportModal.classList.remove("is-visible");
+    pdfExportModal.setAttribute("aria-hidden", "true");
+    pdfExportModal.addEventListener("transitionend", function handler() {
+      pdfExportModal.style.display = "none";
+      pdfExportModal.removeEventListener("transitionend", handler);
+    });
+  }
+
+  if (pdfExportCancelBtn) pdfExportCancelBtn.addEventListener("click", closePdfExportModal);
+  if (pdfExportCloseIcon) pdfExportCloseIcon.addEventListener("click", closePdfExportModal);
+  if (pdfExportModal) {
+    pdfExportModal.addEventListener("click", function (e) {
+      if (e.target === pdfExportModal) closePdfExportModal();
+    });
+  }
+
+  if (pdfExportConfirmBtn) {
+    pdfExportConfirmBtn.addEventListener("click", async function() {
+      closePdfExportModal();
+      
+      if (activePdfExport) return;
+
+      const progressState = createPdfProgressState();
+      activePdfExport = progressState;
+      setPdfExportTriggersBusy(progressState, true);
+      document.body.appendChild(progressState.overlay);
+      updatePdfProgress(progressState, 3, "Starting");
+      progressState.overlay.querySelector(".pdf-progress-cancel")?.focus();
+
+      try {
+        const isLegacy = pdfEngineLegacyInput.checked;
+        const markdown = markdownEditor.value;
+
+        const { fullHtml, tempElement } = await PdfExportEngine.ExportDocumentBuilder.build(markdown, progressState);
+
+        if (isLegacy) {
+          await PdfExportEngine.LegacyRasterBackend.print(tempElement, progressState);
+        } else {
+          updatePdfProgress(progressState, 75, "Generating PDF");
+          if (typeof Neutralino !== 'undefined') {
+            await PdfExportEngine.DesktopChromiumSidecarBackend.print(fullHtml, progressState);
+          } else {
+            await PdfExportEngine.WebPrintBackend.print(fullHtml, progressState);
+          }
+        }
+
+        updatePdfProgress(progressState, 100, "Complete");
+      } catch (error) {
+        if (error instanceof PdfExportCancelledError || progressState.signal.aborted) {
+          console.info("PDF export cancelled");
+        } else {
+          console.error("PDF export failed:", error);
+          alert("PDF export failed: " + error.message);
+        }
+      } finally {
+        cleanupPdfExport(progressState);
+      }
+    });
+  }
+
+  exportPdf.addEventListener("click", async function (event) {
+    event.preventDefault();
+    openPdfExportModal();
   });
 
   copyMarkdownButton.addEventListener("click", function () {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -7549,17 +7549,111 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         let inlinedStyles = "";
+        const inlinedHrefs = new Set();
+        const inlinedStyleChunks = [];
+        let totalRulesProcessed = 0;
+        let lastYieldTime = performance.now();
+        const yieldIntervalMs = 12; // Yield if a block of tasks takes longer than a ~60fps frame budget (12ms)
+
         for (const sheet of Array.from(document.styleSheets)) {
+          let sheetSuccess = false;
+          let rulesText = "";
+
           try {
-            const rules = Array.from(sheet.cssRules || sheet.rules);
-            inlinedStyles += rules.map(r => r.cssText).join("\n") + "\n";
+            const rules = sheet.cssRules || sheet.rules;
+            if (rules) {
+              const ruleCount = rules.length;
+              const ruleChunks = [];
+              let currentChunk = [];
+
+              for (let i = 0; i < ruleCount; i++) {
+                currentChunk.push(rules[i].cssText);
+                totalRulesProcessed++;
+
+                // Yield to event loop to keep the UI responsive and let progress updates draw
+                if (totalRulesProcessed % 500 === 0) {
+                  const now = performance.now();
+                  if (now - lastYieldTime > yieldIntervalMs) {
+                    ruleChunks.push(currentChunk.join("\n"));
+                    currentChunk = [];
+                    updatePdfProgress(state, 26, `Inlining CSS rules (${totalRulesProcessed} rules)`);
+                    await new Promise(resolve => setTimeout(resolve, 0));
+                    throwIfPdfExportAborted(state.signal);
+                    lastYieldTime = performance.now();
+                  }
+                }
+              }
+
+              if (currentChunk.length > 0) {
+                ruleChunks.push(currentChunk.join("\n"));
+              }
+              rulesText = ruleChunks.join("\n") + "\n";
+              sheetSuccess = true;
+            }
           } catch (e) {
-            // Fallback for CORS or cross-origin stylesheets
+            if (sheet.href) {
+              try {
+                const response = await fetch(sheet.href);
+                if (response.ok) {
+                  rulesText = await response.text() + "\n";
+                  sheetSuccess = true;
+                }
+              } catch (fetchErr) {
+                // Ignore and try Neutralino fallback
+              }
+
+              if (!sheetSuccess && typeof Neutralino !== 'undefined') {
+                try {
+                  let relativePath = sheet.href;
+                  if (relativePath.startsWith(window.location.origin)) {
+                    relativePath = relativePath.substring(window.location.origin.length);
+                  }
+                  if (relativePath.startsWith('file://')) {
+                    const url = new URL(relativePath);
+                    relativePath = url.pathname;
+                    if (relativePath.startsWith('/') && navigator.platform.startsWith('Win')) {
+                      relativePath = relativePath.substring(1);
+                    }
+                  } else if (relativePath.startsWith('/')) {
+                    relativePath = relativePath.substring(1);
+                  }
+                  rulesText = await Neutralino.filesystem.readFile(relativePath) + "\n";
+                  sheetSuccess = true;
+                } catch (neErr) {
+                  console.warn(`Neutralino filesystem fallback failed for stylesheet: ${sheet.href}`, neErr);
+                }
+              }
+            }
+          }
+
+          if (sheetSuccess) {
+            // Escape closing style tags inside the rules to prevent parser escape / XSS
+            rulesText = rulesText.replace(/<\/style/gi, '<\\/style');
+            inlinedStyleChunks.push(rulesText);
+            if (sheet.href) {
+              inlinedHrefs.add(sheet.href);
+            }
           }
         }
+        inlinedStyles = inlinedStyleChunks.join("\n");
 
         const parentStyles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
-          .map(el => el.outerHTML)
+          .filter(el => {
+            if (el.tagName === 'LINK' && el.getAttribute('href')) {
+              // Exclude if it was successfully inlined to prevent duplicate styling & offline resource failures
+              return !inlinedHrefs.has(el.href);
+            }
+            // Exclude styles since they are already fully compiled into inlinedStyles
+            return false;
+          })
+          .map(el => {
+            if (el.tagName === 'LINK' && el.getAttribute('href')) {
+              const clone = el.cloneNode(true);
+              clone.setAttribute('href', el.href); // Resolve relative to absolute URL
+              return clone.outerHTML;
+            }
+            return el.outerHTML;
+          })
           .join("\n");
 
         const fullHtml = `<!DOCTYPE html>
@@ -7752,12 +7846,21 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         updatePdfProgress(state, 65, "Calculating legacy page breaks");
-        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
+        // Pass 1: Scale oversized elements first to stabilize their heights
+        const initialAnalysis = analyzeGraphicsForPageBreaks(tempElement, state.signal);
         throwIfPdfExportAborted(state.signal);
 
-        if (pageBreakAnalysis.oversizedElements && pageBreakAnalysis.pageHeightPx) {
-          handleOversizedElements(pageBreakAnalysis.oversizedElements, pageBreakAnalysis.pageHeightPx, state.signal);
+        const pageHeightPx = initialAnalysis.pageHeightPx;
+        if (initialAnalysis.splitElements && pageHeightPx) {
+          const { oversizedElements } = categorizeBySize(initialAnalysis.splitElements, pageHeightPx);
+          if (oversizedElements.length > 0) {
+            handleOversizedElements(oversizedElements, pageHeightPx, state.signal);
+          }
         }
+
+        // Pass 2: Apply page breaks with cascade on the final scaled layout
+        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
+        throwIfPdfExportAborted(state.signal);
         await waitForPdfFrame(state);
 
         const pdfOptions = {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -7548,6 +7548,16 @@ document.addEventListener("DOMContentLoaded", function () {
           }
         });
 
+        let inlinedStyles = "";
+        for (const sheet of Array.from(document.styleSheets)) {
+          try {
+            const rules = Array.from(sheet.cssRules || sheet.rules);
+            inlinedStyles += rules.map(r => r.cssText).join("\n") + "\n";
+          } catch (e) {
+            // Fallback for CORS or cross-origin stylesheets
+          }
+        }
+
         const parentStyles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
           .map(el => el.outerHTML)
           .join("\n");
@@ -7557,6 +7567,9 @@ document.addEventListener("DOMContentLoaded", function () {
 <head>
   <meta charset="utf-8">
   <title>Export Document</title>
+  <style>
+    ${inlinedStyles}
+  </style>
   ${parentStyles}
 </head>
 <body class="${currentTheme === 'dark' ? 'dark-theme' : 'light-theme'}" data-theme="${currentTheme}">

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -7065,12 +7065,13 @@ document.addEventListener("DOMContentLoaded", function () {
     const graphics = [];
 
     // Query all targeting elements in precise DOM layout flow order
-    container.querySelectorAll('img, svg, pre, table').forEach(el => {
+    container.querySelectorAll('img, svg, pre, table, mjx-container[display="true"]').forEach(el => {
       let type = 'img';
       const tag = el.tagName.toLowerCase();
       if (tag === 'svg') type = 'svg';
       else if (tag === 'pre') type = 'pre';
       else if (tag === 'table') type = 'table';
+      else if (tag === 'mjx-container') type = 'math';
       
       graphics.push({ element: el, type: type });
     });
@@ -7313,16 +7314,7 @@ document.addEventListener("DOMContentLoaded", function () {
         remainingRatio: remainingRatio.toFixed(2)
       });
 
-      // Task 4: Whitespace optimization
-      // If remaining space is more than threshold and element almost fits, skip
-      // (Will be handled by Story 1.3 scaling instead)
-      if (remainingRatio > PAGE_BREAK_THRESHOLD) {
-        const scaledHeight = item.height * 0.9; // 90% scale
-        if (scaledHeight <= remainingSpace) {
-          logPdfExportDebug('  -> Skipping (can fit with 90% scaling)');
-          continue;
-        }
-      }
+      // Element is pushed to the next page to prevent splitting across page boundaries.
 
       // Calculate margin needed to push element to next page
       const marginNeeded = currentPageBottom - item.top + 5; // 5px buffer

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -1504,40 +1504,7 @@ a:focus {
 
 
 
-/* ========================================
-   PDF EXPORT TABLE FIX - Rowspan/Colspan
-   ======================================== */
 
-/* Fix for html2canvas not properly rendering rowspan/colspan cells.
-   Apply backgrounds to cells instead of rows to prevent row backgrounds
-   from painting over rowspan cells during canvas capture. */
-.pdf-export table tr {
-  background-color: transparent !important;
-}
-
-.pdf-export table th,
-.pdf-export table td {
-  background-color: var(--table-bg, #ffffff);
-  position: relative;
-}
-
-.pdf-export table tr:nth-child(2n) th,
-.pdf-export table tr:nth-child(2n) td {
-  background-color: var(--bg-color, #f6f8fa);
-}
-
-/* Ensure rowspan cells render correctly */
-.pdf-export table th[rowspan],
-.pdf-export table td[rowspan] {
-  vertical-align: middle;
-  background-color: var(--table-bg, #ffffff) !important;
-}
-
-/* Ensure colspan cells render correctly */
-.pdf-export table th[colspan],
-.pdf-export table td[colspan] {
-  text-align: center;
-}
 
 /* Ensure target elements are block-level so that layout margins function correctly during PDF export */
 .pdf-export-block {
@@ -1559,21 +1526,7 @@ a:focus {
   display: block !important;
 }
 
-/* Dark mode PDF export table fix */
-[data-theme="dark"] .pdf-export table th,
-[data-theme="dark"] .pdf-export table td {
-  background-color: var(--table-bg, #161b22);
-}
 
-[data-theme="dark"] .pdf-export table tr:nth-child(2n) th,
-[data-theme="dark"] .pdf-export table tr:nth-child(2n) td {
-  background-color: #1c2128;
-}
-
-[data-theme="dark"] .pdf-export table th[rowspan],
-[data-theme="dark"] .pdf-export table td[rowspan] {
-  background-color: var(--table-bg, #161b22) !important;
-}
 
 /* ========================================
    MERMAID DIAGRAM TOOLBAR

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -1540,11 +1540,22 @@ a:focus {
 }
 
 /* Ensure target elements are block-level so that layout margins function correctly during PDF export */
+.pdf-export-block {
+  display: block !important;
+  break-inside: avoid !important;
+  page-break-inside: avoid !important;
+}
+
 .pdf-export img,
 .pdf-export svg,
 .pdf-export pre,
 .pdf-export table,
-.pdf-export mjx-container[display="true"] {
+.pdf-export mjx-container[display="true"],
+.pdf-export-block img,
+.pdf-export-block svg,
+.pdf-export-block pre,
+.pdf-export-block table,
+.pdf-export-block mjx-container[display="true"] {
   display: block !important;
 }
 
@@ -3858,12 +3869,13 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
 /* ========================================
    ENTERPRISE PRINT & PDF LAYOUT
    ======================================== */
-@media print {
-  @page {
-    size: A4;
-    margin: 15mm;
-  }
+/* Define @page at top-level outside media query for universal print margin compatibility */
+@page {
+  size: A4;
+  margin: 15mm;
+}
 
+@media print {
   html,
   body {
     height: auto !important;

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -3845,4 +3845,118 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
     transition: none;
   }
 }
-
+
+/* ========================================
+   ENTERPRISE PRINT & PDF LAYOUT
+   ======================================== */
+@media print {
+  @page {
+    size: A4;
+    margin: 15mm;
+  }
+
+  body {
+    background-color: #ffffff !important;
+    color: #24292e !important;
+    font-size: 12pt;
+    line-height: 1.5;
+  }
+
+  /* Hide UI elements during print */
+  .app-container,
+  .toolbar,
+  .mobile-menu,
+  .stats-container,
+  .resize-divider,
+  .pdf-progress-overlay,
+  .modal,
+  .toast,
+  .navbar,
+  .btn {
+    display: none !important;
+  }
+
+  /* Show and fit print content */
+  .pdf-export {
+    position: static !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    background-color: transparent !important;
+    color: inherit !important;
+    display: block !important;
+    box-shadow: none !important;
+  }
+
+  /* Page breaks & fragmentation */
+  h1, h2, h3, h4, h5, h6 {
+    break-after: avoid-page;
+    page-break-after: avoid;
+    break-inside: avoid;
+  }
+
+  p, li, dd, dt, blockquote {
+    orphans: 3;
+    widows: 3;
+  }
+
+  img, figure, figcaption,
+  .mermaid-container, .mermaid, .mermaid svg,
+  .markdown-alert, .alert, blockquote {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Short code blocks should not split; allow long ones to split */
+  pre {
+    break-inside: auto;
+    page-break-inside: auto;
+    white-space: pre-wrap !important;
+    word-break: break-all;
+  }
+  
+  pre:not(.oversized) {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  pre code {
+    white-space: pre-wrap !important;
+    word-break: break-all;
+  }
+
+  /* Tables spanning pages and repeating headers */
+  table {
+    break-inside: auto;
+    page-break-inside: auto;
+    width: 100% !important;
+    border-collapse: collapse;
+  }
+
+  thead {
+    display: table-header-group;
+    break-after: avoid-page;
+    page-break-after: avoid;
+  }
+
+  tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Scale oversized assets to fit page height/width */
+  img, svg, .mermaid-container, .mermaid svg {
+    max-width: 100% !important;
+    max-height: calc(100vh - 30mm) !important;
+    height: auto !important;
+    object-fit: contain !important;
+  }
+
+  /* Force background colors to print */
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+}

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -3855,6 +3855,12 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
     margin: 15mm;
   }
 
+  html,
+  body {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
   body {
     background-color: #ffffff !important;
     color: #24292e !important;

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -1539,6 +1539,15 @@ a:focus {
   text-align: center;
 }
 
+/* Ensure target elements are block-level so that layout margins function correctly during PDF export */
+.pdf-export img,
+.pdf-export svg,
+.pdf-export pre,
+.pdf-export table,
+.pdf-export mjx-container[display="true"] {
+  display: block !important;
+}
+
 /* Dark mode PDF export table fix */
 [data-theme="dark"] .pdf-export table th,
 [data-theme="dark"] .pdf-export table td {

--- a/docs/pdf-export-engine-reengineering-report.md
+++ b/docs/pdf-export-engine-reengineering-report.md
@@ -1,0 +1,673 @@
+# Enterprise PDF Export Engine Re-engineering Program — Final Investigation Report
+
+**Report date:** June 6, 2026  
+**Repository:** `Markdown-Viewer`  
+**Centralized manager:** Agent 0 — Chief PDF Platform Architect  
+**Scope:** PDF export, generation, rendering, performance, pagination, and PDF-specific layout only.  
+**Change policy:** This investigation changes no product code. It creates only this report.
+
+## Governance and evidence standard
+
+Agent 0 created exactly ten specialized agents (Agents 1–10), assigned the roles requested below, coordinated their investigations, reviewed their independent outputs, reconciled disagreements, and retained final approval authority. No additional specialized agent was created. Agent 0 verified material claims against repository evidence and current public primary sources before approving them for this report.
+
+Claims are classified as follows:
+
+- **Observed:** directly established by repository code, documentation, or a cited public source.
+- **Inferred:** a technical conclusion derived from observed implementation behavior; it still requires runtime confirmation where noted.
+- **Proposed:** a design or validation recommendation, not a description of current behavior.
+- **Unverified proprietary detail:** a claim that cannot be confirmed from public source or open code and is not used as an architectural premise.
+
+No measured export-time claim is presented as fact. This checkout contains no PDF benchmark harness, browser executable, generated large-document corpus, or automated PDF visual test suite. The requested 50/100/250/500/1000-page measurements therefore remain acceptance tests, not fabricated results.
+
+---
+
+## Section 1 — Current PDF Export Architecture Analysis
+
+### 1.1 End-to-end workflow
+
+1. **User entry point.** Desktop and mobile PDF controls dispatch the same browser-side click handler. The mobile control forwards to the primary PDF control (`script.js:6172`, `script.js:7461-7650`).
+2. **Dependency acquisition.** On first export, the handler lazy-loads jsPDF 2.5.1 and html2canvas 1.4.1 from CDN definitions (`script.js:28-35`, `script.js:7473-7477`). The desktop build copies shared application files and rewrites CDN assets for offline use during preparation (`desktop-app/prepare.js:45-57`, `desktop-app/prepare.js:139-202`).
+3. **Duplicate Markdown conversion.** Export reads the editor text and synchronously invokes `marked.parse`, then sanitizes the resulting HTML (`script.js:7480-7488`). This is separate from the normal preview pipeline, which can render in `preview-worker.js` and returns HTML to the UI (`preview-worker.js:330-354`, `preview-worker.js:456-480`).
+4. **Off-screen export DOM.** Export creates a fixed-position, off-screen `.markdown-body.pdf-export` element, assigns a 210 mm width, injects the sanitized HTML, applies theme colors, and appends it to the live document (`script.js:7490-7510`).
+5. **Special renderer replay.** Mermaid nodes in the export clone are rendered again with Mermaid; math is typeset again with MathJax; assistive MathML and math scripts are then removed from the export clone (`script.js:7512-7563`). Syntax highlighting is produced during Markdown rendering through the configured renderer (`preview-worker.js:306-320`; corresponding main-thread renderer in `script.js:914-933`).
+6. **Width mutation.** If content overflows horizontally, export increases the entire export container width to its `scrollWidth` (`script.js:6986-7004`, `script.js:7565-7567`).
+7. **Manual page-break heuristic.** Code identifies every `img`, `svg`, `pre`, and `table`; repeatedly reads geometry; calculates synthetic A4 boundaries; and adds top margins to elements predicted to cross boundaries (`script.js:7011-7025`, `script.js:7034-7051`, `script.js:7060-7075`, `script.js:7143-7202`, `script.js:7242-7292`, `script.js:7302-7354`).
+8. **Oversize mutation.** Elements taller than a synthetic page are CSS-transformed down, with a negative bottom margin. Scaling is clamped to 50%, after which the code explicitly warns content may be cut off (`script.js:7364-7418`, `script.js:7425-7454`).
+9. **Monolithic raster capture.** html2canvas captures the *entire* export DOM into one canvas. Its `windowHeight` is the document's full `scrollHeight`; scale is 2.0, 1.5, or 1.25 according to a coarse pixel-area threshold (`script.js:6974-6979`, `script.js:7593-7603`).
+10. **Raster page slicing.** The single canvas is sliced into one page canvas per A4 page. Every page slice is synchronously converted to a PNG data URL and embedded as an image in jsPDF (`script.js:7607-7633`).
+11. **Download and cleanup.** jsPDF saves `document.pdf`; temporary UI and DOM state are removed (`script.js:7635-7649`, `script.js:6941-6962`).
+
+### 1.2 Browser rendering and dependency graph
+
+```text
+Editor Markdown
+  └─ main-thread marked.parse (export-only second parse)
+      └─ DOMPurify sanitize
+          └─ off-screen export DOM
+              ├─ Mermaid lazy load + render (export-only replay)
+              ├─ MathJax typeset (export-only replay)
+              ├─ image/font/browser layout
+              ├─ repeated geometry analysis and margin mutation
+              └─ html2canvas full-document raster
+                  └─ full-size canvas
+                      └─ per-page canvas + PNG data URL
+                          └─ jsPDF image-only pages
+                              └─ document.pdf
+```
+
+Principal PDF dependencies are explicitly documented as html2canvas plus jsPDF (`README.md:183-194`; `wiki/FAQ.md:71-75`). The project documentation itself states that PDF differences are a known limitation of the html2canvas approach and recommends browser Print → Save as PDF for higher quality (`wiki/FAQ.md:144-146`).
+
+### 1.3 Memory lifecycle
+
+At peak, the current path can simultaneously retain:
+
+- Markdown source and parsed/sanitized HTML strings;
+- the full off-screen export DOM and rendered SVG/math subtrees;
+- html2canvas's internal cloned/rendering structures;
+- one full-document RGBA canvas (approximately `width × height × 4` bytes before implementation overhead);
+- one page canvas;
+- one base64 PNG string (base64 adds roughly one-third encoding overhead before JavaScript string overhead);
+- jsPDF's accumulated image/PDF buffers.
+
+This is an inferred peak-memory model from `script.js:7492-7509` and `script.js:7596-7631`. The browser or desktop webview's exact internal copies must be measured with heap and process-memory profiling.
+
+### 1.4 Existing positive controls
+
+The current implementation includes useful safeguards that should be preserved semantically during migration:
+
+- lazy PDF dependency loading (`script.js:7473-7477`);
+- single active export guard and disabled triggers (`script.js:6797-6799`, `script.js:6920-6937`, `script.js:7461-7467`);
+- progress and ETA UI (`script.js:6841-6916`);
+- cancellation checks between phases and pages (`script.js:6811-6829`, `script.js:7611-7633`);
+- adaptive raster scale (`script.js:6974-6979`);
+- cleanup in `finally` (`script.js:7640-7649`);
+- PDF-specific table paint workarounds (`styles.css:1507-1545`).
+
+The cancellation wrapper rejects the caller's wait, but it does not prove that html2canvas's underlying synchronous work stops. That is an inference requiring profiling (`script.js:6817-6829`, `script.js:7596-7603`).
+
+---
+
+## Section 2 — Agent Findings
+
+### Agent 1 — Frontend Architect
+
+**Independent findings**
+
+- **Observed:** The PDF handler is embedded in the 8,887-line `script.js`, and it directly coordinates loading, parsing, rendering, layout, capture, PDF assembly, UI state, cancellation, and download (`script.js:6782-7650`). This is high coupling and prevents isolated testing.
+- **Observed:** Normal preview has a worker-capable render pipeline, but PDF export calls `marked.parse` on the main thread (`preview-worker.js:330-354`, `script.js:7480-7487`).
+- **Observed:** Export re-renders Mermaid and MathJax into a second DOM rather than consuming a stable export snapshot (`script.js:7512-7563`).
+- **Inferred bottleneck:** Full-document capture and PNG conversion dominate for large documents; duplicate parse/render and repeated forced layout amplify the cost.
+- **Note:** Recommended separating `ExportDocumentBuilder`, `AssetReadinessGate`, `PrintLayout`, and platform `PdfBackend` interfaces. The UI handler should only start/cancel a job and display progress.
+
+**Agent 0 decision:** **Approved.** Coupling and duplicate work are directly supported by code. The relative share of each bottleneck remains a measurement item.
+
+### Agent 2 — PDF Engine Specialist
+
+**Independent findings**
+
+- **Observed:** The engine creates one document-sized bitmap and then embeds a PNG for every page (`script.js:7596-7631`). Text, vector diagrams, and links therefore do not remain native PDF text/vector/link objects through this path.
+- **Observed:** Page boundaries are simulated in CSS pixels before capture, then actual PDF slices are calculated from canvas dimensions and millimetres afterward (`script.js:7060-7075`, `script.js:7607-7621`).
+- **Inferred root cause of slowness:** Work and memory scale with total rendered pixel area, while PNG encoding and PDF image compression add per-page CPU cost.
+- **Inferred root cause of layout mismatch:** The pre-capture page model and post-capture slice model can diverge after width fitting, scaling, font/image completion, rounding, transforms, and margin mutation.
+- **Recommendation:** Replace screenshot-to-PDF with Chromium's print compositor, preserving text/vector output and delegating pagination to a paged-media engine.
+
+**Agent 0 decision:** **Approved.** This is the central architecture decision.
+
+### Agent 3 — Performance Engineer
+
+**Independent findings**
+
+- **Observed:** Geometry is read for all target elements and the document is re-analysed up to ten times after style mutation (`script.js:7034-7051`, `script.js:7302-7345`).
+- **Inferred:** Alternating geometry reads and margin writes can trigger repeated style/layout calculation; complexity is approximately `O(iterations × (targets + boundaries comparisons))`, with up to ten whole-document passes.
+- **Observed:** `canvas.toDataURL('image/png')` is called inside the page loop on the main thread (`script.js:7623-7632`).
+- **Observed:** `requestAnimationFrame` yields occur only between major phases/pages; they do not partition html2canvas capture, canvas draw, PNG encoding, or `addImage` internally (`script.js:6964-6968`, `script.js:7596-7603`, `script.js:7623-7632`).
+- **Recommendation:** Profile long tasks, JS heap, DOM nodes, layout duration, canvas allocation, encode duration, and peak resident memory. Move generation out of the interactive renderer process where platform permits.
+
+**Agent 0 decision:** **Approved with qualification.** Exact percentages and task durations are not yet measured.
+
+### Agent 4 — Large Document Specialist
+
+**Independent findings**
+
+- **Observed:** No checked-in benchmark harness, fixture generator, browser automation suite, or PDF parser/visual comparator exists. `desktop-app/package.json` only contains setup/development/build scripts.
+- **Observed environment limitation:** This investigation environment has no Chromium/Chrome/Firefox executable and no prepared desktop `libs` directory, so trustworthy 50/100/250/500/1000-page runs could not be executed.
+- **Static scalability assessment:** One canvas whose height equals the full document (`script.js:7596-7603`) creates a hard scalability risk. html2canvas's official FAQ warns that empty or truncated output can occur when browser canvas-size limits are reached: <https://html2canvas.hertzen.com/faq.html>.
+- **Recommendation:** Do not claim current timing numbers. Build deterministic fixtures and execute the matrix in Section 9 on representative low/mid/high hardware.
+
+**Agent 0 decision:** **Approved.** Absence of measurements is explicitly recorded; no synthetic result is substituted.
+
+### Agent 5 — Markdown Rendering Specialist
+
+**Independent findings**
+
+- **Observed:** Export does not reuse worker-rendered preview HTML; it reparses Markdown on the main thread (`script.js:7480-7487`).
+- **Observed:** Mermaid and MathJax are replayed in the export DOM (`script.js:7512-7563`).
+- **Observed:** Syntax highlighting occurs as part of code rendering (`preview-worker.js:306-320`), so the export parse may repeat highlighting work for every code block.
+- **Inferred:** Image readiness is not represented by an explicit `Promise.all(img.decode())` gate before page analysis/capture. html2canvas may perform its own loading, but layout analysis can still precede final intrinsic image geometry.
+- **Recommendation:** Build a single immutable export snapshot in a worker where possible, then await fonts, decoded images, Mermaid completion, Math completion, and two stable layout frames before print.
+
+**Agent 0 decision:** **Approved.** The image-readiness gap is a code-level absence, while resulting failures require runtime fixtures.
+
+### Agent 6 — Document Layout Engineer
+
+**Independent findings**
+
+- **Observed:** Only `img`, `svg`, `pre`, and whole `table` elements are protected by the manual algorithm (`script.js:7011-7025`). It does not model figures/captions, headings with following paragraphs, list items, blockquotes, alerts, table rows, widows, or orphans.
+- **Observed:** “Page breaks” are implemented as accumulating `margin-top`, not semantic `break-before`/`break-inside` rules (`script.js:7274-7291`).
+- **Observed:** A table larger than one page is scaled as one unit rather than fragmented by row; code blocks larger than one page are similarly scaled, with a 50% floor that can still cut content (`script.js:7364-7454`).
+- **Observed:** After oversized transforms are applied, the code does not run a final full pagination stabilization before capture (`script.js:7569-7578`).
+- **Inferred:** Mermaid handling targets nested SVGs and sometimes their parent, which can create duplicate/nested target interactions because both container descendants and other graphic nodes participate independently.
+- **Recommendation:** Use print CSS and browser fragmentation: `break-inside: avoid-page` for atomic content that fits; allow controlled row/line fragmentation for oversized tables/code; repeat table headers; apply heading keep-with-next rules; never downscale body text/code to 50% merely to avoid a break.
+
+**Agent 0 decision:** **Approved.** Browser support and exact oversized policies must be covered by cross-platform golden tests.
+
+### Agent 7 — Obsidian Benchmark Researcher
+
+**Independent findings**
+
+- **Observed public facts:** Obsidian is proprietary; its production export implementation is not available for source inspection. The official organization publishes help and APIs, not the application source: <https://github.com/obsidianmd>.
+- **Observed public ecosystem:** Community export plugins advertise either Electron `printToPDF` or Pandoc-based pipelines, demonstrating two common ecosystem strategies, but plugin claims are not evidence of Obsidian's internal implementation. Examples: <https://community.obsidian.md/plugins/advanced-pdf-export> and <https://github.com/mokeyish/obsidian-enhancing-export>.
+- **Qualification:** Claims that Obsidian internally uses a specific print API are **unverified proprietary detail** and are excluded from the design rationale.
+- **Benchmark lesson:** Match the rendered HTML with print-specific CSS, expose explicit page controls, and use a real print/PDF compositor; preserve a Pandoc/LaTeX route only for publication workflows that intentionally trade preview fidelity for typesetting control.
+
+**Agent 0 decision:** **Approved with qualification.** No proprietary implementation inference is presented as fact.
+
+### Agent 8 — VS Code & Typora Benchmark Researcher
+
+**Independent findings**
+
+- **Observed:** VS Code core does not provide a built-in Markdown-to-PDF architecture documented as such; comparison must be to extensions. The open-source `yzane/vscode-markdown-pdf` extension uses a Chromium-based browser and Puppeteer PDF options: <https://github.com/yzane/vscode-markdown-pdf>.
+- **Observed:** As of its public 2.0.x documentation/release notes, that extension resolves installed Chrome/Edge/Chromium or a managed Chromium and includes unit/integration test suites. This is an open-source implementation fact, not a statement about VS Code core.
+- **Observed:** Typora's official export documentation says its PDF is rendered from HTML, supports paper size/margins/theme/page-break/header/footer configuration, and also offers an optional Pandoc/LaTeX PDF route: <https://support.typora.io/Export/>.
+- **Qualification:** Typora is proprietary. Public documentation establishes features and HTML-derived output, but not its private internal call graph or performance characteristics.
+- **Recommendation:** Adopt the proven HTML → Chromium print path for fidelity, with configuration surfaces for paper/margins/background/header/footer, and maintain an optional future publication backend only if demanded.
+
+**Agent 0 decision:** **Approved.** The VS Code comparison is correctly scoped to a named extension.
+
+### Agent 9 — QA & Regression Engineer
+
+**Independent findings**
+
+- **Observed:** No automated PDF export tests are checked in. Existing documentation acknowledges visual differences and recommends browser printing (`wiki/FAQ.md:144-146`).
+- **Observed:** Web and desktop share product sources through a copy/rewrite build step (`desktop-app/prepare.js:45-57`), but checked-in copies can drift until preparation runs.
+- **Required regression baseline:** Markdown constructs, theme colors, GitHub alerts, local/remote images, SVG, Mermaid, MathJax, syntax highlighting, rowspan/colspan tables, links, Unicode, emoji, page size, margins, and cancellation.
+- **Recommendation:** Use structural PDF assertions plus visual golden pages and semantic extraction checks. Compare legacy and new output on a frozen corpus before removal of the fallback.
+
+**Agent 0 decision:** **Approved.** A two-layer visual and semantic test strategy is mandatory.
+
+### Agent 10 — Desktop Platform Engineer
+
+**Independent findings**
+
+- **Observed:** Desktop is Neutralino 6.5.0 in window mode, not Electron (`desktop-app/neutralino.config.json:1-10`, `desktop-app/neutralino.config.json:27-44`, `desktop-app/neutralino.config.json:60-66`).
+- **Observed:** Desktop receives the same `script.js`, worker, styles, and assets from the web root during preparation (`desktop-app/prepare.js:45-57`). Therefore it currently executes the same raster engine in its webview.
+- **Observed:** The current native allow list includes file and dialog APIs but no process-launching capability (`desktop-app/neutralino.config.json:16-25`).
+- **Platform conclusion:** Electron `webContents.printToPDF` cannot simply be called from this application. A desktop background exporter requires either (a) a Neutralino extension/sidecar with a controlled Chromium/DevTools Protocol backend, (b) a supported native print-to-PDF API exposed by the selected webview platform, or (c) a desktop-shell migration, which is not justified solely for PDF export without a separate product decision.
+- **Recommendation:** Prefer a narrowly scoped sidecar/extension backend and keep the interactive renderer responsive. Do not migrate the whole desktop shell as part of this PDF program.
+
+**Agent 0 decision:** **Approved.** This resolves a disagreement with agents proposing direct Electron use.
+
+---
+
+## Section 3 — Performance Bottleneck Analysis
+
+### 3.1 Critical path
+
+| Stage | Current behavior | Scaling/risk | Priority |
+|---|---|---|---|
+| Parse/sanitize | Duplicate main-thread parse | Document size and code blocks | Medium |
+| Mermaid/math | Duplicate export rendering | Number/complexity of diagrams/equations | Medium–high |
+| Layout heuristic | Up to 10 geometry/mutation passes | Targets × pages × iterations | High |
+| Full capture | One document-height canvas | Total pixel area | Critical |
+| Page slicing | Canvas allocation/draw per page | Pages × page pixels | High |
+| PNG encoding | `toDataURL` per page | Pages and image entropy | Critical |
+| jsPDF assembly | Full-page PNG per page | Pages and compressed bytes | High |
+| UI execution | Interactive renderer/main thread | Long tasks and freeze risk | Critical |
+
+### 3.2 Why 10–15 minute exports are plausible
+
+This duration is a user-reported symptom, not reproduced in this environment. It is technically plausible because the pipeline performs several total-document operations and produces high-resolution raster pages. At A4 proportions, doubling capture scale approximately quadruples pixel count. A long document can therefore create hundreds of millions of pixel operations, large transient allocations, repeated PNG compression, and garbage-collection pressure.
+
+### 3.3 Responsiveness defects
+
+- The progress overlay does not make synchronous capture or encoding non-blocking.
+- `AbortController` checks cannot preempt a library while it is executing synchronous work.
+- The desktop webview shares the same renderer workload as the UI.
+- No backpressure, page streaming, worker-owned OffscreenCanvas path, or child-process isolation exists.
+
+### 3.4 Instrumentation required before implementation acceptance
+
+Record per phase: wall time, CPU time where available, long tasks over 50 ms, peak JS heap, peak process resident set, DOM-node count, layout/style duration, canvas dimensions/bytes, output bytes, page count, and cancellation latency. Include hardware/OS/browser versions and cold/warm dependency state.
+
+---
+
+## Section 4 — Layout Quality Analysis
+
+### 4.1 Images and Mermaid
+
+Current logic predicts crossings and pushes elements with margins. This can work for some atomic graphics, but it is fragile because pagination is not performed by the same engine that later slices pages. Oversized content is transformed rather than semantically paginated, and the 50% clamp admits cut-off output (`script.js:7374-7387`). Mermaid is rasterized as part of the page image, losing vector scalability.
+
+### 4.2 Code blocks
+
+A `pre` that fits is pushed to a later synthetic page; a taller `pre` is scaled as a whole. Professional behavior should be policy-driven:
+
+- keep short code blocks atomic;
+- allow oversized blocks to fragment between lines;
+- repeat an optional code caption/header, not the whole block;
+- preserve readable font size;
+- show an explicit continuation marker only if product design approves it.
+
+### 4.3 Tables
+
+Whole-table avoidance is unsuitable for multi-page tables. The target behavior is row-boundary fragmentation, repeated `<thead>`, avoidance within ordinary rows, controlled splitting only for an individually oversized row, and preservation of rowspan/colspan semantics. Existing cell-background workarounds show that raster capture already has table-specific fidelity issues (`styles.css:1511-1545`).
+
+### 4.4 Complex flow
+
+Current targeting omits heading keep-with-next, figures with captions, alerts, blockquotes, lists, widows/orphans, footnotes, and user-inserted semantic page breaks. Chromium paged media supports `@page` and fragmentation controls; MDN documents `break-before`, `break-after`, `break-inside`, `orphans`, and `widows`: <https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Paged_media> and <https://developer.mozilla.org/en-US/docs/Web/CSS/break-inside>.
+
+### 4.5 Important limitation
+
+No engine can keep an element taller than the printable page entirely unbroken. “Prevent splitting” must mean:
+
+1. avoid splitting atomic content that fits on one page;
+2. apply an explicit, tested fallback for oversized content (scale graphics within a readable bound, rotate/select landscape where allowed, or fragment at semantic boundaries);
+3. never silently clip.
+
+---
+
+## Section 5 — Industry Benchmark Findings
+
+| Product/project | Publicly established approach | Useful technique | Qualification |
+|---|---|---|---|
+| Obsidian | Proprietary app; community plugins use Electron print or Pandoc | Print-specific styling; plugin ecosystem demonstrates demand for page controls | Internal native pipeline not publicly verified |
+| Typora | Official docs: PDF rendered from HTML; configurable page size, margins, theme, breaks, header/footer; optional Pandoc/LaTeX | HTML print fidelity plus advanced alternate backend | Proprietary internals/performance unknown |
+| VS Code Markdown PDF extension | Open-source Chromium/Puppeteer exporter | Installed/managed Chromium, `page.pdf`, configurable PDF options, tests | Extension, not VS Code core |
+| MarkText | Open-source Electron Markdown editor with PDF output | Relevant codebase for implementation comparison | Repository feature claim alone does not establish current performance |
+| Zettlr | Open-source Pandoc/LaTeX-centered publication workflow | AST/toolchain separation and templates | Different fidelity/performance trade-off from WYSIWYG print |
+| Chromium/Puppeteer | Native paged PDF compositor with page size, margins, background, headers/footers, CSS page-size preference, font waiting | Vector text, browser pagination, accessibility options | Requires browser/native backend; not silently available to ordinary web pages |
+| html2canvas | DOM-to-canvas renderer with documented canvas/CORS constraints | Useful for screenshots, not ideal as the primary long-document PDF engine | Official FAQ warns about canvas limits |
+
+### Source-backed standards and APIs
+
+- Puppeteer PDF options include format, margins, background, header/footer, CSS page-size preference, tagged PDF, and font waiting: <https://pptr.dev/api/puppeteer.pdfoptions>.
+- Electron exposes `webContents.printToPDF`, but this repository does not use Electron: <https://www.electronjs.org/docs/latest/api/web-contents#contentsprinttopdfoptions>.
+- Chrome DevTools Protocol provides browser instrumentation used by automation tools: <https://chromedevtools.github.io/devtools-protocol/>.
+- CSS Paged Media and Fragmentation are the standards-based pagination model: <https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Paged_media>.
+- Zettlr publicly states that Pandoc is expected for import/export and exposes publication templates: <https://github.com/Zettlr/Zettlr> and <https://github.com/Zettlr/pandoc-templates>.
+- MarkText publicly identifies itself as an Electron Markdown editor with HTML/PDF output: <https://github.com/marktext/marktext>.
+
+### Industry conclusion
+
+The recurring proven patterns are:
+
+1. create deterministic HTML;
+2. load all dependent assets before pagination;
+3. apply dedicated print CSS;
+4. let a browser print compositor or publication engine paginate;
+5. isolate heavy work from the interactive renderer;
+6. test PDFs structurally and visually;
+7. avoid turning every page into a high-resolution screenshot unless image output is specifically requested.
+
+---
+
+## Section 6 — Root Cause Analysis
+
+### Primary root cause
+
+**The current engine treats a document as one giant screenshot and treats a PDF as a stack of PNG images.** This is fundamentally mismatched to long, structured, paginated documents.
+
+### Contributing causes
+
+1. **Monolithic full-document canvas:** memory and CPU follow pixel area and browser canvas limits.
+2. **Main-thread execution:** capture, drawing, PNG encoding, and assembly compete with UI responsiveness.
+3. **Two pagination coordinate systems:** synthetic CSS-pixel breaks precede millimetre-derived canvas slicing.
+4. **Layout mutation heuristic:** repeated geometry reads and margin writes are expensive and unstable.
+5. **Duplicate render path:** export reparses and rerenders Markdown, Mermaid, math, and highlighting.
+6. **Incomplete readiness contract:** no explicit unified gate for fonts, images, diagrams, and stable layout.
+7. **Wrong oversized-content policy:** scale-to-fit can harm readability and still clip.
+8. **No platform abstraction:** web and desktop run the same implementation despite different native capabilities.
+9. **No performance/visual acceptance harness:** regressions and target claims cannot be objectively enforced.
+10. **Single-file orchestration:** tightly coupled code inhibits isolated tests and incremental backend replacement.
+
+### Rejected explanations
+
+- **“jsPDF alone is slow.”** Incomplete: jsPDF contributes assembly cost, but full canvas capture and per-page PNG encoding are upstream critical costs.
+- **“Mermaid alone causes the freeze.”** Incomplete: diagrams add work, but plain long text still traverses the monolithic raster path.
+- **“Add more `requestAnimationFrame` calls.”** Rejected as a primary fix: yielding around indivisible synchronous operations does not reduce their cost or memory.
+- **“Only lower canvas scale.”** Rejected: this trades quality for capacity while retaining the flawed architecture.
+- **“Use Electron directly.”** Rejected for this repository: desktop is Neutralino, not Electron.
+
+---
+
+## Section 7 — New PDF Export Architecture
+
+### 7.1 Approved target architecture
+
+```text
+ExportJobController (UI contract only)
+  ├─ cancellation / progress / telemetry
+  └─ ExportDocumentBuilder
+       ├─ worker-based Markdown parse and sanitize
+       ├─ export-only immutable HTML document
+       ├─ deterministic IDs and metadata
+       └─ AssetReadinessGate
+            ├─ document.fonts.ready
+            ├─ img.decode() / error policy
+            ├─ Mermaid render completion
+            ├─ Math render completion
+            └─ stable-layout check
+                 └─ PrintLayout stylesheet
+                      ├─ @page size/margins
+                      ├─ break rules
+                      ├─ table fragmentation/repeated headers
+                      ├─ code and graphic oversized policies
+                      └─ light/dark/background policy
+                           └─ PdfBackend
+                                ├─ WebPrintBackend
+                                ├─ DesktopChromiumSidecarBackend
+                                └─ LegacyRasterBackend (temporary fallback only)
+```
+
+### 7.2 Shared export document builder
+
+- Must not modify editor, preview, toolbar design, search, tabs, themes, settings, or non-PDF Markdown behavior.
+- Consumes Markdown plus a frozen set of PDF options.
+- Reuses parsing modules/worker logic, but has export-only extensions and CSS.
+- Produces a complete isolated document (prefer sandboxed iframe/blob URL in web; temporary local HTML in desktop).
+- Resolves local images through a platform resource resolver and enforces a clear CORS/error policy.
+- Emits readiness and diagnostic events instead of inspecting the live preview DOM.
+
+### 7.3 Print layout policy
+
+- `@page { size: A4; margin: 15mm; }` by default, configurable through existing/new PDF-only options when product scope permits.
+- `break-inside: avoid-page` for images, figures, Mermaid containers, short `pre`, ordinary table rows, alerts, and other atomic blocks.
+- `break-after: avoid-page`/keep-with-next strategy for headings.
+- `orphans` and `widows` for paragraphs where supported.
+- Tables may span pages; `<thead>` repeats; whole-table avoidance is prohibited for long tables.
+- Oversized graphics scale to printable width/height with a documented minimum readability threshold and no silent clipping.
+- Oversized code blocks fragment at line boundaries instead of shrinking to 50%.
+- Print CSS owns pagination; no pixel-coordinate margin insertion algorithm remains in the final engine.
+
+### 7.4 Web backend
+
+A normal web page cannot silently write a PDF using Chromium's privileged `printToPDF` API. Therefore:
+
+- **Default privacy-preserving client path:** open an isolated prepared export document and invoke browser print, where the user selects “Save as PDF.” This is standards-based, vector-capable, and already recommended by project documentation (`wiki/FAQ.md:73-75`, `wiki/FAQ.md:144-146`).
+- **Optional managed-service path:** only if product requirements demand one-click file download, send the prepared HTML/assets to a controlled headless-Chromium service. This changes the current all-client privacy model and requires explicit security/privacy approval; it is not approved by this report.
+- Keep the old raster download behind a temporary compatibility flag during migration, clearly labelled as legacy and unsuitable for very large documents.
+
+### 7.5 Desktop backend
+
+- Implement a narrowly scoped Neutralino extension/sidecar that launches or communicates with a pinned/validated Chromium-compatible executable using Puppeteer Core or Chrome DevTools Protocol.
+- Generate in a separate process, stream progress/logs, enforce timeout and cancellation by terminating the job process, write to a temporary file, then atomically move to the user-selected destination.
+- Package or resolve the browser deterministically and record its version. Prefer installed compatible Chrome/Edge/Chromium with an approved managed fallback, similar in principle to the open-source VS Code Markdown PDF extension.
+- Do not expose arbitrary process execution to page content. The extension accepts a constrained export request schema and whitelisted paths.
+- Do not migrate the whole app to Electron for this feature.
+
+### 7.6 Output characteristics
+
+Expected qualitative improvements:
+
+- selectable/searchable text;
+- vector SVG/Mermaid where Chromium preserves it;
+- functional hyperlinks where supported;
+- browser-native font shaping and pagination;
+- much lower peak raster memory;
+- no per-page PNG encoding loop;
+- semantic page fragmentation;
+- desktop cancellation that can terminate actual work.
+
+Tagged/accessibility output must be tested rather than assumed. Puppeteer exposes a tagged-PDF option, but semantic quality depends on source HTML and Chromium behavior.
+
+---
+
+## Section 8 — Implementation Plan
+
+### Phase 0 — Baseline and decision records
+
+1. Add architecture decision record selecting browser print composition over raster PDF.
+2. Freeze a representative PDF corpus and legacy outputs.
+3. Add telemetry hooks around the existing path before replacement.
+4. Define supported browsers/desktop OS versions and output fidelity rules.
+5. Define privacy decision: client print only for web unless separately approved.
+
+**Exit gate:** reproducible baseline and agreed acceptance thresholds.
+
+### Phase 1 — Modular export document builder
+
+1. Extract PDF orchestration from `script.js` into PDF-only modules without changing behavior.
+2. Reuse worker parsing/highlighting logic through shared pure functions.
+3. Add isolated export document creation and resource resolution.
+4. Add `AssetReadinessGate` for fonts, decoded images, Mermaid, math, and layout stability.
+5. Preserve progress, cancellation, theme, GitHub alerts, and sanitation behavior.
+
+**Exit gate:** generated export HTML is deterministic and fixture-tested.
+
+### Phase 2 — Standards-based print layout
+
+1. Create PDF-only print stylesheet.
+2. Implement block policies for images, Mermaid, tables, code, headings, alerts, lists, and oversized content.
+3. Remove manual margin insertion from the new backend.
+4. Add page-size/margin/background/header/footer schema as PDF-only options if approved.
+
+**Exit gate:** golden pagination corpus passes in pinned Chromium.
+
+### Phase 3 — Web print backend
+
+1. Create sandboxed export iframe/window from the prepared document.
+2. Show a clear “Preparing” → “Ready to print” progression.
+3. Invoke print only after readiness.
+4. Ensure cleanup after `afterprint`, cancellation, or timeout.
+5. Keep legacy direct-download fallback during controlled rollout.
+
+**Exit gate:** supported browsers export without UI lockups in the test matrix.
+
+### Phase 4 — Desktop sidecar backend
+
+1. Define minimal request/response protocol.
+2. Implement constrained Neutralino extension/sidecar.
+3. Resolve/pin Chromium and generate with `preferCSSPageSize`, `printBackground`, font waiting, and configured margins.
+4. Add hard cancellation, crash isolation, temporary-file cleanup, and atomic save.
+5. Package and sign per platform.
+
+**Exit gate:** desktop matrix passes and UI remains responsive during 1000-page generation.
+
+### Phase 5 — Cutover and retirement
+
+1. Run dual-backend comparison in development/QA.
+2. Roll out new backend behind a PDF-only feature flag.
+3. Monitor failures, duration, peak memory, and cancellations without collecting document content.
+4. Make new backend default after gates pass.
+5. Remove html2canvas/jsPDF PDF dependencies and manual pagination only after fallback retirement approval.
+
+**Explicit non-goals:** no editor, preview, toolbar layout, search, tab, theme system, settings system, or non-export Markdown behavior redesign.
+
+---
+
+## Section 9 — Performance Validation Plan
+
+### 9.1 Required fixture matrix
+
+Generate deterministic documents that produce approximately 50, 100, 250, 500, and 1000 A4 pages in each profile:
+
+1. text/headings/lists;
+2. syntax-highlighted code;
+3. large and numerous images;
+4. Mermaid diagrams;
+5. MathJax expressions;
+6. wide and long tables with rowspan/colspan;
+7. mixed “real-world worst case.”
+
+Use local assets for repeatability and a separate remote/CORS reliability suite.
+
+### 9.2 Metrics
+
+For every run capture:
+
+- prepare, render, readiness, paginate/print, write, and total duration;
+- p50/p95 over at least five warm runs plus one cold run;
+- renderer long-task count and maximum long task;
+- UI heartbeat/input latency during export;
+- peak JS heap and process RSS;
+- child-process peak RSS for desktop;
+- output size and page count;
+- cancellation latency at each phase;
+- failures, blank pages, clipped content, missing assets, and PDF parser errors.
+
+### 9.3 Target gates
+
+Targets must be tied to fixture definitions and reference hardware:
+
+- **Small (≤10 pages, ordinary content):** under 2 seconds on reference desktop backend; web preparation under 2 seconds before print UI.
+- **Medium (≤50 pages):** under 5 seconds on reference desktop backend.
+- **Large (≤250 pages mixed):** under 15 seconds on reference desktop backend, excluding remote asset download.
+- **Very large (500/1000 pages):** no UI freeze; heartbeat gaps under 100 ms in the interactive app; bounded memory with no crash; report actual completion time rather than promise under 15 seconds without evidence.
+- **Cancellation:** UI acknowledges within 100 ms; desktop job process terminates and cleans temporary files within 2 seconds.
+
+The user's “large <15 seconds” goal is adopted for a defined ≤250-page reference workload. A universal 1000-page <15-second promise is not approved without benchmark evidence.
+
+### 9.4 Test hardware and platforms
+
+- Low: 4 logical cores, 8 GB RAM.
+- Reference: 8 logical cores, 16 GB RAM, SSD.
+- High: 12+ logical cores, 32 GB RAM.
+- Windows 11, current supported macOS, Ubuntu LTS.
+- Current stable Chrome/Edge plus one previous supported major for web; pinned desktop Chromium version.
+
+### 9.5 Comparative runs
+
+Run legacy raster and new backend on 50/100/250 pages where legacy completes safely. Do not force 500/1000 legacy runs after memory safety thresholds are exceeded. Report speedup as measured ratios, not projections.
+
+---
+
+## Section 10 — Regression Prevention Plan
+
+### 10.1 Test layers
+
+1. **Unit:** option normalization, resource URL resolution, break-policy classification, readiness timeout/error handling, cancellation state machine.
+2. **HTML snapshot:** deterministic export DOM for every Markdown feature.
+3. **Browser integration:** render and print with pinned Chromium.
+4. **PDF structural:** page count, media box, metadata, text extraction, link annotations, embedded fonts, image presence, no corrupt objects.
+5. **Visual regression:** render selected PDF pages to images and compare with perceptual thresholds plus masked dynamic areas.
+6. **Cross-platform end-to-end:** web print flow and desktop save flow.
+7. **Performance budgets:** fail CI/nightly gates on statistically significant regression.
+
+### 10.2 Frozen corpus
+
+Include headings, paragraphs, emphasis, links, task lists, nested lists, blockquotes, GitHub alerts, footnotes if supported, code languages, math, Mermaid types, SVG/raster images, transparent images, very wide images, large images, tables, rowspan/colspan, Unicode/RTL/CJK/emoji, light/dark export policy, and malformed/missing assets.
+
+### 10.3 Compatibility controls
+
+- Compare the new export against the current preview and legacy PDF, but treat documented html2canvas defects as defects to fix—not golden behavior to preserve.
+- Preserve sanitation and no-network/default privacy expectations.
+- Version the export request schema and print stylesheet.
+- Pin desktop Chromium and update it through security-reviewed releases.
+- Keep output diagnostics free of document content by default.
+- Require Agent 0/architecture owner approval before removing the legacy fallback.
+
+---
+
+## Section 11 — Web Verification
+
+### Supported workflow to verify
+
+1. Load each fixture through the normal web application.
+2. Start PDF export and confirm editor input remains responsive during preparation.
+3. Verify the export document is isolated and does not mutate preview/editor DOM.
+4. Confirm fonts, local images, permitted remote images, Mermaid, math, and highlighting are complete before print opens.
+5. Use Chrome/Edge “Save as PDF”; verify page size, margins, backgrounds, page count, text selection, links, and layout.
+6. Repeat cancellation before readiness and close/after-print cleanup.
+7. Test offline behavior with cached/local dependencies.
+8. Test CORS failures and missing assets with explicit warnings rather than silent omission.
+
+### Browser-specific acceptance
+
+- Chromium browsers are the reference because desktop generation also uses Chromium pagination.
+- Firefox/Safari must be tested for the web print flow; documented pagination differences may require browser-specific print CSS or a support limitation.
+- One-click silent file save is not a web acceptance criterion because it is not available to ordinary page JavaScript.
+
+### Current verification status
+
+**Static review complete; runtime verification pending.** This environment had no browser executable and no test harness. The repository currently recommends browser Print → Save as PDF for higher quality (`wiki/FAQ.md:73-75`, `wiki/FAQ.md:144-146`), supporting feasibility but not replacing formal tests.
+
+---
+
+## Section 12 — Desktop Verification
+
+### Desktop-specific workflow
+
+1. Run `desktop-app/prepare.js` and verify web PDF modules/styles are copied exactly.
+2. Launch Neutralino packages on Windows/macOS/Linux.
+3. Confirm the sidecar accepts only the constrained export schema and approved paths.
+4. Generate every fixture with pinned/resolved Chromium.
+5. Monitor UI renderer and sidecar separately for CPU/RSS.
+6. Cancel during parse, asset load, layout, print, and file write.
+7. Kill/crash the sidecar and verify recovery, diagnostics, and temp-file cleanup.
+8. Verify native save dialog, overwrite behavior, permissions, long paths, Unicode paths, read-only destinations, and disk-full errors.
+9. Verify offline export and package integrity/signing.
+10. Confirm output parity with the reference web Chromium print layout.
+
+### Current platform facts
+
+Neutralino configuration identifies version 6.5.0, window mode, and the existing native API allow list (`desktop-app/neutralino.config.json:1-25`, `desktop-app/neutralino.config.json:27-44`, `desktop-app/neutralino.config.json:60-66`). Shared root sources are copied into desktop resources during preparation (`desktop-app/prepare.js:45-57`). Thus current desktop export has the same performance architecture as web, while the proposed desktop backend must be added as a constrained platform service.
+
+### Current verification status
+
+**Static review complete; runtime verification pending.** No Neutralino binaries, browser engine executable, prepared offline libraries, or GUI test capability were available in this checkout environment.
+
+---
+
+## Section 13 — Chief PDF Platform Architect Final Recommendation
+
+### Is the current PDF engine fundamentally flawed?
+
+**Yes, for the stated enterprise and large-document goals.** It is a competent small-document screenshot exporter with progress, cancellation checks, and several targeted workarounds, but its core full-document raster model is fundamentally unsuitable for scalable, high-fidelity paginated documents.
+
+### Is a rewrite justified?
+
+**Yes—a bounded PDF-subsystem rewrite is justified.** Do not rewrite the editor or preview. Replace PDF orchestration, print layout, and backends behind a narrow interface. Preserve the current engine temporarily as a fallback until regression and performance gates pass.
+
+### What architecture should replace it?
+
+A shared deterministic export-document builder plus asset-readiness gate and dedicated print stylesheet, feeding:
+
+- a standards-based browser print backend for web; and
+- an isolated Neutralino sidecar/extension using pinned/resolved Chromium PDF generation for desktop.
+
+Chromium paged-media composition—not html2canvas plus per-page PNGs—is the approved primary engine. Pandoc/LaTeX is not the default because it risks diverging from current rendered Markdown, but it may be evaluated later as an optional publication backend under separate scope.
+
+### What performance improvements are expected?
+
+Expected, pending measurement:
+
+- elimination of the full-document RGBA canvas and per-page PNG data URLs;
+- elimination of repeated manual page-boundary stabilization in the new path;
+- lower main-renderer CPU and memory;
+- selectable vector/text output with smaller files for text-heavy documents;
+- desktop UI responsiveness through process isolation;
+- material speedups likely to be multiple-fold on long text-heavy documents.
+
+No numeric speedup is approved until Section 9 benchmarks run. The program accepts <2 s small, <5 s medium, and <15 s defined large targets, with responsiveness rather than an unsubstantiated fixed deadline for 500/1000 pages.
+
+### How will layout quality improve?
+
+- The same Chromium engine will paginate and emit the PDF, eliminating the current split between synthetic page coordinates and raster slicing.
+- Print CSS will express semantic break policies.
+- Images and Mermaid that fit will remain atomic; oversized graphics will use explicit no-clip policy.
+- Short code blocks remain atomic; oversized code fragments at line boundaries without unreadable global shrink.
+- Tables fragment by rows with repeatable headers rather than being treated as one giant image.
+- Text, links, and supported SVG remain native rather than page-wide PNG pixels.
+
+### Approved guardrails
+
+1. Strictly PDF-only product changes.
+2. No proprietary-app behavior asserted without public evidence.
+3. No replacement library selected solely by anecdote.
+4. No removal of fallback before objective regression gates.
+5. No web server upload/backend without separate privacy/security approval.
+6. No whole-desktop migration to Electron solely for PDF.
+7. No performance claim without reproducible fixtures and environment metadata.
+
+## Final Status: **APPROVED FOR IMPLEMENTATION**
+
+Approval covers the phased architecture and validation program in this report. It does **not** approve immediate deletion of the legacy exporter, a server-side web export service, or a desktop-shell migration. Production cutover remains conditional on the 50/100/250/500/1000-page performance and regression gates.

--- a/index.html
+++ b/index.html
@@ -811,35 +811,15 @@
 
         <!-- PDF Export Modal -->
         <div id="pdf-export-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="pdf-export-modal-title" aria-hidden="true" style="display:none;">
-          <div class="reset-modal-box reset-modal-box--wide modal-box">
+          <div class="reset-modal-box modal-box">
             <div class="modal-header">
-              <p id="pdf-export-modal-title" class="reset-modal-message">PDF Export Settings</p>
+              <p id="pdf-export-modal-title" class="reset-modal-message">Vector PDF Export</p>
               <button type="button" class="modal-close-btn" id="pdf-export-modal-close-icon" aria-label="Close export dialog">
                 <i class="bi bi-x-lg"></i>
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Select your preferred PDF export engine:</p>
-              <div class="share-mode-cards">
-                <label class="share-mode-card is-selected" id="pdf-card-print" for="pdf-engine-print">
-                  <input type="radio" id="pdf-engine-print" name="pdf-engine" value="print" checked />
-                  <span class="share-card-icon"><i class="bi bi-printer"></i></span>
-                  <span class="share-card-body">
-                    <span class="share-card-title">Browser Print (Recommended)</span>
-                    <span class="share-card-desc">Searchable vector text, hyperlinks, vector SVGs, and browser-native pagination.</span>
-                  </span>
-                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
-                </label>
-                <label class="share-mode-card" id="pdf-card-legacy" for="pdf-engine-legacy">
-                  <input type="radio" id="pdf-engine-legacy" name="pdf-engine" value="legacy" />
-                  <span class="share-card-icon"><i class="bi bi-image"></i></span>
-                  <span class="share-card-body">
-                    <span class="share-card-title">Legacy Raster PDF</span>
-                    <span class="share-card-desc">Slices screenshots of the rendered page. Recommended only for offline/compatibility fallback.</span>
-                  </span>
-                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
-                </label>
-              </div>
+              <p class="share-modal-description">Export your Markdown document to a high-fidelity vector PDF with searchable text, functional links, scalable diagrams, and standard page formatting.</p>
             </div>
             <div class="reset-modal-actions">
               <button class="reset-modal-btn reset-modal-cancel" id="pdf-export-modal-close">Cancel</button>

--- a/index.html
+++ b/index.html
@@ -809,6 +809,45 @@
           </div>
         </div>
 
+        <!-- PDF Export Modal -->
+        <div id="pdf-export-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="pdf-export-modal-title" aria-hidden="true" style="display:none;">
+          <div class="reset-modal-box reset-modal-box--wide modal-box">
+            <div class="modal-header">
+              <p id="pdf-export-modal-title" class="reset-modal-message">PDF Export Settings</p>
+              <button type="button" class="modal-close-btn" id="pdf-export-modal-close-icon" aria-label="Close export dialog">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p class="share-modal-description">Select your preferred PDF export engine:</p>
+              <div class="share-mode-cards">
+                <label class="share-mode-card is-selected" id="pdf-card-print" for="pdf-engine-print">
+                  <input type="radio" id="pdf-engine-print" name="pdf-engine" value="print" checked />
+                  <span class="share-card-icon"><i class="bi bi-printer"></i></span>
+                  <span class="share-card-body">
+                    <span class="share-card-title">Browser Print (Recommended)</span>
+                    <span class="share-card-desc">Searchable vector text, hyperlinks, vector SVGs, and browser-native pagination.</span>
+                  </span>
+                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
+                </label>
+                <label class="share-mode-card" id="pdf-card-legacy" for="pdf-engine-legacy">
+                  <input type="radio" id="pdf-engine-legacy" name="pdf-engine" value="legacy" />
+                  <span class="share-card-icon"><i class="bi bi-image"></i></span>
+                  <span class="share-card-body">
+                    <span class="share-card-title">Legacy Raster PDF</span>
+                    <span class="share-card-desc">Slices screenshots of the rendered page. Recommended only for offline/compatibility fallback.</span>
+                  </span>
+                  <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
+                </label>
+              </div>
+            </div>
+            <div class="reset-modal-actions">
+              <button class="reset-modal-btn reset-modal-cancel" id="pdf-export-modal-close">Cancel</button>
+              <button class="reset-modal-btn reset-modal-confirm" id="pdf-export-modal-confirm">Export</button>
+            </div>
+          </div>
+        </div>
+
         <!-- GitHub Import Modal -->
         <div id="github-import-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="github-import-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box">

--- a/preview-worker.js
+++ b/preview-worker.js
@@ -343,7 +343,13 @@ function configureMarked() {
 
 function ensureLibraries(urls) {
   if (!librariesLoaded) {
-    importScripts(urls.marked, urls.highlight);
+    const scripts = [];
+    if (urls.marked) scripts.push(urls.marked);
+    if (urls.highlight) scripts.push(urls.highlight);
+    if (urls.purify) scripts.push(urls.purify);
+    if (scripts.length > 0) {
+      importScripts(...scripts);
+    }
     librariesLoaded = true;
   }
   configureMarked();
@@ -461,6 +467,34 @@ function renderSegmentedMarkdown(markdown, options) {
 
 self.onmessage = function(event) {
   const data = event.data || {};
+  if (data.type === "render-full") {
+    try {
+      const options = data.options || {};
+      ensureLibraries(options.libraryUrls || {});
+      mermaidIdCounter = 0;
+      const html = marked.parse(data.markdown || "");
+      let sanitized = html;
+      if (typeof DOMPurify !== "undefined") {
+        sanitized = DOMPurify.sanitize(html, {
+          ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
+          ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled', 'data-original-code']
+        });
+      }
+      self.postMessage({
+        type: "render-full-result",
+        requestId: data.requestId,
+        html: sanitized
+      });
+    } catch (error) {
+      self.postMessage({
+        type: "render-full-error",
+        requestId: data.requestId,
+        error: error && error.message ? error.message : "Full worker render failed."
+      });
+    }
+    return;
+  }
+
   if (data.type !== "render") return;
 
   try {

--- a/script.js
+++ b/script.js
@@ -7065,13 +7065,16 @@ document.addEventListener("DOMContentLoaded", function () {
     const graphics = [];
 
     // Query all targeting elements in precise DOM layout flow order
-    container.querySelectorAll('img, svg, pre, table, mjx-container[display="true"]').forEach(el => {
+    container.querySelectorAll('.pdf-export-block').forEach(el => {
+      const child = el.firstElementChild;
       let type = 'img';
-      const tag = el.tagName.toLowerCase();
-      if (tag === 'svg') type = 'svg';
-      else if (tag === 'pre') type = 'pre';
-      else if (tag === 'table') type = 'table';
-      else if (tag === 'mjx-container') type = 'math';
+      if (child) {
+        const tag = child.tagName.toLowerCase();
+        if (tag === 'svg') type = 'svg';
+        else if (tag === 'pre') type = 'pre';
+        else if (tag === 'table') type = 'table';
+        else if (tag === 'mjx-container') type = 'math';
+      }
       
       graphics.push({ element: el, type: type });
     });
@@ -7540,6 +7543,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
         await PdfExportEngine.AssetReadinessGate.awaitReady(tempElement, markdown, state);
         throwIfPdfExportAborted(state.signal);
+
+        // Wrap target elements in block-level wrappers to ensure layout shifts and page breaks render reliably
+        tempElement.querySelectorAll('img, svg, pre, table, mjx-container[display="true"]').forEach(el => {
+          if (el.closest('.pdf-export-block')) return;
+
+          const wrapper = document.createElement('div');
+          wrapper.className = 'pdf-export-block';
+          el.parentNode.insertBefore(wrapper, el);
+          wrapper.appendChild(el);
+        });
 
         const pageHeightPx = tempElement.offsetWidth * (PAGE_CONFIG.contentHeight / PAGE_CONFIG.contentWidth);
         tempElement.querySelectorAll("pre").forEach(pre => {

--- a/script.js
+++ b/script.js
@@ -29,8 +29,6 @@ document.addEventListener("DOMContentLoaded", function () {
   const CDN = {
     mermaid: 'https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js',
     mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js',
-    jspdf: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',
-    html2canvas: 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js',
     pako: 'https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js',
     joypixels: 'https://cdn.jsdelivr.net/npm/emoji-toolkit@9.0.1/lib/js/joypixels.min.js',
     joypixels_css: 'https://cdn.jsdelivr.net/npm/emoji-toolkit@9.0.1/extras/css/joypixels.min.css'
@@ -6832,22 +6830,6 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  // ============================================
-  // Page-Break Detection Functions (Story 1.1)
-  // ============================================
-
-  // Page configuration constants for A4 PDF export
-  const PAGE_CONFIG = {
-    a4Width: 210,           // mm
-    a4Height: 297,          // mm
-    margin: 15,             // mm each side
-    contentWidth: 180,      // 210 - 30 (margins)
-    contentHeight: 267,     // 297 - 30 (margins)
-    windowWidth: 1000,      // html2canvas config
-    scale: 2                // html2canvas scale factor
-  };
-
-  const PDF_EXPORT_DEBUG = false;
   let activePdfExport = null;
 
   class PdfExportCancelledError extends Error {
@@ -6855,10 +6837,6 @@ document.addEventListener("DOMContentLoaded", function () {
       super("PDF generation cancelled.");
       this.name = "PdfExportCancelledError";
     }
-  }
-
-  function logPdfExportDebug(...args) {
-    if (PDF_EXPORT_DEBUG) console.log(...args);
   }
 
   function throwIfPdfExportAborted(signal) {
@@ -7024,383 +7002,6 @@ document.addEventListener("DOMContentLoaded", function () {
     return /(^|[^\\])\$\$|\\\[|\\\(|(^|[^\\])\$[^$\n]+\$/.test(markdown);
   }
 
-  function choosePdfCanvasScale(element) {
-    const pixelArea = element.offsetWidth * element.scrollHeight;
-    if (pixelArea > 14000000) return 1.25;
-    if (pixelArea > 8000000) return 1.5;
-    return PAGE_CONFIG.scale;
-  }
-
-  function readPixelStyle(element, propertyName) {
-    const value = window.getComputedStyle(element).getPropertyValue(propertyName);
-    return parseFloat(value) || 0;
-  }
-
-  function fitExportElementToContent(element) {
-    if (!element) return false;
-
-    const overflow = element.scrollWidth - element.clientWidth;
-    if (overflow <= 1) return false;
-
-    const paddingLeft = readPixelStyle(element, 'padding-left');
-    const paddingRight = readPixelStyle(element, 'padding-right');
-    const borderLeft = readPixelStyle(element, 'border-left-width');
-    const borderRight = readPixelStyle(element, 'border-right-width');
-    const boxSizing = window.getComputedStyle(element).boxSizing;
-
-    const requiredWidth = boxSizing === 'border-box'
-      ? Math.ceil(element.scrollWidth + paddingRight + borderLeft + borderRight)
-      : Math.ceil(element.scrollWidth - paddingLeft + paddingRight);
-
-    element.style.width = `${requiredWidth}px`;
-    return true;
-  }
-
-  /**
-   * Task 1: Identifies all graphic elements that may need page-break handling
-   * @param {HTMLElement} container - The container element to search within
-   * @returns {Array} Array of {element, type} objects
-   */
-  function identifyGraphicElements(container) {
-    const graphics = [];
-
-    // Query all targeting elements in precise DOM layout flow order
-    container.querySelectorAll('.pdf-export-block').forEach(el => {
-      const child = el.firstElementChild;
-      let type = 'img';
-      if (child) {
-        const tag = child.tagName.toLowerCase();
-        if (tag === 'svg') type = 'svg';
-        else if (tag === 'pre') type = 'pre';
-        else if (tag === 'table') type = 'table';
-        else if (tag === 'mjx-container') type = 'math';
-      }
-      
-      graphics.push({ element: el, type: type });
-    });
-
-    return graphics;
-  }
-
-  /**
-   * Task 2: Calculates element positions relative to the container
-   * @param {Array} elements - Array of {element, type} objects
-   * @param {HTMLElement} container - The container element
-   * @returns {Array} Array with position data added
-   */
-  function calculateElementPositions(elements, container) {
-    const containerRect = container.getBoundingClientRect();
-
-    return elements.map(item => {
-      const rect = item.element.getBoundingClientRect();
-      const top = rect.top - containerRect.top;
-      const height = rect.height;
-      const bottom = top + height;
-
-      return {
-        element: item.element,
-        type: item.type,
-        top: top,
-        height: height,
-        bottom: bottom
-      };
-    });
-  }
-
-  /**
-   * Task 3: Calculates page boundary positions
-   * @param {number} totalHeight - Total height of content in pixels
-   * @param {number} elementWidth - Actual width of the rendered element in pixels
-   * @param {Object} pageConfig - Page configuration object
-   * @returns {Array} Array of y-coordinates where pages end
-   */
-  function calculatePageBoundaries(totalHeight, elementWidth, pageConfig) {
-    // Calculate pixel height per page based on the element's actual width
-    // This must match how PDF pagination will split the canvas
-    // The aspect ratio of content area determines page height relative to width
-    const aspectRatio = pageConfig.contentHeight / pageConfig.contentWidth;
-    const pageHeightPx = elementWidth * aspectRatio;
-
-    const boundaries = [];
-    let y = pageHeightPx;
-
-    while (y < totalHeight) {
-      boundaries.push(y);
-      y += pageHeightPx;
-    }
-
-    return { boundaries, pageHeightPx };
-  }
-
-  /**
-   * Task 4: Detects which elements would be split across page boundaries
-   * @param {Array} elements - Array of elements with position data
-   * @param {Array} pageBoundaries - Array of page break y-coordinates
-   * @returns {Array} Array of split elements with additional split info
-   */
-  function detectSplitElements(elements, pageBoundaries) {
-    // Handle edge case: empty elements array
-    if (!elements || elements.length === 0) {
-      return [];
-    }
-
-    // Handle edge case: no page boundaries (single page)
-    if (!pageBoundaries || pageBoundaries.length === 0) {
-      return [];
-    }
-
-    const splitElements = [];
-
-    for (const item of elements) {
-      // Find which page the element starts on
-      let startPage = 0;
-      for (let i = 0; i < pageBoundaries.length; i++) {
-        if (item.top >= pageBoundaries[i]) {
-          startPage = i + 1;
-        } else {
-          break;
-        }
-      }
-
-      // Find which page the element ends on
-      let endPage = 0;
-      for (let i = 0; i < pageBoundaries.length; i++) {
-        if (item.bottom > pageBoundaries[i]) {
-          endPage = i + 1;
-        } else {
-          break;
-        }
-      }
-
-      // Element is split if it spans multiple pages
-      if (endPage > startPage) {
-        // Calculate overflow amount (how much crosses into next page)
-        const boundaryY = pageBoundaries[startPage] || pageBoundaries[0];
-        const overflowAmount = item.bottom - boundaryY;
-
-        splitElements.push({
-          element: item.element,
-          type: item.type,
-          top: item.top,
-          height: item.height,
-          splitPageIndex: startPage,
-          overflowAmount: overflowAmount
-        });
-      }
-    }
-
-    return splitElements;
-  }
-
-  /**
-   * Task 5: Main entry point for analyzing graphics for page breaks
-   * @param {HTMLElement} tempElement - The rendered content container
-   * @returns {Object} Analysis result with totalElements, splitElements, pageCount
-   */
-  function analyzeGraphicsForPageBreaks(tempElement, signal) {
-    try {
-      throwIfPdfExportAborted(signal);
-
-      // Step 1: Identify all graphic elements
-      const graphics = identifyGraphicElements(tempElement);
-      logPdfExportDebug('Step 1 - Graphics found:', graphics.length, graphics.map(g => g.type));
-
-      // Step 2: Calculate positions for each element
-      const elementsWithPositions = calculateElementPositions(graphics, tempElement);
-      logPdfExportDebug('Step 2 - Element positions:', elementsWithPositions.map(e => ({
-        type: e.type,
-        top: Math.round(e.top),
-        height: Math.round(e.height),
-        bottom: Math.round(e.bottom)
-      })));
-
-      throwIfPdfExportAborted(signal);
-
-      // Step 3: Calculate page boundaries using the element's ACTUAL width
-      const totalHeight = tempElement.scrollHeight;
-      const elementWidth = tempElement.offsetWidth;
-      const { boundaries: pageBoundaries, pageHeightPx } = calculatePageBoundaries(
-        totalHeight,
-        elementWidth,
-        PAGE_CONFIG
-      );
-
-      logPdfExportDebug('Step 3 - Page boundaries:', {
-        elementWidth,
-        totalHeight,
-        pageHeightPx: Math.round(pageHeightPx),
-        boundaries: pageBoundaries.map(b => Math.round(b))
-      });
-
-      // Step 4: Detect split elements
-      const splitElements = detectSplitElements(elementsWithPositions, pageBoundaries);
-      logPdfExportDebug('Step 4 - Split elements detected:', splitElements.length);
-
-      // Calculate page count
-      const pageCount = pageBoundaries.length + 1;
-
-      return {
-        totalElements: graphics.length,
-        splitElements: splitElements,
-        pageCount: pageCount,
-        pageBoundaries: pageBoundaries,
-        pageHeightPx: pageHeightPx
-      };
-    } catch (error) {
-      if (error instanceof PdfExportCancelledError) throw error;
-      console.error('Page-break analysis failed:', error);
-      return {
-        totalElements: 0,
-        splitElements: [],
-        pageCount: 1,
-        pageBoundaries: [],
-        pageHeightPx: 0
-      };
-    }
-  }
-
-  // ============================================
-  // End Page-Break Detection Functions
-  // ============================================
-
-  // ============================================
-  // Page-Break Insertion Functions (Story 1.2)
-  // ============================================
-
-  // Threshold for whitespace optimization (30% of page height)
-  const PAGE_BREAK_THRESHOLD = 0.3;
-
-  /**
-   * Task 3: Categorizes split elements by whether they fit on a single page
-   * @param {Array} splitElements - Array of split elements from detection
-   * @param {number} pageHeightPx - Page height in pixels
-   * @returns {Object} { fittingElements, oversizedElements }
-   */
-  function categorizeBySize(splitElements, pageHeightPx) {
-    const fittingElements = [];
-    const oversizedElements = [];
-
-    for (const item of splitElements) {
-      if (item.height <= pageHeightPx) {
-        fittingElements.push(item);
-      } else {
-        oversizedElements.push(item);
-      }
-    }
-
-    return { fittingElements, oversizedElements };
-  }
-
-  /**
-   * Task 1: Inserts page breaks by adjusting margins for fitting elements
-   * @param {Array} fittingElements - Elements that fit on a single page
-   * @param {number} pageHeightPx - Page height in pixels
-   */
-  function insertPageBreaks(fittingElements, pageHeightPx, signal) {
-    for (const item of fittingElements) {
-      throwIfPdfExportAborted(signal);
-
-      // Calculate where the current page ends
-      const currentPageBottom = (item.splitPageIndex + 1) * pageHeightPx;
-
-      // Calculate remaining space on current page
-      const remainingSpace = currentPageBottom - item.top;
-      const remainingRatio = remainingSpace / pageHeightPx;
-
-      logPdfExportDebug('Processing split element:', {
-        type: item.type,
-        top: Math.round(item.top),
-        height: Math.round(item.height),
-        splitPageIndex: item.splitPageIndex,
-        currentPageBottom: Math.round(currentPageBottom),
-        remainingSpace: Math.round(remainingSpace),
-        remainingRatio: remainingRatio.toFixed(2)
-      });
-
-      // Element is pushed to the next page to prevent splitting across page boundaries.
-
-      // Calculate margin needed to push element to next page
-      const marginNeeded = currentPageBottom - item.top + 5; // 5px buffer
-
-      logPdfExportDebug('  -> Applying marginTop:', marginNeeded, 'px');
-
-      // Determine which element to apply margin to
-      // For SVG elements (Mermaid diagrams), apply to parent container for proper layout
-      let targetElement = item.element;
-      if (item.type === 'svg' && item.element.parentElement) {
-        targetElement = item.element.parentElement;
-        logPdfExportDebug('  -> Using parent element:', targetElement.tagName, targetElement.className);
-      }
-
-      // Apply margin to push element to next page
-      const currentMargin = parseFloat(targetElement.style.marginTop) || 0;
-      targetElement.style.marginTop = `${currentMargin + marginNeeded}px`;
-
-      logPdfExportDebug('  -> Element after margin:', targetElement.tagName, 'marginTop =', targetElement.style.marginTop);
-    }
-  }
-
-  /**
-   * Task 2: Applies page breaks with cascading adjustment handling
-   * @param {HTMLElement} tempElement - The rendered content container
-   * @param {Object} pageConfig - Page configuration object (unused, kept for API compatibility)
-   * @param {number} maxIterations - Maximum iterations to prevent infinite loops
-   * @returns {Object} Final analysis result
-   */
-  function applyPageBreaksWithCascade(tempElement, pageConfig, maxIterations = 10, signal) {
-    let iteration = 0;
-    let analysis;
-    let previousSplitCount = -1;
-
-    do {
-      throwIfPdfExportAborted(signal);
-
-      // Re-analyze after each adjustment
-      analysis = analyzeGraphicsForPageBreaks(tempElement, signal);
-
-      // Use pageHeightPx from analysis (calculated from actual element width)
-      const pageHeightPx = analysis.pageHeightPx;
-
-      // Categorize elements by size
-      const { fittingElements, oversizedElements } = categorizeBySize(
-        analysis.splitElements,
-        pageHeightPx
-      );
-
-      // Store oversized elements for Story 1.3
-      analysis.oversizedElements = oversizedElements;
-
-      // If no fitting elements need adjustment, we're done
-      if (fittingElements.length === 0) {
-        break;
-      }
-
-      // Check if we're making progress (prevent infinite loops)
-      if (fittingElements.length === previousSplitCount) {
-        console.warn('Page-break adjustment not making progress, stopping');
-        break;
-      }
-      previousSplitCount = fittingElements.length;
-
-      // Apply page breaks to fitting elements
-      insertPageBreaks(fittingElements, pageHeightPx, signal);
-      iteration++;
-
-    } while (iteration < maxIterations);
-
-    if (iteration >= maxIterations) {
-      console.warn('Page-break stabilization reached max iterations:', maxIterations);
-    }
-
-    logPdfExportDebug('Page-break cascade complete:', {
-      iterations: iteration,
-      finalSplitCount: analysis.splitElements.length,
-      oversizedCount: analysis.oversizedElements ? analysis.oversizedElements.length : 0
-    });
-
-    return analysis;
-  }
-
   // ============================================
   // End Page-Break Insertion Functions
   // ============================================
@@ -7554,7 +7155,8 @@ document.addEventListener("DOMContentLoaded", function () {
           wrapper.appendChild(el);
         });
 
-        const pageHeightPx = tempElement.offsetWidth * (PAGE_CONFIG.contentHeight / PAGE_CONFIG.contentWidth);
+        // A4 page content aspect ratio (contentHeight 267mm / contentWidth 180mm)
+        const pageHeightPx = tempElement.offsetWidth * (267 / 180);
         tempElement.querySelectorAll("pre").forEach(pre => {
           if (pre.offsetHeight > pageHeightPx) {
             pre.classList.add("oversized");
@@ -7846,95 +7448,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
         return outputPath;
       }
-    },
-
-    LegacyRasterBackend: {
-      print: async function(tempElement, state) {
-        throwIfPdfExportAborted(state.signal);
-
-        if (typeof jspdf === 'undefined' || typeof html2canvas === 'undefined') {
-          updatePdfProgress(state, 62, "Loading PDF libraries");
-          await runPdfAbortable(state, Promise.all([loadScript(CDN.jspdf), loadScript(CDN.html2canvas)]));
-          throwIfPdfExportAborted(state.signal);
-        }
-
-        updatePdfProgress(state, 65, "Calculating legacy page breaks");
-        // Pass 1: Scale oversized elements first to stabilize their heights
-        const initialAnalysis = analyzeGraphicsForPageBreaks(tempElement, state.signal);
-        throwIfPdfExportAborted(state.signal);
-
-        const pageHeightPx = initialAnalysis.pageHeightPx;
-        if (initialAnalysis.splitElements && pageHeightPx) {
-          const { oversizedElements } = categorizeBySize(initialAnalysis.splitElements, pageHeightPx);
-          if (oversizedElements.length > 0) {
-            handleOversizedElements(oversizedElements, pageHeightPx, state.signal);
-          }
-        }
-
-        // Pass 2: Apply page breaks with cascade on the final scaled layout
-        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
-        throwIfPdfExportAborted(state.signal);
-        await waitForPdfFrame(state);
-
-        const pdfOptions = {
-          orientation: 'portrait',
-          unit: 'mm',
-          format: 'a4',
-          compress: true,
-          hotfixes: ["px_scaling"]
-        };
-
-        const pdf = new jspdf.jsPDF(pdfOptions);
-        const pageWidth = pdf.internal.pageSize.getWidth();
-        const pageHeight = pdf.internal.pageSize.getHeight();
-        const margin = 15;
-        const contentWidth = pageWidth - (margin * 2);
-        const captureScale = choosePdfCanvasScale(tempElement);
-
-        updatePdfProgress(state, 75, "Capturing document");
-        const canvas = await runPdfAbortable(state, html2canvas(tempElement, {
-          scale: captureScale,
-          useCORS: true,
-          allowTaint: false,
-          logging: false,
-          windowWidth: Math.max(PAGE_CONFIG.windowWidth, Math.ceil(tempElement.getBoundingClientRect().width)),
-          windowHeight: tempElement.scrollHeight
-        }));
-        await waitForPdfFrame(state);
-        throwIfPdfExportAborted(state.signal);
-
-        const scaleFactor = canvas.width / contentWidth;
-        const imgHeight = canvas.height / scaleFactor;
-        const pagesCount = Math.ceil(imgHeight / (pageHeight - margin * 2));
-
-        updatePdfProgress(state, 80, "Rendering pages");
-        for (let page = 0; page < pagesCount; page++) {
-          throwIfPdfExportAborted(state.signal);
-          const pageProgress = 80 + ((page + 1) / pagesCount) * 18;
-          updatePdfProgress(state, pageProgress, `Rendering page ${page + 1} of ${pagesCount}`);
-
-          if (page > 0) pdf.addPage();
-
-          const sourceY = page * (pageHeight - margin * 2) * scaleFactor;
-          const sourceHeight = Math.min(canvas.height - sourceY, (pageHeight - margin * 2) * scaleFactor);
-          const destHeight = sourceHeight / scaleFactor;
-
-          const pageCanvas = document.createElement('canvas');
-          pageCanvas.width = canvas.width;
-          pageCanvas.height = sourceHeight;
-
-          const ctx = pageCanvas.getContext('2d');
-          ctx.drawImage(canvas, 0, sourceY, canvas.width, sourceHeight, 0, 0, canvas.width, sourceHeight);
-
-          const imgData = pageCanvas.toDataURL('image/png');
-          pdf.addImage(imgData, 'PNG', margin, margin, contentWidth, destHeight);
-          await waitForPdfFrame(state);
-        }
-
-        throwIfPdfExportAborted(state.signal);
-        updatePdfProgress(state, 98, "Saving document");
-        pdf.save("document.pdf");
-      }
     }
   };
 
@@ -7943,29 +7456,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const pdfExportConfirmBtn = document.getElementById("pdf-export-modal-confirm");
   const pdfExportCancelBtn = document.getElementById("pdf-export-modal-close");
   const pdfExportCloseIcon = document.getElementById("pdf-export-modal-close-icon");
-  const pdfCardPrint = document.getElementById("pdf-card-print");
-  const pdfCardLegacy = document.getElementById("pdf-card-legacy");
-  const pdfEnginePrintInput = document.getElementById("pdf-engine-print");
-  const pdfEngineLegacyInput = document.getElementById("pdf-engine-legacy");
-
-  function syncPdfCardStyles() {
-    if (pdfEnginePrintInput.checked) {
-      pdfCardPrint.classList.add("is-selected");
-      pdfCardLegacy.classList.remove("is-selected");
-    } else {
-      pdfCardLegacy.classList.add("is-selected");
-      pdfCardPrint.classList.remove("is-selected");
-    }
-  }
-
-  if (pdfEnginePrintInput && pdfEngineLegacyInput) {
-    pdfEnginePrintInput.addEventListener("change", syncPdfCardStyles);
-    pdfEngineLegacyInput.addEventListener("change", syncPdfCardStyles);
-  }
 
   function openPdfExportModal() {
-    pdfEnginePrintInput.checked = true;
-    syncPdfCardStyles();
     pdfExportModal.style.display = "";
     requestAnimationFrame(() => {
       pdfExportModal.classList.add("is-visible");
@@ -8004,20 +7496,15 @@ document.addEventListener("DOMContentLoaded", function () {
       progressState.overlay.querySelector(".pdf-progress-cancel")?.focus();
 
       try {
-        const isLegacy = pdfEngineLegacyInput.checked;
         const markdown = markdownEditor.value;
 
-        const { fullHtml, tempElement } = await PdfExportEngine.ExportDocumentBuilder.build(markdown, progressState);
+        const { fullHtml } = await PdfExportEngine.ExportDocumentBuilder.build(markdown, progressState);
 
-        if (isLegacy) {
-          await PdfExportEngine.LegacyRasterBackend.print(tempElement, progressState);
+        updatePdfProgress(progressState, 75, "Generating PDF");
+        if (typeof Neutralino !== 'undefined') {
+          await PdfExportEngine.DesktopChromiumSidecarBackend.print(fullHtml, progressState);
         } else {
-          updatePdfProgress(progressState, 75, "Generating PDF");
-          if (typeof Neutralino !== 'undefined') {
-            await PdfExportEngine.DesktopChromiumSidecarBackend.print(fullHtml, progressState);
-          } else {
-            await PdfExportEngine.WebPrintBackend.print(fullHtml, progressState);
-          }
+          await PdfExportEngine.WebPrintBackend.print(fullHtml, progressState);
         }
 
         updatePdfProgress(progressState, 100, "Complete");

--- a/script.js
+++ b/script.js
@@ -551,6 +551,11 @@ document.addEventListener("DOMContentLoaded", function () {
         if (data.type === "render-result") {
           previewWorkerFailureCount = 0;
           pending.resolve(data.result);
+        } else if (data.type === "render-full-result") {
+          previewWorkerFailureCount = 0;
+          pending.resolve(data.html);
+        } else if (data.type === "render-full-error") {
+          pending.reject(new Error(data.error || "Preview worker render-full failed."));
         } else {
           recordPreviewWorkerRenderFailure();
           pending.reject(new Error(data.error || "Preview worker render failed."));
@@ -592,6 +597,54 @@ document.addEventListener("DOMContentLoaded", function () {
         },
       });
     });
+  }
+
+  function requestFullWorkerRender(rawVal) {
+    const worker = getPreviewWorker();
+    if (!worker) return Promise.reject(new Error("Worker unavailable"));
+
+    const requestId = ++previewWorkerRequestCounter;
+    return new Promise(function(resolve, reject) {
+      const timeoutId = setTimeout(function() {
+        previewWorkerRequests.delete(requestId);
+        reject(new Error("Full render worker timeout."));
+      }, 30000); // 30s timeout for full document render
+
+      previewWorkerRequests.set(requestId, { resolve, reject, timeoutId });
+
+      try {
+        worker.postMessage({
+          type: "render-full",
+          requestId: requestId,
+          markdown: rawVal,
+          options: {
+            libraryUrls: getPreviewWorkerLibraryUrls()
+          },
+        });
+      } catch (e) {
+        previewWorkerRequests.delete(requestId);
+        clearTimeout(timeoutId);
+        reject(e);
+      }
+    });
+  }
+
+  async function parseMarkdownFull(markdown) {
+    try {
+      const html = await requestFullWorkerRender(markdown);
+      return html;
+    } catch (e) {
+      console.warn("Full worker render failed, falling back to main thread:", e);
+      const { frontmatter, body } = parseFrontmatter(markdown);
+      const tableHtml = frontmatter ? renderFrontmatterTable(frontmatter) : '';
+      const referenceData = extractReferenceDefinitions(body);
+      const parsedHtml = tableHtml + marked.parse(referenceData.cleanedMarkdown);
+      const sanitizedHtml = DOMPurify.sanitize(parsedHtml, {
+        ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
+        ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled', 'data-original-code']
+      });
+      return sanitizedHtml;
+    }
   }
 
   function parseInlineWithoutFootnotes(text) {
@@ -7458,195 +7511,411 @@ document.addEventListener("DOMContentLoaded", function () {
   // End Oversized Graphics Scaling Functions
   // ============================================
 
-  exportPdf.addEventListener("click", async function (event) {
-    event.preventDefault();
-    if (activePdfExport) return;
+  // ============================================
+  // New Modular PDF Export Engine
+  // ============================================
+  const PdfExportEngine = {
+    ExportDocumentBuilder: {
+      build: async function(markdown, state) {
+        updatePdfProgress(state, 15, "Parsing markdown");
+        await waitForPdfFrame(state);
+        
+        const sanitizedHtml = await parseMarkdownFull(markdown);
+        throwIfPdfExportAborted(state.signal);
 
-    const progressState = createPdfProgressState();
-    activePdfExport = progressState;
-    setPdfExportTriggersBusy(progressState, true);
-    document.body.appendChild(progressState.overlay);
-    updatePdfProgress(progressState, 3, "Starting");
-    progressState.overlay.querySelector(".pdf-progress-cancel")?.focus();
+        updatePdfProgress(state, 24, "Preparing document");
+        await waitForPdfFrame(state);
+        
+        const tempElement = document.createElement("div");
+        state.tempElement = tempElement;
+        tempElement.className = "markdown-body pdf-export";
+        tempElement.innerHTML = sanitizedHtml;
+        enhanceGitHubAlerts(tempElement);
+        tempElement.style.padding = "20px";
+        tempElement.style.width = "210mm";
+        tempElement.style.margin = "0 auto";
+        tempElement.style.fontSize = "14px";
+        tempElement.style.position = "fixed";
+        tempElement.style.left = "-9999px";
+        tempElement.style.top = "0";
 
-    try {
-      // PERF-002: Lazy-load PDF libraries on first export
-      if (typeof jspdf === 'undefined' || typeof html2canvas === 'undefined') {
-        updatePdfProgress(progressState, 8, "Loading PDF libraries");
-        await runPdfAbortable(progressState, Promise.all([loadScript(CDN.jspdf), loadScript(CDN.html2canvas)]));
-        throwIfPdfExportAborted(progressState.signal);
-      }
+        const currentTheme = document.documentElement.getAttribute("data-theme");
+        tempElement.style.backgroundColor = currentTheme === "dark" ? "#0d1117" : "#ffffff";
+        tempElement.style.color = currentTheme === "dark" ? "#c9d1d9" : "#24292e";
 
-      updatePdfProgress(progressState, 15, "Parsing markdown");
-      await waitForPdfFrame(progressState);
-      const markdown = markdownEditor.value;
-      const html = marked.parse(markdown);
-      const sanitizedHtml = DOMPurify.sanitize(html, {
-        ADD_TAGS: ['mjx-container', 'svg', 'path', 'g', 'marker', 'defs', 'pattern', 'clipPath', 'input'],
-        ADD_ATTR: ['id', 'class', 'style', 'align', 'viewBox', 'd', 'fill', 'stroke', 'transform', 'marker-end', 'marker-start', 'type', 'checked', 'disabled', 'data-original-code']
-      });
-      throwIfPdfExportAborted(progressState.signal);
+        document.body.appendChild(tempElement);
+        await waitForPdfFrame(state);
 
-      updatePdfProgress(progressState, 24, "Preparing document");
-      await waitForPdfFrame(progressState);
-      const tempElement = document.createElement("div");
-      progressState.tempElement = tempElement;
-      tempElement.className = "markdown-body pdf-export";
-      tempElement.innerHTML = sanitizedHtml;
-      enhanceGitHubAlerts(tempElement);
-      tempElement.style.padding = "20px";
-      tempElement.style.width = "210mm";
-      tempElement.style.margin = "0 auto";
-      tempElement.style.fontSize = "14px";
-      tempElement.style.position = "fixed";
-      tempElement.style.left = "-9999px";
-      tempElement.style.top = "0";
+        await PdfExportEngine.AssetReadinessGate.awaitReady(tempElement, markdown, state);
+        throwIfPdfExportAborted(state.signal);
 
-      const currentTheme = document.documentElement.getAttribute("data-theme");
-      tempElement.style.backgroundColor = currentTheme === "dark" ? "#0d1117" : "#ffffff";
-      tempElement.style.color = currentTheme === "dark" ? "#c9d1d9" : "#24292e";
-
-      document.body.appendChild(tempElement);
-      await waitForPdfFrame(progressState);
-
-      const mermaidNodes = tempElement.querySelectorAll('.mermaid');
-      if (mermaidNodes.length > 0) {
-        updatePdfProgress(progressState, 34, "Rendering diagrams");
-        try {
-          if (typeof mermaid === 'undefined') {
-            await runPdfAbortable(progressState, loadScript(CDN.mermaid));
+        const pageHeightPx = tempElement.offsetWidth * (PAGE_CONFIG.contentHeight / PAGE_CONFIG.contentWidth);
+        tempElement.querySelectorAll("pre").forEach(pre => {
+          if (pre.offsetHeight > pageHeightPx) {
+            pre.classList.add("oversized");
           }
-          throwIfPdfExportAborted(progressState.signal);
-          initMermaid(true);
-          await runPdfAbortable(progressState, mermaid.init(undefined, mermaidNodes));
-          tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
-            container.classList.remove('is-loading');
-          });
-        } catch (mermaidError) {
-          if (mermaidError instanceof PdfExportCancelledError) throw mermaidError;
-          console.warn("Mermaid rendering issue:", mermaidError);
-          tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
-            container.classList.remove('is-loading');
-          });
-        }
-        throwIfPdfExportAborted(progressState.signal);
-        await waitForPdfFrame(progressState);
-      }
-
-      if (window.MathJax && markdownLikelyContainsMath(markdown)) {
-        updatePdfProgress(progressState, 44, "Rendering math");
-        try {
-          await runPdfAbortable(progressState, MathJax.typesetPromise([tempElement]));
-        } catch (mathJaxError) {
-          if (mathJaxError instanceof PdfExportCancelledError) throw mathJaxError;
-          console.warn("MathJax rendering issue:", mathJaxError);
-        }
-        throwIfPdfExportAborted(progressState.signal);
-
-        // Hide MathJax assistive elements that cause duplicate text in PDF
-        // These are screen reader elements that html2canvas captures as visible
-        // Use multiple CSS properties to ensure html2canvas doesn't render them
-        const assistiveElements = tempElement.querySelectorAll('mjx-assistive-mml');
-        assistiveElements.forEach(el => {
-          el.style.display = 'none';
-          el.style.visibility = 'hidden';
-          el.style.position = 'absolute';
-          el.style.width = '0';
-          el.style.height = '0';
-          el.style.overflow = 'hidden';
-          el.remove(); // Remove entirely from DOM
         });
 
-        // Also hide any MathJax script elements that might contain source
-        const mathScripts = tempElement.querySelectorAll('script[type*="math"], script[type*="tex"]');
-        mathScripts.forEach(el => el.remove());
+        const parentStyles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
+          .map(el => el.outerHTML)
+          .join("\n");
+
+        const fullHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Export Document</title>
+  ${parentStyles}
+</head>
+<body class="${currentTheme === 'dark' ? 'dark-theme' : 'light-theme'}" data-theme="${currentTheme}">
+  <div class="markdown-body pdf-export" style="padding: 20px; width: 100%; box-shadow: none;">
+    ${tempElement.innerHTML}
+  </div>
+</body>
+</html>`;
+
+        return { fullHtml, tempElement };
       }
+    },
 
-      await waitForPdfFrame(progressState);
-      fitExportElementToContent(tempElement);
-      await waitForPdfFrame(progressState);
+    AssetReadinessGate: {
+      awaitReady: async function(tempElement, markdown, state) {
+        if (window.MathJax && markdownLikelyContainsMath(markdown)) {
+          updatePdfProgress(state, 30, "Rendering math");
+          try {
+            await runPdfAbortable(state, MathJax.typesetPromise([tempElement]));
+          } catch (err) {
+            console.warn("MathJax rendering issue:", err);
+          }
+          throwIfPdfExportAborted(state.signal);
+          
+          tempElement.querySelectorAll('mjx-assistive-mml').forEach(el => el.remove());
+          tempElement.querySelectorAll('script[type*="math"], script[type*="tex"]').forEach(el => el.remove());
+        }
 
-      // Analyze and apply page-breaks for graphics (Story 1.1 + 1.2)
-      updatePdfProgress(progressState, 55, "Optimizing page breaks");
-      const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, progressState.signal);
-      throwIfPdfExportAborted(progressState.signal);
+        const mermaidNodes = tempElement.querySelectorAll('.mermaid');
+        if (mermaidNodes.length > 0) {
+          updatePdfProgress(state, 40, "Rendering diagrams");
+          try {
+            if (typeof mermaid === 'undefined') {
+              await runPdfAbortable(state, loadScript(CDN.mermaid));
+            }
+            throwIfPdfExportAborted(state.signal);
+            initMermaid(true);
+            await runPdfAbortable(state, mermaid.init(undefined, mermaidNodes));
+            tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
+              container.classList.remove('is-loading');
+            });
+          } catch (err) {
+            console.warn("Mermaid rendering issue:", err);
+            tempElement.querySelectorAll('.mermaid-container.is-loading').forEach(container => {
+              container.classList.remove('is-loading');
+            });
+          }
+          throwIfPdfExportAborted(state.signal);
+        }
 
-      // Scale oversized graphics that can't fit on a single page (Story 1.3)
-      if (pageBreakAnalysis.oversizedElements && pageBreakAnalysis.pageHeightPx) {
-        handleOversizedElements(pageBreakAnalysis.oversizedElements, pageBreakAnalysis.pageHeightPx, progressState.signal);
+        const images = Array.from(tempElement.querySelectorAll("img"));
+        if (images.length > 0) {
+          updatePdfProgress(state, 50, "Loading images");
+          await Promise.all(images.map(img => {
+            if (img.complete) return Promise.resolve();
+            return new Promise(resolve => {
+              img.addEventListener("load", resolve, { once: true });
+              img.addEventListener("error", resolve, { once: true });
+            });
+          }));
+          await Promise.all(images.map(img => {
+            if (typeof img.decode === "function") {
+              return img.decode().catch(() => {});
+            }
+            return Promise.resolve();
+          }));
+          throwIfPdfExportAborted(state.signal);
+        }
+
+        if (document.fonts && typeof document.fonts.ready === "object") {
+          updatePdfProgress(state, 55, "Loading fonts");
+          await document.fonts.ready;
+          throwIfPdfExportAborted(state.signal);
+        }
+
+        updatePdfProgress(state, 60, "Stabilizing layout");
+        await waitForPdfFrame(state);
+        await waitForPdfFrame(state);
       }
-      await waitForPdfFrame(progressState);
+    },
 
-      const pdfOptions = {
-        orientation: 'portrait',
-        unit: 'mm',
-        format: 'a4',
-        compress: true,
-        hotfixes: ["px_scaling"]
-      };
+    WebPrintBackend: {
+      print: function(fullHtml, state) {
+        return new Promise((resolve, reject) => {
+          try {
+            throwIfPdfExportAborted(state.signal);
+            
+            const iframe = document.createElement("iframe");
+            iframe.style.position = "fixed";
+            iframe.style.left = "-9999px";
+            iframe.style.top = "0";
+            iframe.style.width = "100%";
+            iframe.style.height = "100%";
+            document.body.appendChild(iframe);
+            
+            const doc = iframe.contentDocument || iframe.contentWindow.document;
+            doc.open();
+            doc.write(fullHtml);
+            doc.close();
 
-      const pdf = new jspdf.jsPDF(pdfOptions);
-      const pageWidth = pdf.internal.pageSize.getWidth();
-      const pageHeight = pdf.internal.pageSize.getHeight();
-      const margin = 15;
-      const contentWidth = pageWidth - (margin * 2);
-      const captureScale = choosePdfCanvasScale(tempElement);
+            const cleanup = () => {
+              if (iframe.parentNode) {
+                iframe.parentNode.removeChild(iframe);
+              }
+            };
 
-      updatePdfProgress(progressState, 65, "Capturing document");
-      const canvas = await runPdfAbortable(progressState, html2canvas(tempElement, {
-        scale: captureScale,
-        useCORS: true,
-        allowTaint: false,
-        logging: false,
-        windowWidth: Math.max(PAGE_CONFIG.windowWidth, Math.ceil(tempElement.getBoundingClientRect().width)),
-        windowHeight: tempElement.scrollHeight
-      }));
-      await waitForPdfFrame(progressState);
-      throwIfPdfExportAborted(progressState.signal);
-
-      const scaleFactor = canvas.width / contentWidth;
-      const imgHeight = canvas.height / scaleFactor;
-      const pagesCount = Math.ceil(imgHeight / (pageHeight - margin * 2));
-
-      updatePdfProgress(progressState, 76, "Rendering pages");
-      for (let page = 0; page < pagesCount; page++) {
-        throwIfPdfExportAborted(progressState.signal);
-        const pageProgress = 76 + ((page + 1) / pagesCount) * 18;
-        updatePdfProgress(progressState, pageProgress, `Rendering page ${page + 1} of ${pagesCount}`);
-
-        if (page > 0) pdf.addPage();
-
-        const sourceY = page * (pageHeight - margin * 2) * scaleFactor;
-        const sourceHeight = Math.min(canvas.height - sourceY, (pageHeight - margin * 2) * scaleFactor);
-        const destHeight = sourceHeight / scaleFactor;
-
-        const pageCanvas = document.createElement('canvas');
-        pageCanvas.width = canvas.width;
-        pageCanvas.height = sourceHeight;
-
-        const ctx = pageCanvas.getContext('2d');
-        ctx.drawImage(canvas, 0, sourceY, canvas.width, sourceHeight, 0, 0, canvas.width, sourceHeight);
-
-        const imgData = pageCanvas.toDataURL('image/png');
-        pdf.addImage(imgData, 'PNG', margin, margin, contentWidth, destHeight);
-        await waitForPdfFrame(progressState);
+            iframe.contentWindow.focus();
+            
+            iframe.contentWindow.addEventListener("afterprint", () => {
+              cleanup();
+              resolve();
+            }, { once: true });
+            
+            iframe.contentWindow.print();
+            
+            setTimeout(() => {
+              cleanup();
+              resolve();
+            }, 5000);
+          } catch (err) {
+            reject(err);
+          }
+        });
       }
+    },
 
-      throwIfPdfExportAborted(progressState.signal);
-      updatePdfProgress(progressState, 98, "Preparing download");
-      pdf.save("document.pdf");
-      updatePdfProgress(progressState, 100, "Complete");
+    DesktopChromiumSidecarBackend: {
+      print: async function(fullHtml, state) {
+        throwIfPdfExportAborted(state.signal);
 
-    } catch (error) {
-      if (error instanceof PdfExportCancelledError || progressState.signal.aborted) {
-        console.info("PDF export cancelled");
-      } else {
-        console.error("PDF export failed:", error);
-        alert("PDF export failed: " + error.message);
+        const outputPath = await Neutralino.os.showSaveDialog("Save PDF Document", {
+          filters: [{ name: "PDF files", extensions: ["pdf"] }]
+        });
+
+        if (!outputPath) {
+          throw new Error("Export cancelled by user.");
+        }
+
+        throwIfPdfExportAborted(state.signal);
+
+        let port;
+        try {
+          port = await Neutralino.filesystem.readFile(".pdf_exporter_port");
+          port = port.trim();
+        } catch (err) {
+          throw new Error("Local PDF exporter extension is not running. Please make sure the desktop application is running properly.");
+        }
+
+        throwIfPdfExportAborted(state.signal);
+
+        const response = await fetch(`http://127.0.0.1:${port}/export`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            html: fullHtml,
+            outputPath: outputPath
+          }),
+          signal: state.signal
+        });
+
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({}));
+          throw new Error(errData.error || `HTTP error ${response.status}`);
+        }
+
+        return outputPath;
       }
-    } finally {
-      cleanupPdfExport(progressState);
+    },
+
+    LegacyRasterBackend: {
+      print: async function(tempElement, state) {
+        throwIfPdfExportAborted(state.signal);
+
+        if (typeof jspdf === 'undefined' || typeof html2canvas === 'undefined') {
+          updatePdfProgress(state, 62, "Loading PDF libraries");
+          await runPdfAbortable(state, Promise.all([loadScript(CDN.jspdf), loadScript(CDN.html2canvas)]));
+          throwIfPdfExportAborted(state.signal);
+        }
+
+        updatePdfProgress(state, 65, "Calculating legacy page breaks");
+        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
+        throwIfPdfExportAborted(state.signal);
+
+        if (pageBreakAnalysis.oversizedElements && pageBreakAnalysis.pageHeightPx) {
+          handleOversizedElements(pageBreakAnalysis.oversizedElements, pageBreakAnalysis.pageHeightPx, state.signal);
+        }
+        await waitForPdfFrame(state);
+
+        const pdfOptions = {
+          orientation: 'portrait',
+          unit: 'mm',
+          format: 'a4',
+          compress: true,
+          hotfixes: ["px_scaling"]
+        };
+
+        const pdf = new jspdf.jsPDF(pdfOptions);
+        const pageWidth = pdf.internal.pageSize.getWidth();
+        const pageHeight = pdf.internal.pageSize.getHeight();
+        const margin = 15;
+        const contentWidth = pageWidth - (margin * 2);
+        const captureScale = choosePdfCanvasScale(tempElement);
+
+        updatePdfProgress(state, 75, "Capturing document");
+        const canvas = await runPdfAbortable(state, html2canvas(tempElement, {
+          scale: captureScale,
+          useCORS: true,
+          allowTaint: false,
+          logging: false,
+          windowWidth: Math.max(PAGE_CONFIG.windowWidth, Math.ceil(tempElement.getBoundingClientRect().width)),
+          windowHeight: tempElement.scrollHeight
+        }));
+        await waitForPdfFrame(state);
+        throwIfPdfExportAborted(state.signal);
+
+        const scaleFactor = canvas.width / contentWidth;
+        const imgHeight = canvas.height / scaleFactor;
+        const pagesCount = Math.ceil(imgHeight / (pageHeight - margin * 2));
+
+        updatePdfProgress(state, 80, "Rendering pages");
+        for (let page = 0; page < pagesCount; page++) {
+          throwIfPdfExportAborted(state.signal);
+          const pageProgress = 80 + ((page + 1) / pagesCount) * 18;
+          updatePdfProgress(state, pageProgress, `Rendering page ${page + 1} of ${pagesCount}`);
+
+          if (page > 0) pdf.addPage();
+
+          const sourceY = page * (pageHeight - margin * 2) * scaleFactor;
+          const sourceHeight = Math.min(canvas.height - sourceY, (pageHeight - margin * 2) * scaleFactor);
+          const destHeight = sourceHeight / scaleFactor;
+
+          const pageCanvas = document.createElement('canvas');
+          pageCanvas.width = canvas.width;
+          pageCanvas.height = sourceHeight;
+
+          const ctx = pageCanvas.getContext('2d');
+          ctx.drawImage(canvas, 0, sourceY, canvas.width, sourceHeight, 0, 0, canvas.width, sourceHeight);
+
+          const imgData = pageCanvas.toDataURL('image/png');
+          pdf.addImage(imgData, 'PNG', margin, margin, contentWidth, destHeight);
+          await waitForPdfFrame(state);
+        }
+
+        throwIfPdfExportAborted(state.signal);
+        updatePdfProgress(state, 98, "Saving document");
+        pdf.save("document.pdf");
+      }
     }
+  };
+
+  // PDF Export Modal Elements
+  const pdfExportModal = document.getElementById("pdf-export-modal");
+  const pdfExportConfirmBtn = document.getElementById("pdf-export-modal-confirm");
+  const pdfExportCancelBtn = document.getElementById("pdf-export-modal-close");
+  const pdfExportCloseIcon = document.getElementById("pdf-export-modal-close-icon");
+  const pdfCardPrint = document.getElementById("pdf-card-print");
+  const pdfCardLegacy = document.getElementById("pdf-card-legacy");
+  const pdfEnginePrintInput = document.getElementById("pdf-engine-print");
+  const pdfEngineLegacyInput = document.getElementById("pdf-engine-legacy");
+
+  function syncPdfCardStyles() {
+    if (pdfEnginePrintInput.checked) {
+      pdfCardPrint.classList.add("is-selected");
+      pdfCardLegacy.classList.remove("is-selected");
+    } else {
+      pdfCardLegacy.classList.add("is-selected");
+      pdfCardPrint.classList.remove("is-selected");
+    }
+  }
+
+  if (pdfEnginePrintInput && pdfEngineLegacyInput) {
+    pdfEnginePrintInput.addEventListener("change", syncPdfCardStyles);
+    pdfEngineLegacyInput.addEventListener("change", syncPdfCardStyles);
+  }
+
+  function openPdfExportModal() {
+    pdfEnginePrintInput.checked = true;
+    syncPdfCardStyles();
+    pdfExportModal.style.display = "";
+    requestAnimationFrame(() => {
+      pdfExportModal.classList.add("is-visible");
+      pdfExportModal.setAttribute("aria-hidden", "false");
+    });
+  }
+
+  function closePdfExportModal() {
+    pdfExportModal.classList.remove("is-visible");
+    pdfExportModal.setAttribute("aria-hidden", "true");
+    pdfExportModal.addEventListener("transitionend", function handler() {
+      pdfExportModal.style.display = "none";
+      pdfExportModal.removeEventListener("transitionend", handler);
+    });
+  }
+
+  if (pdfExportCancelBtn) pdfExportCancelBtn.addEventListener("click", closePdfExportModal);
+  if (pdfExportCloseIcon) pdfExportCloseIcon.addEventListener("click", closePdfExportModal);
+  if (pdfExportModal) {
+    pdfExportModal.addEventListener("click", function (e) {
+      if (e.target === pdfExportModal) closePdfExportModal();
+    });
+  }
+
+  if (pdfExportConfirmBtn) {
+    pdfExportConfirmBtn.addEventListener("click", async function() {
+      closePdfExportModal();
+      
+      if (activePdfExport) return;
+
+      const progressState = createPdfProgressState();
+      activePdfExport = progressState;
+      setPdfExportTriggersBusy(progressState, true);
+      document.body.appendChild(progressState.overlay);
+      updatePdfProgress(progressState, 3, "Starting");
+      progressState.overlay.querySelector(".pdf-progress-cancel")?.focus();
+
+      try {
+        const isLegacy = pdfEngineLegacyInput.checked;
+        const markdown = markdownEditor.value;
+
+        const { fullHtml, tempElement } = await PdfExportEngine.ExportDocumentBuilder.build(markdown, progressState);
+
+        if (isLegacy) {
+          await PdfExportEngine.LegacyRasterBackend.print(tempElement, progressState);
+        } else {
+          updatePdfProgress(progressState, 75, "Generating PDF");
+          if (typeof Neutralino !== 'undefined') {
+            await PdfExportEngine.DesktopChromiumSidecarBackend.print(fullHtml, progressState);
+          } else {
+            await PdfExportEngine.WebPrintBackend.print(fullHtml, progressState);
+          }
+        }
+
+        updatePdfProgress(progressState, 100, "Complete");
+      } catch (error) {
+        if (error instanceof PdfExportCancelledError || progressState.signal.aborted) {
+          console.info("PDF export cancelled");
+        } else {
+          console.error("PDF export failed:", error);
+          alert("PDF export failed: " + error.message);
+        }
+      } finally {
+        cleanupPdfExport(progressState);
+      }
+    });
+  }
+
+  exportPdf.addEventListener("click", async function (event) {
+    event.preventDefault();
+    openPdfExportModal();
   });
 
   copyMarkdownButton.addEventListener("click", function () {

--- a/script.js
+++ b/script.js
@@ -7549,17 +7549,111 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         let inlinedStyles = "";
+        const inlinedHrefs = new Set();
+        const inlinedStyleChunks = [];
+        let totalRulesProcessed = 0;
+        let lastYieldTime = performance.now();
+        const yieldIntervalMs = 12; // Yield if a block of tasks takes longer than a ~60fps frame budget (12ms)
+
         for (const sheet of Array.from(document.styleSheets)) {
+          let sheetSuccess = false;
+          let rulesText = "";
+
           try {
-            const rules = Array.from(sheet.cssRules || sheet.rules);
-            inlinedStyles += rules.map(r => r.cssText).join("\n") + "\n";
+            const rules = sheet.cssRules || sheet.rules;
+            if (rules) {
+              const ruleCount = rules.length;
+              const ruleChunks = [];
+              let currentChunk = [];
+
+              for (let i = 0; i < ruleCount; i++) {
+                currentChunk.push(rules[i].cssText);
+                totalRulesProcessed++;
+
+                // Yield to event loop to keep the UI responsive and let progress updates draw
+                if (totalRulesProcessed % 500 === 0) {
+                  const now = performance.now();
+                  if (now - lastYieldTime > yieldIntervalMs) {
+                    ruleChunks.push(currentChunk.join("\n"));
+                    currentChunk = [];
+                    updatePdfProgress(state, 26, `Inlining CSS rules (${totalRulesProcessed} rules)`);
+                    await new Promise(resolve => setTimeout(resolve, 0));
+                    throwIfPdfExportAborted(state.signal);
+                    lastYieldTime = performance.now();
+                  }
+                }
+              }
+
+              if (currentChunk.length > 0) {
+                ruleChunks.push(currentChunk.join("\n"));
+              }
+              rulesText = ruleChunks.join("\n") + "\n";
+              sheetSuccess = true;
+            }
           } catch (e) {
-            // Fallback for CORS or cross-origin stylesheets
+            if (sheet.href) {
+              try {
+                const response = await fetch(sheet.href);
+                if (response.ok) {
+                  rulesText = await response.text() + "\n";
+                  sheetSuccess = true;
+                }
+              } catch (fetchErr) {
+                // Ignore and try Neutralino fallback
+              }
+
+              if (!sheetSuccess && typeof Neutralino !== 'undefined') {
+                try {
+                  let relativePath = sheet.href;
+                  if (relativePath.startsWith(window.location.origin)) {
+                    relativePath = relativePath.substring(window.location.origin.length);
+                  }
+                  if (relativePath.startsWith('file://')) {
+                    const url = new URL(relativePath);
+                    relativePath = url.pathname;
+                    if (relativePath.startsWith('/') && navigator.platform.startsWith('Win')) {
+                      relativePath = relativePath.substring(1);
+                    }
+                  } else if (relativePath.startsWith('/')) {
+                    relativePath = relativePath.substring(1);
+                  }
+                  rulesText = await Neutralino.filesystem.readFile(relativePath) + "\n";
+                  sheetSuccess = true;
+                } catch (neErr) {
+                  console.warn(`Neutralino filesystem fallback failed for stylesheet: ${sheet.href}`, neErr);
+                }
+              }
+            }
+          }
+
+          if (sheetSuccess) {
+            // Escape closing style tags inside the rules to prevent parser escape / XSS
+            rulesText = rulesText.replace(/<\/style/gi, '<\\/style');
+            inlinedStyleChunks.push(rulesText);
+            if (sheet.href) {
+              inlinedHrefs.add(sheet.href);
+            }
           }
         }
+        inlinedStyles = inlinedStyleChunks.join("\n");
 
         const parentStyles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
-          .map(el => el.outerHTML)
+          .filter(el => {
+            if (el.tagName === 'LINK' && el.getAttribute('href')) {
+              // Exclude if it was successfully inlined to prevent duplicate styling & offline resource failures
+              return !inlinedHrefs.has(el.href);
+            }
+            // Exclude styles since they are already fully compiled into inlinedStyles
+            return false;
+          })
+          .map(el => {
+            if (el.tagName === 'LINK' && el.getAttribute('href')) {
+              const clone = el.cloneNode(true);
+              clone.setAttribute('href', el.href); // Resolve relative to absolute URL
+              return clone.outerHTML;
+            }
+            return el.outerHTML;
+          })
           .join("\n");
 
         const fullHtml = `<!DOCTYPE html>
@@ -7752,12 +7846,21 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         updatePdfProgress(state, 65, "Calculating legacy page breaks");
-        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
+        // Pass 1: Scale oversized elements first to stabilize their heights
+        const initialAnalysis = analyzeGraphicsForPageBreaks(tempElement, state.signal);
         throwIfPdfExportAborted(state.signal);
 
-        if (pageBreakAnalysis.oversizedElements && pageBreakAnalysis.pageHeightPx) {
-          handleOversizedElements(pageBreakAnalysis.oversizedElements, pageBreakAnalysis.pageHeightPx, state.signal);
+        const pageHeightPx = initialAnalysis.pageHeightPx;
+        if (initialAnalysis.splitElements && pageHeightPx) {
+          const { oversizedElements } = categorizeBySize(initialAnalysis.splitElements, pageHeightPx);
+          if (oversizedElements.length > 0) {
+            handleOversizedElements(oversizedElements, pageHeightPx, state.signal);
+          }
         }
+
+        // Pass 2: Apply page breaks with cascade on the final scaled layout
+        const pageBreakAnalysis = applyPageBreaksWithCascade(tempElement, PAGE_CONFIG, 10, state.signal);
+        throwIfPdfExportAborted(state.signal);
         await waitForPdfFrame(state);
 
         const pdfOptions = {

--- a/script.js
+++ b/script.js
@@ -7548,6 +7548,16 @@ document.addEventListener("DOMContentLoaded", function () {
           }
         });
 
+        let inlinedStyles = "";
+        for (const sheet of Array.from(document.styleSheets)) {
+          try {
+            const rules = Array.from(sheet.cssRules || sheet.rules);
+            inlinedStyles += rules.map(r => r.cssText).join("\n") + "\n";
+          } catch (e) {
+            // Fallback for CORS or cross-origin stylesheets
+          }
+        }
+
         const parentStyles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
           .map(el => el.outerHTML)
           .join("\n");
@@ -7557,6 +7567,9 @@ document.addEventListener("DOMContentLoaded", function () {
 <head>
   <meta charset="utf-8">
   <title>Export Document</title>
+  <style>
+    ${inlinedStyles}
+  </style>
   ${parentStyles}
 </head>
 <body class="${currentTheme === 'dark' ? 'dark-theme' : 'light-theme'}" data-theme="${currentTheme}">

--- a/script.js
+++ b/script.js
@@ -7065,12 +7065,13 @@ document.addEventListener("DOMContentLoaded", function () {
     const graphics = [];
 
     // Query all targeting elements in precise DOM layout flow order
-    container.querySelectorAll('img, svg, pre, table').forEach(el => {
+    container.querySelectorAll('img, svg, pre, table, mjx-container[display="true"]').forEach(el => {
       let type = 'img';
       const tag = el.tagName.toLowerCase();
       if (tag === 'svg') type = 'svg';
       else if (tag === 'pre') type = 'pre';
       else if (tag === 'table') type = 'table';
+      else if (tag === 'mjx-container') type = 'math';
       
       graphics.push({ element: el, type: type });
     });
@@ -7313,16 +7314,7 @@ document.addEventListener("DOMContentLoaded", function () {
         remainingRatio: remainingRatio.toFixed(2)
       });
 
-      // Task 4: Whitespace optimization
-      // If remaining space is more than threshold and element almost fits, skip
-      // (Will be handled by Story 1.3 scaling instead)
-      if (remainingRatio > PAGE_BREAK_THRESHOLD) {
-        const scaledHeight = item.height * 0.9; // 90% scale
-        if (scaledHeight <= remainingSpace) {
-          logPdfExportDebug('  -> Skipping (can fit with 90% scaling)');
-          continue;
-        }
-      }
+      // Element is pushed to the next page to prevent splitting across page boundaries.
 
       // Calculate margin needed to push element to next page
       const marginNeeded = currentPageBottom - item.top + 5; // 5px buffer

--- a/styles.css
+++ b/styles.css
@@ -1504,40 +1504,7 @@ a:focus {
 
 
 
-/* ========================================
-   PDF EXPORT TABLE FIX - Rowspan/Colspan
-   ======================================== */
 
-/* Fix for html2canvas not properly rendering rowspan/colspan cells.
-   Apply backgrounds to cells instead of rows to prevent row backgrounds
-   from painting over rowspan cells during canvas capture. */
-.pdf-export table tr {
-  background-color: transparent !important;
-}
-
-.pdf-export table th,
-.pdf-export table td {
-  background-color: var(--table-bg, #ffffff);
-  position: relative;
-}
-
-.pdf-export table tr:nth-child(2n) th,
-.pdf-export table tr:nth-child(2n) td {
-  background-color: var(--bg-color, #f6f8fa);
-}
-
-/* Ensure rowspan cells render correctly */
-.pdf-export table th[rowspan],
-.pdf-export table td[rowspan] {
-  vertical-align: middle;
-  background-color: var(--table-bg, #ffffff) !important;
-}
-
-/* Ensure colspan cells render correctly */
-.pdf-export table th[colspan],
-.pdf-export table td[colspan] {
-  text-align: center;
-}
 
 /* Ensure target elements are block-level so that layout margins function correctly during PDF export */
 .pdf-export-block {
@@ -1559,21 +1526,7 @@ a:focus {
   display: block !important;
 }
 
-/* Dark mode PDF export table fix */
-[data-theme="dark"] .pdf-export table th,
-[data-theme="dark"] .pdf-export table td {
-  background-color: var(--table-bg, #161b22);
-}
 
-[data-theme="dark"] .pdf-export table tr:nth-child(2n) th,
-[data-theme="dark"] .pdf-export table tr:nth-child(2n) td {
-  background-color: #1c2128;
-}
-
-[data-theme="dark"] .pdf-export table th[rowspan],
-[data-theme="dark"] .pdf-export table td[rowspan] {
-  background-color: var(--table-bg, #161b22) !important;
-}
 
 /* ========================================
    MERMAID DIAGRAM TOOLBAR

--- a/styles.css
+++ b/styles.css
@@ -1540,11 +1540,22 @@ a:focus {
 }
 
 /* Ensure target elements are block-level so that layout margins function correctly during PDF export */
+.pdf-export-block {
+  display: block !important;
+  break-inside: avoid !important;
+  page-break-inside: avoid !important;
+}
+
 .pdf-export img,
 .pdf-export svg,
 .pdf-export pre,
 .pdf-export table,
-.pdf-export mjx-container[display="true"] {
+.pdf-export mjx-container[display="true"],
+.pdf-export-block img,
+.pdf-export-block svg,
+.pdf-export-block pre,
+.pdf-export-block table,
+.pdf-export-block mjx-container[display="true"] {
   display: block !important;
 }
 
@@ -3858,12 +3869,13 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
 /* ========================================
    ENTERPRISE PRINT & PDF LAYOUT
    ======================================== */
-@media print {
-  @page {
-    size: A4;
-    margin: 15mm;
-  }
+/* Define @page at top-level outside media query for universal print margin compatibility */
+@page {
+  size: A4;
+  margin: 15mm;
+}
 
+@media print {
   html,
   body {
     height: auto !important;

--- a/styles.css
+++ b/styles.css
@@ -3845,4 +3845,118 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
     transition: none;
   }
 }
-
+
+/* ========================================
+   ENTERPRISE PRINT & PDF LAYOUT
+   ======================================== */
+@media print {
+  @page {
+    size: A4;
+    margin: 15mm;
+  }
+
+  body {
+    background-color: #ffffff !important;
+    color: #24292e !important;
+    font-size: 12pt;
+    line-height: 1.5;
+  }
+
+  /* Hide UI elements during print */
+  .app-container,
+  .toolbar,
+  .mobile-menu,
+  .stats-container,
+  .resize-divider,
+  .pdf-progress-overlay,
+  .modal,
+  .toast,
+  .navbar,
+  .btn {
+    display: none !important;
+  }
+
+  /* Show and fit print content */
+  .pdf-export {
+    position: static !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    background-color: transparent !important;
+    color: inherit !important;
+    display: block !important;
+    box-shadow: none !important;
+  }
+
+  /* Page breaks & fragmentation */
+  h1, h2, h3, h4, h5, h6 {
+    break-after: avoid-page;
+    page-break-after: avoid;
+    break-inside: avoid;
+  }
+
+  p, li, dd, dt, blockquote {
+    orphans: 3;
+    widows: 3;
+  }
+
+  img, figure, figcaption,
+  .mermaid-container, .mermaid, .mermaid svg,
+  .markdown-alert, .alert, blockquote {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Short code blocks should not split; allow long ones to split */
+  pre {
+    break-inside: auto;
+    page-break-inside: auto;
+    white-space: pre-wrap !important;
+    word-break: break-all;
+  }
+  
+  pre:not(.oversized) {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  pre code {
+    white-space: pre-wrap !important;
+    word-break: break-all;
+  }
+
+  /* Tables spanning pages and repeating headers */
+  table {
+    break-inside: auto;
+    page-break-inside: auto;
+    width: 100% !important;
+    border-collapse: collapse;
+  }
+
+  thead {
+    display: table-header-group;
+    break-after: avoid-page;
+    page-break-after: avoid;
+  }
+
+  tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Scale oversized assets to fit page height/width */
+  img, svg, .mermaid-container, .mermaid svg {
+    max-width: 100% !important;
+    max-height: calc(100vh - 30mm) !important;
+    height: auto !important;
+    object-fit: contain !important;
+  }
+
+  /* Force background colors to print */
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -3855,6 +3855,12 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
     margin: 15mm;
   }
 
+  html,
+  body {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
   body {
     background-color: #ffffff !important;
     color: #24292e !important;

--- a/styles.css
+++ b/styles.css
@@ -1539,6 +1539,15 @@ a:focus {
   text-align: center;
 }
 
+/* Ensure target elements are block-level so that layout margins function correctly during PDF export */
+.pdf-export img,
+.pdf-export svg,
+.pdf-export pre,
+.pdf-export table,
+.pdf-export mjx-container[display="true"] {
+  display: block !important;
+}
+
 /* Dark mode PDF export table fix */
 [data-theme="dark"] .pdf-export table th,
 [data-theme="dark"] .pdf-export table td {

--- a/test-pdf-export.js
+++ b/test-pdf-export.js
@@ -1,0 +1,93 @@
+/**
+ * test-pdf-export.js
+ * Verification test suite for the Enterprise PDF Export Engine.
+ * Runs in Node.js to check architectural integrity and compliance.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const SCRIPT_PATH = path.join(__dirname, "script.js");
+const CSS_PATH = path.join(__dirname, "styles.css");
+const WORKER_PATH = path.join(__dirname, "preview-worker.js");
+const CONFIG_PATH = path.join(__dirname, "desktop-app", "neutralino.config.json");
+const SIDECAR_PATH = path.join(__dirname, "desktop-app", "extensions", "pdf-exporter", "index.js");
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`[PASS] ${message}`);
+    passed++;
+  } else {
+    console.error(`[FAIL] ${message}`);
+    failed++;
+  }
+}
+
+console.log("=========================================");
+console.log("PDF Export Re-engineering Verification Suite");
+console.log("=========================================\n");
+
+// Test 1: Verify render-full message capability in preview-worker.js
+try {
+  const workerContent = fs.readFileSync(WORKER_PATH, "utf8");
+  assert(workerContent.includes("render-full"), "preview-worker.js supports render-full message type");
+  assert(workerContent.includes("render-full-result"), "preview-worker.js emits render-full-result event");
+  assert(workerContent.includes("DOMPurify.sanitize"), "preview-worker.js contains DOMPurify sanitation hooks");
+} catch (e) {
+  assert(false, `Could not read preview-worker.js: ${e.message}`);
+}
+
+// Test 2: Verify print layouts in styles.css
+try {
+  const cssContent = fs.readFileSync(CSS_PATH, "utf8");
+  assert(cssContent.includes("@media print"), "styles.css contains @media print rules");
+  assert(cssContent.includes("size: A4;"), "styles.css specifies A4 page size");
+  assert(cssContent.includes("break-inside: avoid"), "styles.css enforces break-inside protection");
+  assert(cssContent.includes("orphans: 3;"), "styles.css includes widow/orphan protection (orphans)");
+  assert(cssContent.includes("widows: 3;"), "styles.css includes widow/orphan protection (widows)");
+  assert(cssContent.includes("table-header-group"), "styles.css repeats table headers using table-header-group");
+} catch (e) {
+  assert(false, `Could not read styles.css: ${e.message}`);
+}
+
+// Test 3: Verify architectural classes in script.js
+try {
+  const scriptContent = fs.readFileSync(SCRIPT_PATH, "utf8");
+  assert(scriptContent.includes("PdfExportEngine"), "script.js declares the PdfExportEngine namespace");
+  assert(scriptContent.includes("ExportDocumentBuilder"), "script.js implements ExportDocumentBuilder");
+  assert(scriptContent.includes("AssetReadinessGate"), "script.js implements AssetReadinessGate");
+  assert(scriptContent.includes("WebPrintBackend"), "script.js implements WebPrintBackend");
+  assert(scriptContent.includes("DesktopChromiumSidecarBackend"), "script.js implements DesktopChromiumSidecarBackend");
+  assert(scriptContent.includes("LegacyRasterBackend"), "script.js implements LegacyRasterBackend");
+  assert(scriptContent.includes("pdf-export-modal"), "script.js integrates pdf-export-modal controller");
+  assert(scriptContent.includes("parseMarkdownFull"), "script.js contains parseMarkdownFull helper");
+} catch (e) {
+  assert(false, `Could not read script.js: ${e.message}`);
+}
+
+// Test 4: Verify desktop config & sidecar script
+try {
+  const configContent = fs.readFileSync(CONFIG_PATH, "utf8");
+  assert(configContent.includes("extensions.*"), "neutralino.config.json enables extensions native API");
+  assert(configContent.includes("com.markdownviewer.pdfexporter"), "neutralino.config.json registers the pdf-exporter extension");
+
+  const sidecarContent = fs.readFileSync(SIDECAR_PATH, "utf8");
+  assert(sidecarContent.includes("findChromeOrEdge"), "sidecar contains system browser detection logic");
+  assert(sidecarContent.includes("generatePdf"), "sidecar implements generatePdf browser-native caller");
+  assert(sidecarContent.includes("http.createServer"), "sidecar exposes an offline, zero-dependency HTTP server");
+} catch (e) {
+  assert(false, `Could not verify desktop configs or sidecar: ${e.message}`);
+}
+
+console.log("\n=========================================");
+console.log(`Verification Complete: ${passed} passed, ${failed} failed.`);
+console.log("=========================================");
+
+if (failed > 0) {
+  process.exit(1);
+} else {
+  process.exit(0);
+}

--- a/test-pdf-export.js
+++ b/test-pdf-export.js
@@ -61,11 +61,12 @@ try {
   assert(scriptContent.includes("AssetReadinessGate"), "script.js implements AssetReadinessGate");
   assert(scriptContent.includes("WebPrintBackend"), "script.js implements WebPrintBackend");
   assert(scriptContent.includes("DesktopChromiumSidecarBackend"), "script.js implements DesktopChromiumSidecarBackend");
-  assert(scriptContent.includes("LegacyRasterBackend"), "script.js implements LegacyRasterBackend");
+  assert(!scriptContent.includes("LegacyRasterBackend"), "script.js has completely removed LegacyRasterBackend");
   assert(scriptContent.includes("pdf-export-modal"), "script.js integrates pdf-export-modal controller");
   assert(scriptContent.includes("parseMarkdownFull"), "script.js contains parseMarkdownFull helper");
-  assert(scriptContent.includes("container.querySelectorAll('.pdf-export-block')"), "script.js queries .pdf-export-block in identifyGraphicElements");
-  assert(scriptContent.includes("else if (tag === 'mjx-container') type = 'math';"), "script.js tags mjx-container as 'math'");
+  assert(scriptContent.includes(".closest('.pdf-export-block')"), "script.js utilizes .pdf-export-block wrappers for page-break avoidance");
+  assert(!scriptContent.includes("jspdf"), "script.js has completely removed jspdf library references");
+  assert(!scriptContent.includes("html2canvas"), "script.js has completely removed html2canvas library references");
 } catch (e) {
   assert(false, `Could not read script.js: ${e.message}`);
 }

--- a/test-pdf-export.js
+++ b/test-pdf-export.js
@@ -64,7 +64,7 @@ try {
   assert(scriptContent.includes("LegacyRasterBackend"), "script.js implements LegacyRasterBackend");
   assert(scriptContent.includes("pdf-export-modal"), "script.js integrates pdf-export-modal controller");
   assert(scriptContent.includes("parseMarkdownFull"), "script.js contains parseMarkdownFull helper");
-  assert(scriptContent.includes('mjx-container[display="true"]'), "script.js queries mjx-container[display=\"true\"] in identifyGraphicElements");
+  assert(scriptContent.includes("container.querySelectorAll('.pdf-export-block')"), "script.js queries .pdf-export-block in identifyGraphicElements");
   assert(scriptContent.includes("else if (tag === 'mjx-container') type = 'math';"), "script.js tags mjx-container as 'math'");
 } catch (e) {
   assert(false, `Could not read script.js: ${e.message}`);

--- a/test-pdf-export.js
+++ b/test-pdf-export.js
@@ -64,6 +64,8 @@ try {
   assert(scriptContent.includes("LegacyRasterBackend"), "script.js implements LegacyRasterBackend");
   assert(scriptContent.includes("pdf-export-modal"), "script.js integrates pdf-export-modal controller");
   assert(scriptContent.includes("parseMarkdownFull"), "script.js contains parseMarkdownFull helper");
+  assert(scriptContent.includes('mjx-container[display="true"]'), "script.js queries mjx-container[display=\"true\"] in identifyGraphicElements");
+  assert(scriptContent.includes("else if (tag === 'mjx-container') type = 'math';"), "script.js tags mjx-container as 'math'");
 } catch (e) {
   assert(false, `Could not read script.js: ${e.message}`);
 }
@@ -80,6 +82,17 @@ try {
   assert(sidecarContent.includes("http.createServer"), "sidecar exposes an offline, zero-dependency HTTP server");
 } catch (e) {
   assert(false, `Could not verify desktop configs or sidecar: ${e.message}`);
+}
+
+// Test 5: Verify optimized cooperative CSS inlining in script.js
+try {
+  const scriptContent = fs.readFileSync(SCRIPT_PATH, "utf8");
+  assert(scriptContent.includes("yieldIntervalMs"), "script.js implements yield interval threshold for CSS rules processing");
+  assert(scriptContent.includes("totalRulesProcessed"), "script.js tracks rules processed count for batch yielding");
+  assert(scriptContent.includes("throwIfPdfExportAborted"), "script.js verifies cancellation state inside yielding loop");
+  assert(scriptContent.includes("currentChunk = []"), "script.js uses chunked style accumulation to optimize memory/GC");
+} catch (e) {
+  assert(false, `Could not verify optimized CSS inlining: ${e.message}`);
 }
 
 console.log("\n=========================================");


### PR DESCRIPTION
This PR begins the migration away from the current html2canvas + jsPDF bitmap export pipeline and introduces the foundation for a print-oriented PDF architecture designed for large documents, professional output quality, and long-term maintainability.

The existing implementation renders the entire document into a single large canvas, slices the bitmap into pages, and embeds PNG images into a PDF. While functional for small documents, this architecture has significant limitations in performance, memory usage, pagination quality, text fidelity, and scalability.