### PR TITLE
Fix PowerShell syntax highlighting and fenced math rendering

### DIFF
--- a/desktop-app/resources/index.html
+++ b/desktop-app/resources/index.html
@@ -25,6 +25,7 @@
     <!-- Loading order optimized - ensure libraries are loaded asynchronously using defer -->
     <script src="/libs/marked.min.js" integrity="sha384-odPBjvtXVM/5hOYIr3A1dB+flh0c3wAT3bSesIOqEGmyUA4JoKf/YTWy0XKOYAY7" crossorigin="anonymous" defer></script>
     <script src="/libs/highlight.min.js" integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp" crossorigin="anonymous" defer></script>
+    <script src="/libs/powershell.min.js" integrity="sha384-LWJZQx0dgGhEK7snfNYrQs5K+QKD1sOmE02sOQCz4br9UmqSJDvPLoUVFaUyFnjq" crossorigin="anonymous" defer></script>
     <script src="/libs/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous" defer></script>
     <script src="/libs/FileSaver.min.js" integrity="sha384-PlRSzpewlarQuj5alIadXwjNUX+2eNMKwr0f07ShWYLy8B6TjEbm7ZlcN/ScSbwy" crossorigin="anonymous" defer></script>
     <!-- PERF-002: MathJax, Mermaid, JoyPixels, jsPDF, html2canvas, pako are now lazy-loaded by script.js on first use -->

--- a/desktop-app/resources/js/preview-worker.js
+++ b/desktop-app/resources/js/preview-worker.js
@@ -318,6 +318,10 @@ function configureMarked() {
       return `<div class="abc-container is-loading"><div class="abc-notation" id="${uniqueId}" data-original-code="${encodeURIComponent(code)}">${escapeHtml(code)}</div></div>`;
     }
 
+    if (language === "math") {
+      return `<div class="math-block">$$\n${code}\n$$</div>\n`;
+    }
+
     const validLanguage = hljs && hljs.getLanguage(language) ? language : "plaintext";
     const highlightedCode = hljs
       ? hljs.highlight(code, { language: validLanguage }).value
@@ -364,6 +368,9 @@ function configureMarked() {
 function ensureLibraries(urls) {
   if (!librariesLoaded) {
     importScripts(urls.marked, urls.highlight);
+    if (urls.powershell) {
+      importScripts(urls.powershell);
+    }
     librariesLoaded = true;
   }
   configureMarked();

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -457,6 +457,7 @@ document.addEventListener("DOMContentLoaded", function () {
     return {
       marked: getLoadedScriptUrl("marked", "https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"),
       highlight: getLoadedScriptUrl("highlight", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"),
+      powershell: getLoadedScriptUrl("powershell.min.js", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/powershell.min.js"),
     };
   }
 
@@ -940,6 +941,10 @@ document.addEventListener("DOMContentLoaded", function () {
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;");
       return `<div class="abc-container is-loading"><div class="abc-notation" id="${uniqueId}" data-original-code="${encodeURIComponent(code)}">${escapedCode}</div></div>`;
+    }
+
+    if (language === 'math') {
+      return `<div class="math-block">$$\n${code}\n$$</div>\n`;
     }
     
     const validLanguage = hljs.getLanguage(language) ? language : "plaintext";
@@ -2312,7 +2317,7 @@ document.addEventListener("DOMContentLoaded", function () {
       console.warn("ABC notation processing failed:", e);
     }
 
-    const hasMath = /\$\$|\$[^$]|\\\(|\\\[/.test(rawVal || '');
+    const hasMath = /\$\$|\$[^$]|\\\(|\\\[/.test(rawVal || '') || /```math\b/.test(rawVal || '');
     if (hasMath) {
       const typesetTargets = roots.filter(function(root) {
         return root && root.nodeType === Node.ELEMENT_NODE && /\$\$|\$[^$]|\\\(|\\\[/.test(root.textContent || '');
@@ -7420,7 +7425,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function markdownLikelyContainsMath(markdown) {
-    return /(^|[^\\])\$\$|\\\[|\\\(|(^|[^\\])\$[^$\n]+\$/.test(markdown);
+    return /(^|[^\\])\$\$|\\\[|\\\(|(^|[^\\])\$[^$\n]+\$/.test(markdown) || /```math\b/.test(markdown);
   }
 
   function choosePdfCanvasScale(element) {

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
     <!-- Loading order optimized - ensure libraries are loaded asynchronously using defer -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js" integrity="sha384-odPBjvtXVM/5hOYIr3A1dB+flh0c3wAT3bSesIOqEGmyUA4JoKf/YTWy0XKOYAY7" crossorigin="anonymous" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp" crossorigin="anonymous" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/powershell.min.js" integrity="sha384-LWJZQx0dgGhEK7snfNYrQs5K+QKD1sOmE02sOQCz4br9UmqSJDvPLoUVFaUyFnjq" crossorigin="anonymous" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.9/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js" integrity="sha384-PlRSzpewlarQuj5alIadXwjNUX+2eNMKwr0f07ShWYLy8B6TjEbm7ZlcN/ScSbwy" crossorigin="anonymous" defer></script>
     <!-- PERF-002: MathJax, Mermaid, JoyPixels, jsPDF, html2canvas, pako are now lazy-loaded by script.js on first use -->

--- a/preview-worker.js
+++ b/preview-worker.js
@@ -318,6 +318,10 @@ function configureMarked() {
       return `<div class="abc-container is-loading"><div class="abc-notation" id="${uniqueId}" data-original-code="${encodeURIComponent(code)}">${escapeHtml(code)}</div></div>`;
     }
 
+    if (language === "math") {
+      return `<div class="math-block">$$\n${code}\n$$</div>\n`;
+    }
+
     const validLanguage = hljs && hljs.getLanguage(language) ? language : "plaintext";
     const highlightedCode = hljs
       ? hljs.highlight(code, { language: validLanguage }).value
@@ -364,6 +368,9 @@ function configureMarked() {
 function ensureLibraries(urls) {
   if (!librariesLoaded) {
     importScripts(urls.marked, urls.highlight);
+    if (urls.powershell) {
+      importScripts(urls.powershell);
+    }
     librariesLoaded = true;
   }
   configureMarked();

--- a/script.js
+++ b/script.js
@@ -457,6 +457,7 @@ document.addEventListener("DOMContentLoaded", function () {
     return {
       marked: getLoadedScriptUrl("marked", "https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"),
       highlight: getLoadedScriptUrl("highlight", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"),
+      powershell: getLoadedScriptUrl("powershell.min.js", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/powershell.min.js"),
     };
   }
 
@@ -940,6 +941,10 @@ document.addEventListener("DOMContentLoaded", function () {
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;");
       return `<div class="abc-container is-loading"><div class="abc-notation" id="${uniqueId}" data-original-code="${encodeURIComponent(code)}">${escapedCode}</div></div>`;
+    }
+
+    if (language === 'math') {
+      return `<div class="math-block">$$\n${code}\n$$</div>\n`;
     }
     
     const validLanguage = hljs.getLanguage(language) ? language : "plaintext";
@@ -2312,7 +2317,7 @@ document.addEventListener("DOMContentLoaded", function () {
       console.warn("ABC notation processing failed:", e);
     }
 
-    const hasMath = /\$\$|\$[^$]|\\\(|\\\[/.test(rawVal || '');
+    const hasMath = /\$\$|\$[^$]|\\\(|\\\[/.test(rawVal || '') || /```math\b/.test(rawVal || '');
     if (hasMath) {
       const typesetTargets = roots.filter(function(root) {
         return root && root.nodeType === Node.ELEMENT_NODE && /\$\$|\$[^$]|\\\(|\\\[/.test(root.textContent || '');
@@ -7420,7 +7425,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function markdownLikelyContainsMath(markdown) {
-    return /(^|[^\\])\$\$|\\\[|\\\(|(^|[^\\])\$[^$\n]+\$/.test(markdown);
+    return /(^|[^\\])\$\$|\\\[|\\\(|(^|[^\\])\$[^$\n]+\$/.test(markdown) || /```math\b/.test(markdown);
   }
 
   function choosePdfCanvasScale(element) {


### PR DESCRIPTION
## Description

This pull request resolves two issues in the Markdown Viewer:
1. **PowerShell Syntax Highlighting**: PowerShell code blocks were displaying without color because highlight.js core/standard bundle does not include PowerShell by default.
2. **Fenced Math Block Rendering**: Code blocks fenced with ` ```math ` were not parsed as LaTeX display math, resulting in raw unrendered text.

## Changes

### 1. PowerShell Syntax Highlighting Support
- **Web**: Added the official CDN highlight.js `languages/powershell.min.js` script to `index.html`.
- **Web Worker**: Updated `script.js` and `preview-worker.js` to load the PowerShell language script into the preview web worker so off-thread compilation highlights PowerShell correctly.
- **Desktop (Offline)**: Updated `prepare.js` to automatically detect, download, cryptographically validate (using SHA-384 SRI), and local-cache the PowerShell script for offline desktop app support.

### 2. Fenced Math Block Rendering (` ```math `)
- **Renderer support**: Added a check in `renderer.code` inside `script.js` and `preview-worker.js` for `language === 'math'`, converting it into a MathJax-compatible block: `<div class="math-block">$$\n[code]\n$$</div>`.
- **Detection**: Updated `hasMath` check and `markdownLikelyContainsMath` regex in `script.js` to check for ` ```math ` fences, ensuring MathJax triggers rendering even if standard dollar-sign delimiters are absent.
