### PR TITLE
Fix #178: Export files using active tab title instead of 'document'

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -1153,6 +1153,16 @@ document.addEventListener("DOMContentLoaded", function () {
   let saveTabStateTimeout = null;
   let untitledCounter = 0;
 
+  function getExportFilename(extension, fallback) {
+    const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
+    let title = activeTab ? activeTab.title : "";
+    if (title) {
+      title = title.replace(/\.(md|markdown|html|pdf|png)$/i, '');
+      title = title.replace(/[\\/:*?"<>|]/g, "_").trim();
+    }
+    return title ? `${title}.${extension}` : fallback;
+  }
+
   function loadTabsFromStorage() {
     try {
       return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
@@ -6851,7 +6861,7 @@ document.addEventListener("DOMContentLoaded", function () {
       const blob = new Blob([markdownEditor.value], {
         type: "text/markdown;charset=utf-8",
       });
-      saveAs(blob, "document.md");
+      saveAs(blob, getExportFilename("md", "document.md"));
     } catch (e) {
       console.error("Export failed:", e);
       alert("Export failed: " + e.message);
@@ -7198,7 +7208,7 @@ document.addEventListener("DOMContentLoaded", function () {
       if (typeof Neutralino !== 'undefined') {
         nativeSaveHtml(fullHtml);
       } else {
-        saveAs(blob, "document.html");
+        saveAs(blob, getExportFilename("html", "document.html"));
       }
     } catch (e) {
       console.error("HTML export failed:", e);
@@ -8507,7 +8517,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       throwIfPdfExportAborted(progressState.signal);
       updatePdfProgress(progressState, 98, "Preparing download");
-      pdf.save("document.pdf");
+      pdf.save(getExportFilename("pdf", "document.pdf"));
       updatePdfProgress(progressState, 100, "Complete");
 
     } catch (error) {
@@ -8717,7 +8727,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       updatePdfProgress(progressState, 95, "Saving image");
       canvas.toBlob((blob) => {
-        saveAs(blob, "document.png");
+        saveAs(blob, getExportFilename("png", "document.png"));
       }, "image/png");
       updatePdfProgress(progressState, 100, "Complete");
 

--- a/script.js
+++ b/script.js
@@ -1153,6 +1153,16 @@ document.addEventListener("DOMContentLoaded", function () {
   let saveTabStateTimeout = null;
   let untitledCounter = 0;
 
+  function getExportFilename(extension, fallback) {
+    const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
+    let title = activeTab ? activeTab.title : "";
+    if (title) {
+      title = title.replace(/\.(md|markdown|html|pdf|png)$/i, '');
+      title = title.replace(/[\\/:*?"<>|]/g, "_").trim();
+    }
+    return title ? `${title}.${extension}` : fallback;
+  }
+
   function loadTabsFromStorage() {
     try {
       return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
@@ -6851,7 +6861,7 @@ document.addEventListener("DOMContentLoaded", function () {
       const blob = new Blob([markdownEditor.value], {
         type: "text/markdown;charset=utf-8",
       });
-      saveAs(blob, "document.md");
+      saveAs(blob, getExportFilename("md", "document.md"));
     } catch (e) {
       console.error("Export failed:", e);
       alert("Export failed: " + e.message);
@@ -7198,7 +7208,7 @@ document.addEventListener("DOMContentLoaded", function () {
       if (typeof Neutralino !== 'undefined') {
         nativeSaveHtml(fullHtml);
       } else {
-        saveAs(blob, "document.html");
+        saveAs(blob, getExportFilename("html", "document.html"));
       }
     } catch (e) {
       console.error("HTML export failed:", e);
@@ -8507,7 +8517,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       throwIfPdfExportAborted(progressState.signal);
       updatePdfProgress(progressState, 98, "Preparing download");
-      pdf.save("document.pdf");
+      pdf.save(getExportFilename("pdf", "document.pdf"));
       updatePdfProgress(progressState, 100, "Complete");
 
     } catch (error) {
@@ -8717,7 +8727,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       updatePdfProgress(progressState, 95, "Saving image");
       canvas.toBlob((blob) => {
-        saveAs(blob, "document.png");
+        saveAs(blob, getExportFilename("png", "document.png"));
       }, "image/png");
       updatePdfProgress(progressState, 100, "Complete");
 


### PR DESCRIPTION
Resolves #178

### Description
Currently, when exporting/downloading documents to Markdown (`.md`), HTML (`.html`), PDF (`.pdf`), or PNG (`.png`), the application always defaults to `"document"` as the base filename.

This change introduces a helper function `getExportFilename(extension, fallback)` that retrieves the active tab's title, sanitizes it (replacing invalid OS filename characters `\ / : * ? " < > |` with underscores), cleans up existing extensions (e.g., preventing `title.md.md`), and uses it as the default filename. If there is no active tab or the title is empty, it falls back to `"document.<extension>"`.

### Changes Made
- Defined helper function `getExportFilename(extension, fallback)` in `script.js`.
- Replaced hardcoded `"document.md"`, `"document.html"`, `"document.pdf"`, and `"document.png"` with dynamic filename calls.
- Regenerated the compiled desktop app resources (`desktop-app/resources/js/script.js`) by running `node prepare.js`.
