### PR TITLE
fix: resolve PlantUML sequence diagram rendering squish bug

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -1445,12 +1445,25 @@ document.addEventListener("DOMContentLoaded", async function () {
     let normalized = String(source || '');
     const changes = [];
 
-    if (engine === 'plantuml' && /@startuml[\s\S]*?\bnwdiag\s*\{/i.test(normalized)) {
-      normalized = normalized
-        .replace(/@startuml/i, '')
-        .replace(/\bnwdiag\s*\{/i, '@startnwdiag')
-        .replace(/\n\s*\}\s*\n\s*@enduml\s*$/i, '\n@endnwdiag');
-      changes.push('legacy-nwdiag-wrapper');
+    if (engine === 'plantuml') {
+      if (/@startuml[\s\S]*?\bnwdiag\s*\{/i.test(normalized)) {
+        normalized = normalized
+          .replace(/@startuml/i, '')
+          .replace(/\bnwdiag\s*\{/i, '@startnwdiag')
+          .replace(/\n\s*\}\s*\n\s*@enduml\s*$/i, '\n@endnwdiag');
+        changes.push('legacy-nwdiag-wrapper');
+      }
+      
+      const hasDefaultFont = /skinparam\s+defaultFontName\b/i.test(normalized);
+      if (!hasDefaultFont) {
+        const startRegex = /^(\s*@start[a-z]+)/mi;
+        if (startRegex.test(normalized)) {
+          normalized = normalized.replace(startRegex, '$1\nskinparam defaultFontName sans-serif');
+        } else {
+          normalized = 'skinparam defaultFontName sans-serif\n' + normalized;
+        }
+        changes.push('plantuml-default-font-fallback');
+      }
     }
 
     if (engine === 'd2') {

--- a/script.js
+++ b/script.js
@@ -1445,12 +1445,25 @@ document.addEventListener("DOMContentLoaded", async function () {
     let normalized = String(source || '');
     const changes = [];
 
-    if (engine === 'plantuml' && /@startuml[\s\S]*?\bnwdiag\s*\{/i.test(normalized)) {
-      normalized = normalized
-        .replace(/@startuml/i, '')
-        .replace(/\bnwdiag\s*\{/i, '@startnwdiag')
-        .replace(/\n\s*\}\s*\n\s*@enduml\s*$/i, '\n@endnwdiag');
-      changes.push('legacy-nwdiag-wrapper');
+    if (engine === 'plantuml') {
+      if (/@startuml[\s\S]*?\bnwdiag\s*\{/i.test(normalized)) {
+        normalized = normalized
+          .replace(/@startuml/i, '')
+          .replace(/\bnwdiag\s*\{/i, '@startnwdiag')
+          .replace(/\n\s*\}\s*\n\s*@enduml\s*$/i, '\n@endnwdiag');
+        changes.push('legacy-nwdiag-wrapper');
+      }
+      
+      const hasDefaultFont = /skinparam\s+defaultFontName\b/i.test(normalized);
+      if (!hasDefaultFont) {
+        const startRegex = /^(\s*@start[a-z]+)/mi;
+        if (startRegex.test(normalized)) {
+          normalized = normalized.replace(startRegex, '$1\nskinparam defaultFontName sans-serif');
+        } else {
+          normalized = 'skinparam defaultFontName sans-serif\n' + normalized;
+        }
+        changes.push('plantuml-default-font-fallback');
+      }
     }
 
     if (engine === 'd2') {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'markdown-viewer-cache-v3.7.16';
+const CACHE_NAME = 'markdown-viewer-cache-v3.7.17';
 
 // PERF-011: Split precache into critical (local files) and lazy (CDN libraries)
 // Critical assets are precached during SW install for instant offline startup


### PR DESCRIPTION
Resolves the issue where PlantUML sequence diagrams render incorrectly inside Markdown code fences.

Without a font family configuration, the official PlantUML server returns text elements with `textLength="0"` in headless JRE environments. This collapses the horizontal layout of the diagram (e.g., squishing it to a 54px total width), causing participant boxes and messages to overlap.

This PR injects `skinparam defaultFontName sans-serif` during diagram source normalization when no custom `defaultFontName` is defined. This forces the server to measure font metrics using a standard fallback, restoring the expected layout and spacing.

## Changes
- **script.js** and **desktop-app/resources/js/script.js**: Injected default font skinparam for PlantUML diagrams when not specified in source.
- **sw.js**: Bumped service worker cache version to `markdown-viewer-cache-v3.7.17` to invalidate old assets.