### PR TITLE
fix(find): improve readability and visibility of highlighted matches in dark mode

### DIFF
--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -28,6 +28,8 @@
   --fr-btn-active-bg: #ddf4ff;
   --fr-match-highlight: #ffdf5d;
   --fr-match-active: #ff9b30;
+  --fr-match-text-color: #24292e;
+  --fr-match-active-text-color: #24292e;
   --fr-error-bg: #ffebe9;
   --fr-error-border: #ff8577;
   --fr-text-danger: #cf222e;
@@ -61,7 +63,9 @@
   --fr-btn-active: #2f81f7;
   --fr-btn-active-bg: rgba(56, 139, 253, 0.15);
   --fr-match-highlight: rgba(187, 128, 9, 0.4);
-  --fr-match-active: #f1e05a;
+  --fr-match-active: #ad6200;
+  --fr-match-text-color: #c9d1d9;
+  --fr-match-active-text-color: #ffffff;
   --fr-error-bg: rgba(248, 81, 73, 0.1);
   --fr-error-border: rgba(248, 81, 73, 0.4);
   --fr-text-danger: #ff7b72;
@@ -622,10 +626,13 @@ body {
   color: transparent !important;
   padding: 0 !important;
   margin: 0 !important;
+  outline: 1px solid var(--accent-color, #0366d6) !important;
+  outline-offset: -1px;
 }
 
 .preview-find-highlight {
   background-color: var(--fr-match-highlight, rgba(255, 223, 93, 0.4)) !important;
+  color: var(--fr-match-text-color, inherit) !important;
   border-radius: 2px;
   padding: 0 1px !important;
   margin: 0 !important;
@@ -633,6 +640,9 @@ body {
 
 .preview-find-highlight.active {
   background-color: var(--fr-match-active, #ff9b30) !important;
+  color: var(--fr-match-active-text-color, inherit) !important;
+  outline: 1px solid var(--accent-color, #0366d6) !important;
+  outline-offset: -1px;
 }
 
 /* Dropdown improvements */

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,8 @@
   --fr-btn-active-bg: #ddf4ff;
   --fr-match-highlight: #ffdf5d;
   --fr-match-active: #ff9b30;
+  --fr-match-text-color: #24292e;
+  --fr-match-active-text-color: #24292e;
   --fr-error-bg: #ffebe9;
   --fr-error-border: #ff8577;
   --fr-text-danger: #cf222e;
@@ -61,7 +63,9 @@
   --fr-btn-active: #2f81f7;
   --fr-btn-active-bg: rgba(56, 139, 253, 0.15);
   --fr-match-highlight: rgba(187, 128, 9, 0.4);
-  --fr-match-active: #f1e05a;
+  --fr-match-active: #ad6200;
+  --fr-match-text-color: #c9d1d9;
+  --fr-match-active-text-color: #ffffff;
   --fr-error-bg: rgba(248, 81, 73, 0.1);
   --fr-error-border: rgba(248, 81, 73, 0.4);
   --fr-text-danger: #ff7b72;
@@ -622,10 +626,13 @@ body {
   color: transparent !important;
   padding: 0 !important;
   margin: 0 !important;
+  outline: 1px solid var(--accent-color, #0366d6) !important;
+  outline-offset: -1px;
 }
 
 .preview-find-highlight {
   background-color: var(--fr-match-highlight, rgba(255, 223, 93, 0.4)) !important;
+  color: var(--fr-match-text-color, inherit) !important;
   border-radius: 2px;
   padding: 0 1px !important;
   margin: 0 !important;
@@ -633,6 +640,9 @@ body {
 
 .preview-find-highlight.active {
   background-color: var(--fr-match-active, #ff9b30) !important;
+  color: var(--fr-match-active-text-color, inherit) !important;
+  outline: 1px solid var(--accent-color, #0366d6) !important;
+  outline-offset: -1px;
 }
 
 /* Dropdown improvements */


### PR DESCRIPTION
## Description
This PR addresses visibility and contrast issues with the Find & Replace highlighted matches in Dark Mode. 

Since the editor is a standard `<textarea>`, character-level text coloring cannot be customized inside it (it uses the main text color, which is a light gray `#c9d1d9` in dark mode). Overlaying bright yellow/orange highlights made text completely unreadable.

### Solution
1. **Legible Backgrounds in Dark Mode**: Adjusted `--fr-match-active` from a bright solid yellow (`#f1e05a`) to a solid dark orange/gold (`#ad6200`). This ensures the white/light-gray text remains highly readable.
2. **Text Color Overrides**: Introduced new `--fr-match-text-color` and `--fr-match-active-text-color` variables to enforce high-contrast text rendering on highlights in the HTML preview pane.
3. **Active Match Outline**: Added a `1px` outline using the theme's `var(--accent-color)` to active matches in both the editor and preview. This enables active matches to stand out instantly without relying on overly bright backgrounds.

## Files Modified
* `styles.css` — Core CSS updates.
* `desktop-app/resources/styles.css` — Synchronized desktop assets via build pipeline.

## Verification Details
* **Light Mode**: Retains soft yellow (`#ffdf5d`) and orange (`#ff9b30`) highlights with a blue outline for active match.
* **Dark Mode**: All matches render as translucent gold; the active match displays as dark orange/gold with white text and a light blue outline (`#58a6ff`). Text is fully legible.