### PR TITLE
feat(share): improve Live Share and Share Snapshot flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,11 +180,11 @@
                         <i class="bi bi-clipboard"></i> <span class="btn-text">Copy</span>
                     </button>
                     
-                    <button id="share-button" class="tool-button" title="Share a snapshot URL">
+                    <button id="share-button" class="tool-button" title="Share Snapshot">
                         <i class="bi bi-share"></i> <span class="btn-text">Share Snapshot</span>
                     </button>
 
-                    <button id="live-share-button" class="tool-button" title="Start temporary live collaboration">
+                    <button id="live-share-button" class="tool-button" title="Live Share">
                         <i class="bi bi-broadcast"></i> <span class="btn-text">Live Share</span>
                     </button>
                     <div id="live-share-toolbar-participants" class="live-share-toolbar-participants" aria-label="Live Share participants" hidden></div>
@@ -307,11 +307,11 @@
                                 <i class="bi bi-clipboard me-2"></i> Copy
                             </button>
                             
-                            <button id="mobile-share-button" class="mobile-menu-item" title="Share a snapshot URL">
+                            <button id="mobile-share-button" class="mobile-menu-item" title="Share Snapshot">
                                 <i class="bi bi-share me-2"></i> Share Snapshot
                             </button>
 
-                            <button id="mobile-live-share-button" class="mobile-menu-item" title="Start temporary live collaboration">
+                            <button id="mobile-live-share-button" class="mobile-menu-item" title="Live Share">
                                 <i class="bi bi-broadcast me-2"></i> Live Share
                             </button>
                             

--- a/index.html
+++ b/index.html
@@ -737,17 +737,13 @@
                   <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
                 </label>
               </div>
-              <div class="live-share-invite share-snapshot-invite">
+              <div class="live-share-invite share-snapshot-invite" id="share-invite-section" hidden>
                 <div class="live-share-invite-header">
-                  <span class="live-share-section-title">Snapshot link</span>
-                  <span class="live-share-invite-state" id="share-invite-state">Created after clicking Share</span>
+                  <span class="live-share-section-title">Copy link</span>
+                  <span class="live-share-invite-state" id="share-invite-state">Ready to copy</span>
                 </div>
                 <div class="share-url-row live-share-link-row">
-                  <input type="text" id="share-url-input" class="rename-modal-input share-url-input" readonly placeholder="Click Share to create a snapshot link" aria-label="Share URL" />
-                  <button class="reset-modal-btn share-generate-btn live-share-copy-btn" id="share-generate-btn" title="Create share link">
-                    <i class="bi bi-share"></i>
-                    <span>Share</span>
-                  </button>
+                  <input type="text" id="share-url-input" class="rename-modal-input share-url-input" readonly placeholder="Share link appears here" aria-label="Share URL" />
                   <button class="reset-modal-btn share-copy-btn live-share-copy-btn" id="share-copy-btn" title="Copy link">
                     <i class="bi bi-clipboard"></i>
                     <span>Copy</span>
@@ -756,7 +752,8 @@
               </div>
             </div>
             <div class="reset-modal-actions">
-              <button class="reset-modal-btn reset-modal-cancel" id="share-modal-close">Close</button>
+              <button class="reset-modal-btn reset-modal-cancel" id="share-modal-close">Cancel</button>
+              <button class="reset-modal-btn share-generate-btn" id="share-generate-btn" title="Create share link">Share</button>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -715,10 +715,10 @@
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Create a snapshot link for the active Markdown tab.</p>
+              <p class="share-modal-description">Create a temporary snapshot link.</p>
               <p class="share-modal-notice">
                 <i class="bi bi-info-circle"></i>
-                <span>Small snapshots stay encoded in the URL. Larger snapshots use a short Cloudflare KV link that expires after 90 days. Snapshot tabs are temporary and are not saved locally; anyone with the link can open the snapshot.</span>
+                <span>Small links stay in the URL. Large links use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally.</span>
               </p>
               <div class="live-share-section-title">Access</div>
               <div class="share-mode-cards">

--- a/index.html
+++ b/index.html
@@ -791,7 +791,10 @@
                 </div>
               </div>
               <div class="live-share-access-status" id="live-share-access-status" hidden>
-                <span>Access: <strong id="live-share-access-label">Can edit</strong></span>
+                <span class="live-share-access-icon" aria-hidden="true">
+                  <i class="bi bi-key"></i>
+                </span>
+                <span class="live-share-access-title">Access: <strong id="live-share-access-label">Can edit</strong></span>
                 <span id="live-share-access-note">Collaborators can edit this document.</span>
               </div>
               <div class="live-share-status" id="live-share-status" aria-live="polite">

--- a/index.html
+++ b/index.html
@@ -715,7 +715,7 @@
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Small links stay in the URL. Large links use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally.</p>
+              <p class="share-modal-description">Small documents stay encoded in the URL. Large documents use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally.</p>
               <div class="live-share-section-title">Access</div>
               <div class="share-mode-cards">
                 <label class="share-mode-card" id="share-card-view" for="share-mode-view">

--- a/index.html
+++ b/index.html
@@ -709,13 +709,14 @@
         <div id="share-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="share-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide modal-box">
             <div class="modal-header">
-              <p id="share-modal-title" class="reset-modal-message">Share Document</p>
+              <p id="share-modal-title" class="reset-modal-message">Share Snapshot</p>
               <button type="button" class="modal-close-btn" id="share-modal-close-icon" aria-label="Close share dialog">
                 <i class="bi bi-x-lg"></i>
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Choose how recipients can open this snapshot.</p>
+              <p class="share-modal-description">Create a snapshot link for the active Markdown tab.</p>
+              <div class="live-share-section-title">Access</div>
               <div class="share-mode-cards">
                 <label class="share-mode-card" id="share-card-view" for="share-mode-view">
                   <input type="radio" id="share-mode-view" name="share-mode" value="view" checked />
@@ -730,19 +731,25 @@
                   <input type="radio" id="share-mode-edit" name="share-mode" value="edit" />
                   <span class="share-card-icon"><i class="bi bi-pencil-square"></i></span>
                   <span class="share-card-body">
-                    <span class="share-card-title">Edit</span>
+                    <span class="share-card-title">Can edit</span>
                     <span class="share-card-desc">Opens in split editor + preview mode.</span>
                   </span>
                   <span class="share-card-check"><i class="bi bi-check-lg"></i></span>
                 </label>
               </div>
-              <div class="share-url-row">
-                <input type="text" id="share-url-input" class="rename-modal-input share-url-input" readonly placeholder="Generating link…" aria-label="Share URL" />
-                <button class="reset-modal-btn share-copy-btn" id="share-copy-btn" title="Copy link">
-                  <i class="bi bi-clipboard"></i>
-                </button>
+              <div class="live-share-invite share-snapshot-invite">
+                <div class="live-share-invite-header">
+                  <span class="live-share-section-title">Snapshot link</span>
+                  <span class="live-share-invite-state">Ready to copy</span>
+                </div>
+                <div class="share-url-row live-share-link-row">
+                  <input type="text" id="share-url-input" class="rename-modal-input share-url-input" readonly placeholder="Generating link..." aria-label="Share URL" />
+                  <button class="reset-modal-btn share-copy-btn live-share-copy-btn" id="share-copy-btn" title="Copy link">
+                    <i class="bi bi-clipboard"></i>
+                    <span>Copy</span>
+                  </button>
+                </div>
               </div>
-              <p class="share-modal-notice"><i class="bi bi-info-circle"></i> Small snapshots stay encoded in the URL. Larger snapshots use a short Cloudflare KV link that expires after 90 days.</p>
             </div>
             <div class="reset-modal-actions">
               <button class="reset-modal-btn reset-modal-cancel" id="share-modal-close">Close</button>

--- a/index.html
+++ b/index.html
@@ -740,10 +740,14 @@
               <div class="live-share-invite share-snapshot-invite">
                 <div class="live-share-invite-header">
                   <span class="live-share-section-title">Snapshot link</span>
-                  <span class="live-share-invite-state">Ready to copy</span>
+                  <span class="live-share-invite-state" id="share-invite-state">Created after clicking Share</span>
                 </div>
                 <div class="share-url-row live-share-link-row">
-                  <input type="text" id="share-url-input" class="rename-modal-input share-url-input" readonly placeholder="Generating link..." aria-label="Share URL" />
+                  <input type="text" id="share-url-input" class="rename-modal-input share-url-input" readonly placeholder="Click Share to create a snapshot link" aria-label="Share URL" />
+                  <button class="reset-modal-btn share-generate-btn live-share-copy-btn" id="share-generate-btn" title="Create share link">
+                    <i class="bi bi-share"></i>
+                    <span>Share</span>
+                  </button>
                   <button class="reset-modal-btn share-copy-btn live-share-copy-btn" id="share-copy-btn" title="Copy link">
                     <i class="bi bi-clipboard"></i>
                     <span>Copy</span>

--- a/index.html
+++ b/index.html
@@ -766,7 +766,7 @@
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Start a temporary Cloudflare live room for the active Markdown tab.</p>
+              <p class="share-modal-description">Temporary in-memory room. No document data is stored.</p>
               <div class="reset-modal-field">
                 <label class="reset-modal-label" for="live-share-display-name">Display name</label>
                 <input type="text" id="live-share-display-name" class="rename-modal-input" maxlength="40" autocomplete="off" placeholder="Fresh Tomato" />
@@ -817,9 +817,7 @@
                     <span>Copy</span>
                   </button>
                 </div>
-                <p class="live-share-invite-help" id="live-share-invite-help">Click Start session to create a temporary room and generate an invite link.</p>
               </div>
-              <p class="share-modal-notice"><i class="bi bi-info-circle"></i> Live rooms are relayed in memory. Share the invite link with people you want to collaborate with.</p>
             </div>
             <div class="reset-modal-actions">
               <button class="reset-modal-btn reset-modal-cancel" id="live-share-end-btn" disabled>End live session</button>

--- a/index.html
+++ b/index.html
@@ -771,6 +771,29 @@
                 <label class="reset-modal-label" for="live-share-display-name">Display name</label>
                 <input type="text" id="live-share-display-name" class="rename-modal-input" maxlength="40" autocomplete="off" placeholder="Fresh Tomato" />
               </div>
+              <div class="live-share-access-control" id="live-share-access-control">
+                <div class="live-share-section-title">Access</div>
+                <div class="live-share-access-options" role="radiogroup" aria-label="Live Share access mode">
+                  <label class="live-share-access-option">
+                    <input type="radio" name="live-share-access-mode" value="edit" checked />
+                    <span class="live-share-access-option-copy">
+                      <span class="live-share-access-option-title">Can edit</span>
+                      <span class="live-share-access-option-desc">Collaborators can type and sync changes.</span>
+                    </span>
+                  </label>
+                  <label class="live-share-access-option">
+                    <input type="radio" name="live-share-access-mode" value="view" />
+                    <span class="live-share-access-option-copy">
+                      <span class="live-share-access-option-title">View only</span>
+                      <span class="live-share-access-option-desc">Collaborators can read updates without editing.</span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div class="live-share-access-status" id="live-share-access-status" hidden>
+                <span>Access: <strong id="live-share-access-label">Can edit</strong></span>
+                <span id="live-share-access-note">Collaborators can edit this document.</span>
+              </div>
               <div class="live-share-status" id="live-share-status" aria-live="polite">
                 <span class="live-share-status-dot" aria-hidden="true"></span>
                 <span id="live-share-status-text">No live room active</span>
@@ -793,7 +816,7 @@
                 </div>
                 <p class="live-share-invite-help" id="live-share-invite-help">Click Start session to create a temporary room and generate an invite link.</p>
               </div>
-              <p class="share-modal-notice"><i class="bi bi-info-circle"></i> Live rooms are relayed in memory. Everyone with the live link can edit while the room is active.</p>
+              <p class="share-modal-notice"><i class="bi bi-info-circle"></i> Live rooms are relayed in memory. Share the invite link with people you want to collaborate with.</p>
             </div>
             <div class="reset-modal-actions">
               <button class="reset-modal-btn reset-modal-cancel" id="live-share-end-btn" disabled>End live session</button>

--- a/index.html
+++ b/index.html
@@ -758,6 +758,23 @@
           </div>
         </div>
 
+        <div id="share-error-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="share-error-title" aria-hidden="true" style="display:none;">
+          <div class="reset-modal-box reset-modal-box--wide modal-box">
+            <div class="modal-header">
+              <p id="share-error-title" class="reset-modal-message">Share link failed</p>
+              <button type="button" class="modal-close-btn" id="share-error-close-icon" aria-label="Close share error dialog">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p id="share-error-message" class="share-modal-description">The share link could not be generated.</p>
+            </div>
+            <div class="reset-modal-actions">
+              <button class="reset-modal-btn reset-modal-cancel" id="share-error-close">Close</button>
+            </div>
+          </div>
+        </div>
+
         <!-- Live Share Modal -->
         <div id="live-share-modal" class="reset-modal-overlay modal-overlay" role="dialog" aria-modal="true" aria-labelledby="live-share-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide modal-box">

--- a/index.html
+++ b/index.html
@@ -716,6 +716,10 @@
             </div>
             <div class="modal-body">
               <p class="share-modal-description">Create a snapshot link for the active Markdown tab.</p>
+              <p class="share-modal-notice">
+                <i class="bi bi-info-circle"></i>
+                <span>Small snapshots stay encoded in the URL. Larger snapshots use a short Cloudflare KV link that expires after 90 days. Snapshot tabs are temporary and are not saved locally; anyone with the link can open the snapshot.</span>
+              </p>
               <div class="live-share-section-title">Access</div>
               <div class="share-mode-cards">
                 <label class="share-mode-card" id="share-card-view" for="share-mode-view">

--- a/index.html
+++ b/index.html
@@ -715,11 +715,7 @@
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Create a temporary snapshot link.</p>
-              <p class="share-modal-notice">
-                <i class="bi bi-info-circle"></i>
-                <span>Small links stay in the URL. Large links use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally.</span>
-              </p>
+              <p class="share-modal-description">Small links stay in the URL. Large links use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally.</p>
               <div class="live-share-section-title">Access</div>
               <div class="share-mode-cards">
                 <label class="share-mode-card" id="share-card-view" for="share-mode-view">

--- a/index.html
+++ b/index.html
@@ -715,7 +715,7 @@
               </button>
             </div>
             <div class="modal-body">
-              <p class="share-modal-description">Small documents stay encoded in the URL. Large documents use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally.</p>
+              <p class="share-modal-description">Small documents stay encoded in the URL. Large documents use temporary Cloudflare KV for 90 days. Shared tabs are not saved locally on the recipient's device.</p>
               <div class="live-share-section-title">Access</div>
               <div class="share-mode-cards">
                 <label class="share-mode-card" id="share-card-view" for="share-mode-view">

--- a/script.js
+++ b/script.js
@@ -11741,11 +11741,14 @@ document.addEventListener("DOMContentLoaded", async function () {
   const shareModalCloseX  = document.getElementById('share-modal-close-icon');
   const shareModalClose   = document.getElementById('share-modal-close');
   const shareUrlInput     = document.getElementById('share-url-input');
+  const shareGenerateBtn  = document.getElementById('share-generate-btn');
   const shareCopyBtn      = document.getElementById('share-copy-btn');
+  const shareInviteState  = document.getElementById('share-invite-state');
   const shareModeView     = document.getElementById('share-mode-view');
   const shareModeEdit     = document.getElementById('share-mode-edit');
   const shareCardView     = document.getElementById('share-card-view');
   const shareCardEdit     = document.getElementById('share-card-edit');
+  let generatedShareSnapshotUrl = '';
 
   function buildShareUrl(mode) {
     const markdownText = markdownEditor.value;
@@ -11789,21 +11792,39 @@ document.addEventListener("DOMContentLoaded", async function () {
     return getPublicAppBaseUrl() + '#' + getShareHashForMode(payload.id, mode);
   }
 
-  function updateShareUrlField() {
+  function setShareInviteState(text) {
+    if (shareInviteState) {
+      shareInviteState.textContent = text;
+    }
+  }
+
+  function resetShareSnapshotLink() {
+    generatedShareSnapshotUrl = '';
+    shareUrlInput.value = '';
+    shareUrlInput.placeholder = 'Click Share to create a snapshot link';
+    shareCopyBtn.disabled = true;
+    if (shareGenerateBtn) {
+      shareGenerateBtn.disabled = false;
+      shareGenerateBtn.innerHTML = '<i class="bi bi-share"></i><span>Share</span>';
+    }
+    if (shareCopyBtn) {
+      shareCopyBtn.innerHTML = '<i class="bi bi-clipboard"></i><span>Copy</span>';
+    }
+    setShareInviteState('Created after clicking Share');
+  }
+
+  async function createShareSnapshotLink() {
     const mode = getCurrentShareMode();
     const url = buildShareUrl(mode);
     if (!url) {
       shareUrlInput.value = 'Error generating link.';
       shareCopyBtn.disabled = true;
-      return;
+      throw new Error('Unable to create share link');
     }
     if (shouldUseServerShare(markdownEditor.value || '', url)) {
-      shareUrlInput.value = 'Short Cloudflare link will be created when copied.';
-      shareCopyBtn.disabled = false;
-    } else {
-      shareUrlInput.value = url;
-      shareCopyBtn.disabled = false;
+      return await createStoredShareUrl(mode);
     }
+    return url;
   }
 
   function openShareModal() {
@@ -11820,7 +11841,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     // Reset to view-only by default each time
     shareModeView.checked = true;
     syncShareCardStyles();
-    updateShareUrlField();
+    resetShareSnapshotLink();
     shareModal.style.display = '';
     requestAnimationFrame(() => {
       shareModal.classList.add('is-visible');
@@ -11849,52 +11870,60 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   shareModeView.addEventListener('change', function () {
     syncShareCardStyles();
-    updateShareUrlField();
+    resetShareSnapshotLink();
   });
   shareModeEdit.addEventListener('change', function () {
     syncShareCardStyles();
-    updateShareUrlField();
+    resetShareSnapshotLink();
   });
 
+  if (shareGenerateBtn) {
+    shareGenerateBtn.addEventListener('click', async function () {
+      if (shareGenerateBtn.disabled) return;
+      const originalHTML = shareGenerateBtn.innerHTML;
+      shareGenerateBtn.disabled = true;
+      shareCopyBtn.disabled = true;
+      shareGenerateBtn.innerHTML = '<i class="bi bi-hourglass-split"></i><span>Sharing...</span>';
+      shareUrlInput.value = 'Creating snapshot link...';
+      setShareInviteState('Creating link');
+      try {
+        const url = await createShareSnapshotLink();
+        generatedShareSnapshotUrl = url;
+        shareUrlInput.value = url;
+        shareCopyBtn.disabled = false;
+        setShareInviteState('Ready to copy');
+      } catch (error) {
+        console.error('Share link generation failed:', error);
+        generatedShareSnapshotUrl = '';
+        shareUrlInput.value = 'Failed to create share link.';
+        shareCopyBtn.disabled = true;
+        setShareInviteState('Link failed');
+        alert('Failed to create share link: ' + error.message);
+      } finally {
+        shareGenerateBtn.disabled = false;
+        shareGenerateBtn.innerHTML = originalHTML;
+      }
+    });
+  }
+
   shareCopyBtn.addEventListener('click', async function () {
-    if (shareCopyBtn.disabled) return;
-    const mode = getCurrentShareMode();
-    const legacyUrl = buildShareUrl(mode);
-
-    function onCopied() {
-      const orig = shareCopyBtn.innerHTML;
-      shareCopyBtn.innerHTML = '<i class="bi bi-check-lg"></i>';
-      setTimeout(() => { shareCopyBtn.innerHTML = orig; }, 2000);
-    }
-
+    if (shareCopyBtn.disabled || !generatedShareSnapshotUrl) return;
     const originalHTML = shareCopyBtn.innerHTML;
     shareCopyBtn.disabled = true;
     try {
-      let url = legacyUrl;
-      if (shouldUseServerShare(markdownEditor.value || '', legacyUrl)) {
-        shareCopyBtn.innerHTML = '<i class="bi bi-hourglass-split"></i>';
-        shareUrlInput.value = 'Saving snapshot to Cloudflare KV...';
-        url = await createStoredShareUrl(mode);
-      }
-      if (!url) {
-        throw new Error('Unable to create share link');
-      }
-      await copyTextToClipboard(url);
-      shareUrlInput.value = url;
-      const hashIndex = url.indexOf('#');
+      await copyTextToClipboard(generatedShareSnapshotUrl);
+      shareUrlInput.value = generatedShareSnapshotUrl;
+      const hashIndex = generatedShareSnapshotUrl.indexOf('#');
       if (hashIndex !== -1) {
-        window.location.hash = url.slice(hashIndex + 1);
+        window.location.hash = generatedShareSnapshotUrl.slice(hashIndex + 1);
       }
-      onCopied();
+      shareCopyBtn.innerHTML = '<i class="bi bi-check-lg"></i><span>Copied</span>';
+      setTimeout(() => { shareCopyBtn.innerHTML = originalHTML; }, 2000);
     } catch (error) {
       console.error('Share copy failed:', error);
-      alert('Failed to create share link: ' + error.message);
-      updateShareUrlField();
+      alert('Failed to copy share link: ' + error.message);
     } finally {
       shareCopyBtn.disabled = false;
-      if (shareCopyBtn.innerHTML.indexOf('hourglass') !== -1) {
-        shareCopyBtn.innerHTML = originalHTML;
-      }
     }
   });
 

--- a/script.js
+++ b/script.js
@@ -15844,7 +15844,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const modalAboutTitle = document.getElementById('about-modal-title');
     if (modalAboutTitle) modalAboutTitle.textContent = dict.aboutTitle;
     const modalShareTitle = document.getElementById('share-modal-title');
-    if (modalShareTitle) modalShareTitle.textContent = dict.shareTitle;
+    if (modalShareTitle) modalShareTitle.textContent = dict.shareSnapshot || 'Share Snapshot';
     const modalRenameTitle = document.getElementById('rename-modal-title');
     if (modalRenameTitle) modalRenameTitle.textContent = dict.renameTitle;
     const modalLinkTitle = document.getElementById('link-modal-title');

--- a/script.js
+++ b/script.js
@@ -286,6 +286,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     }));
   }
 
+  function isShareSnapshotActive() {
+    return Boolean(activeTabId && isShareSnapshotTabId(activeTabId));
+  }
+
   function stripTemporaryTabs(tabsArr) {
     return (tabsArr || []).filter(function(tab) {
       return !isShareSnapshotTab(tab);
@@ -296,6 +300,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!isShareSnapshotViewOnlyActive()) return false;
     alert('This shared snapshot is view only. The Markdown source cannot be downloaded or copied.');
     announceToScreenReader('This shared snapshot is view only.');
+    return true;
+  }
+
+  function blockTemporarySnapshotShare() {
+    if (!isShareSnapshotActive()) return false;
+    alert('Shared snapshot tabs are temporary and cannot be shared again.');
+    announceToScreenReader('Shared snapshot tabs cannot be shared again.');
     return true;
   }
 
@@ -11957,6 +11968,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function openShareModal() {
+    if (blockTemporarySnapshotShare()) return;
     // PERF-002: Lazy-load pako on first share
     if (typeof pako === 'undefined') {
       loadScript(CDN.pako).then(function() {
@@ -12305,6 +12317,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function updateLiveEditorAccess() {
     const snapshotViewOnly = isShareSnapshotViewOnlyActive();
+    const snapshotActive = isShareSnapshotActive();
     const viewOnly = isLiveViewOnlyParticipant() || snapshotViewOnly;
     if (markdownEditor) {
       markdownEditor.readOnly = viewOnly;
@@ -12355,6 +12368,32 @@ document.addEventListener("DOMContentLoaded", async function () {
       } else if (button.dataset.shareSnapshotSourceDisabled === 'true') {
         const originalTitle = button.dataset.shareSnapshotOriginalTitle || '';
         delete button.dataset.shareSnapshotSourceDisabled;
+        delete button.dataset.shareSnapshotOriginalTitle;
+        button.disabled = false;
+        button.classList.remove('disabled');
+        button.setAttribute('aria-disabled', 'false');
+        if (originalTitle) {
+          button.setAttribute('title', originalTitle);
+        } else {
+          button.removeAttribute('title');
+        }
+      }
+    });
+
+    [shareButton, mobileShareButton].forEach(function(button) {
+      if (!button) return;
+      if (snapshotActive) {
+        if (button.dataset.shareSnapshotReshareDisabled !== 'true') {
+          button.dataset.shareSnapshotOriginalTitle = button.getAttribute('title') || '';
+        }
+        button.dataset.shareSnapshotReshareDisabled = 'true';
+        button.disabled = true;
+        button.classList.add('disabled');
+        button.setAttribute('aria-disabled', 'true');
+        button.title = 'Shared snapshot tabs cannot be shared again';
+      } else if (button.dataset.shareSnapshotReshareDisabled === 'true') {
+        const originalTitle = button.dataset.shareSnapshotOriginalTitle || '';
+        delete button.dataset.shareSnapshotReshareDisabled;
         delete button.dataset.shareSnapshotOriginalTitle;
         button.disabled = false;
         button.classList.remove('disabled');

--- a/script.js
+++ b/script.js
@@ -310,6 +310,17 @@ document.addEventListener("DOMContentLoaded", async function () {
     return true;
   }
 
+  function isLiveShareDocumentActive() {
+    return Boolean(liveCollaboration && activeTabId === liveCollaboration.tabId);
+  }
+
+  function blockLiveDocumentShareSnapshot() {
+    if (!isLiveShareDocumentActive()) return false;
+    alert('Live Share documents cannot be shared as snapshots.');
+    announceToScreenReader('Live Share documents cannot be shared as snapshots.');
+    return true;
+  }
+
   function blockTemporarySnapshotLiveShare() {
     if (!isShareSnapshotActive()) return false;
     alert('Shared snapshot tabs are temporary and cannot start Live Share.');
@@ -11976,6 +11987,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function openShareModal() {
     if (blockTemporarySnapshotShare()) return;
+    if (blockLiveDocumentShareSnapshot()) return;
     // PERF-002: Lazy-load pako on first share
     if (typeof pako === 'undefined') {
       loadScript(CDN.pako).then(function() {
@@ -12325,6 +12337,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   function updateLiveEditorAccess() {
     const snapshotViewOnly = isShareSnapshotViewOnlyActive();
     const snapshotActive = isShareSnapshotActive();
+    const liveShareDocumentActive = isLiveShareDocumentActive();
     const viewOnly = isLiveViewOnlyParticipant() || snapshotViewOnly;
     if (markdownEditor) {
       markdownEditor.readOnly = viewOnly;
@@ -12389,7 +12402,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     [shareButton, mobileShareButton].forEach(function(button) {
       if (!button) return;
-      if (snapshotActive) {
+      if (snapshotActive || liveShareDocumentActive) {
         if (button.dataset.shareSnapshotReshareDisabled !== 'true') {
           button.dataset.shareSnapshotOriginalTitle = button.getAttribute('title') || '';
         }

--- a/script.js
+++ b/script.js
@@ -310,6 +310,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     return true;
   }
 
+  function blockTemporarySnapshotLiveShare() {
+    if (!isShareSnapshotActive()) return false;
+    alert('Shared snapshot tabs are temporary and cannot start Live Share.');
+    announceToScreenReader('Shared snapshot tabs cannot start Live Share.');
+    return true;
+  }
+
   function getEditorReadOnlyMessage() {
     if (isShareSnapshotViewOnlyActive()) {
       return 'This shared snapshot is view only.';
@@ -12406,6 +12413,32 @@ document.addEventListener("DOMContentLoaded", async function () {
       }
     });
 
+    [liveShareButton, mobileLiveShareButton].forEach(function(button) {
+      if (!button) return;
+      if (snapshotActive) {
+        if (button.dataset.shareSnapshotLiveDisabled !== 'true') {
+          button.dataset.shareSnapshotOriginalTitle = button.getAttribute('title') || '';
+        }
+        button.dataset.shareSnapshotLiveDisabled = 'true';
+        button.disabled = true;
+        button.classList.add('disabled');
+        button.setAttribute('aria-disabled', 'true');
+        button.title = 'Shared snapshot tabs cannot start Live Share';
+      } else if (button.dataset.shareSnapshotLiveDisabled === 'true') {
+        const originalTitle = button.dataset.shareSnapshotOriginalTitle || '';
+        delete button.dataset.shareSnapshotLiveDisabled;
+        delete button.dataset.shareSnapshotOriginalTitle;
+        button.disabled = false;
+        button.classList.remove('disabled');
+        button.setAttribute('aria-disabled', 'false');
+        if (originalTitle) {
+          button.setAttribute('title', originalTitle);
+        } else {
+          button.removeAttribute('title');
+        }
+      }
+    });
+
     if (markdownFormatToolbar) {
       markdownFormatToolbar.classList.toggle('is-live-view-only', viewOnly);
       markdownFormatToolbar.querySelectorAll('[data-md-action]').forEach(function(button) {
@@ -13760,6 +13793,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function openLiveShareModal() {
     if (!liveShareModal) return;
+    if (blockTemporarySnapshotLiveShare()) return;
     if (liveShareDisplayName && !liveShareDisplayName.value) {
       liveShareDisplayName.value = getOrCreateGeneratedLiveName();
     }

--- a/script.js
+++ b/script.js
@@ -198,6 +198,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   // View Mode State - Story 1.1
   let currentViewMode = 'split'; // 'editor', 'split', or 'preview'
+  const shareSnapshotViewOnlyTabIds = new Set();
   const APP_VERSION = '3.8.1';
   let activeModal = null;
   let lastFocusedElement = null;
@@ -269,6 +270,30 @@ document.addEventListener("DOMContentLoaded", async function () {
   let isResizing = false;
   let editorWidthPercent = 50; // Default 50%
   const MIN_PANE_PERCENT = 20; // Minimum 20% width
+
+  function isShareSnapshotViewOnlyActive() {
+    return Boolean(activeTabId && shareSnapshotViewOnlyTabIds.has(activeTabId));
+  }
+
+  function getEditorReadOnlyMessage() {
+    if (isShareSnapshotViewOnlyActive()) {
+      return 'This shared snapshot is view only.';
+    }
+    if (isLiveViewOnlyParticipant()) {
+      return 'This Live Share session is view only.';
+    }
+    return 'This document is read only.';
+  }
+
+  function applyShareSnapshotAccessMode(mode) {
+    if (!activeTabId) return;
+    if (mode === 'view') {
+      shareSnapshotViewOnlyTabIds.add(activeTabId);
+    } else {
+      shareSnapshotViewOnlyTabIds.delete(activeTabId);
+    }
+    updateLiveEditorAccess();
+  }
 
   const mobileMenuToggle    = document.getElementById("mobile-menu-toggle");
   const mobileMenuPanel     = document.getElementById("mobile-menu-panel");
@@ -4940,6 +4965,10 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   // View Mode Functions - Story 1.1 & 1.2
   function setViewMode(mode) {
+    if (isShareSnapshotViewOnlyActive() && mode !== 'preview') {
+      mode = 'preview';
+      announceToScreenReader(getEditorReadOnlyMessage());
+    }
     if (mode === currentViewMode) return;
 
     const previousMode = currentViewMode;
@@ -9084,7 +9113,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function runMarkdownTool(action, button) {
     if (!canMutateEditor() && isLiveMutatingAction(action)) {
-      announceToScreenReader('This Live Share session is view only.');
+      announceToScreenReader(getEditorReadOnlyMessage());
       return;
     }
     if (action === 'undo') {
@@ -9427,16 +9456,19 @@ document.addEventListener("DOMContentLoaded", async function () {
   });
 
   markdownEditor.addEventListener("input", function(e) {
-    if (!canMutateEditor() && liveCollaboration && !liveCollaboration.isApplyingRemoteChange) {
-      const restoredMarkdown = liveCollaboration.lastMarkdown || '';
+    if (!canMutateEditor() && (!liveCollaboration || !liveCollaboration.isApplyingRemoteChange)) {
+      const activeTab = tabs.find(function(tab) { return tab.id === activeTabId; });
+      const restoredMarkdown = liveCollaboration
+        ? (liveCollaboration.lastMarkdown || '')
+        : (activeTab && typeof activeTab.content === 'string' ? activeTab.content : markdownEditor.value || '');
       if (markdownEditor.value !== restoredMarkdown) {
         markdownEditor.value = restoredMarkdown;
         lastPushedValue = restoredMarkdown;
-        renderMarkdown({ reason: 'live-readonly-restore', force: true });
+        renderMarkdown({ reason: 'readonly-restore', force: true });
         updateDocumentStats();
         scheduleLineNumberUpdate({ force: true });
       }
-      announceToScreenReader('This Live Share session is view only.');
+      announceToScreenReader(getEditorReadOnlyMessage());
       return;
     }
     handleKeystrokeHistory(e);
@@ -9465,7 +9497,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   markdownEditor.addEventListener('beforeinput', function(e) {
     if (!canMutateEditor()) {
       e.preventDefault();
-      announceToScreenReader('This Live Share session is view only.');
+      announceToScreenReader(getEditorReadOnlyMessage());
     }
   });
 
@@ -12168,7 +12200,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function canMutateEditor() {
-    return !isLiveViewOnlyParticipant();
+    return !isLiveViewOnlyParticipant() && !isShareSnapshotViewOnlyActive();
   }
 
   function isLiveMutatingAction(action) {
@@ -12202,13 +12234,42 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function updateLiveEditorAccess() {
-    const viewOnly = isLiveViewOnlyParticipant();
+    const snapshotViewOnly = isShareSnapshotViewOnlyActive();
+    const viewOnly = isLiveViewOnlyParticipant() || snapshotViewOnly;
     if (markdownEditor) {
       markdownEditor.readOnly = viewOnly;
       markdownEditor.setAttribute('aria-readonly', viewOnly ? 'true' : 'false');
       markdownEditor.classList.toggle('live-share-readonly-editor', viewOnly);
-      markdownEditor.title = viewOnly ? 'Live Share is view only. You can read updates but cannot edit this document.' : '';
+      markdownEditor.title = viewOnly ? getEditorReadOnlyMessage() : '';
     }
+
+    viewModeButtons.forEach(function(button) {
+      const mode = button.getAttribute('data-view-mode');
+      const shouldDisable = snapshotViewOnly && mode !== 'preview';
+      if (shouldDisable) {
+        button.dataset.shareSnapshotDisabled = 'true';
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+      } else if (button.dataset.shareSnapshotDisabled === 'true') {
+        delete button.dataset.shareSnapshotDisabled;
+        button.disabled = false;
+        button.setAttribute('aria-disabled', 'false');
+      }
+    });
+
+    mobileViewModeButtons.forEach(function(button) {
+      const mode = button.getAttribute('data-mode');
+      const shouldDisable = snapshotViewOnly && mode !== 'preview';
+      if (shouldDisable) {
+        button.dataset.shareSnapshotDisabled = 'true';
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+      } else if (button.dataset.shareSnapshotDisabled === 'true') {
+        delete button.dataset.shareSnapshotDisabled;
+        button.disabled = false;
+        button.setAttribute('aria-disabled', 'false');
+      }
+    });
 
     if (markdownFormatToolbar) {
       markdownFormatToolbar.classList.toggle('is-live-view-only', viewOnly);
@@ -13766,8 +13827,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     const rest = hash.slice('#id='.length);
     const ampIdx = rest.indexOf('&');
     const id = decodeURIComponent(ampIdx === -1 ? rest : rest.slice(0, ampIdx));
-    const params = ampIdx === -1 ? '' : rest.slice(ampIdx + 1);
-    const isEdit = params.split('&').includes('edit=1');
 
     if (!SERVER_SHARE_ID_PATTERN.test(id)) return;
 
@@ -13786,10 +13845,12 @@ document.addEventListener("DOMContentLoaded", async function () {
         return;
       }
 
+      const shareMode = payload && payload.mode === 'edit' ? 'edit' : 'view';
       markdownEditor.value = payload && typeof payload.content === 'string' ? payload.content : '';
+      applyShareSnapshotAccessMode(shareMode);
       renderMarkdown({ reason: 'document-load', showSkeleton: true });
+      setViewMode(shareMode === 'edit' ? 'split' : 'preview');
       saveCurrentTabState();
-      setViewMode(isEdit || (payload && payload.mode === 'edit') ? 'split' : 'preview');
     } catch (e) {
       console.error('Failed to load stored shared content:', e);
       alert('Network error while loading shared content.');
@@ -13826,11 +13887,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!encoded) return;
     try {
       const decoded = decodeMarkdownFromShare(encoded);
+      const shareMode = isEdit ? 'edit' : 'view';
       markdownEditor.value = decoded;
+      applyShareSnapshotAccessMode(shareMode);
       renderMarkdown({ reason: 'document-load', showSkeleton: true });
-      saveCurrentTabState();
       // Apply the correct view mode: edit=1 → split, default → preview only
-      setViewMode(isEdit ? 'split' : 'preview');
+      setViewMode(shareMode === 'edit' ? 'split' : 'preview');
+      saveCurrentTabState();
     } catch (e) {
       console.error("Failed to load shared content:", e);
       alert("The shared URL could not be decoded. It may be corrupted or incomplete.");
@@ -13898,7 +13961,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const isCmdOrCtrl = e.ctrlKey || e.metaKey;
       if (!canMutateEditor() && isCmdOrCtrl && ['z', 'y'].indexOf(e.key.toLowerCase()) !== -1) {
         e.preventDefault();
-        announceToScreenReader('This Live Share session is view only.');
+        announceToScreenReader(getEditorReadOnlyMessage());
         return;
       }
       if (isCmdOrCtrl && !e.shiftKey && e.key.toLowerCase() === 'z') {

--- a/script.js
+++ b/script.js
@@ -11740,6 +11740,10 @@ document.addEventListener("DOMContentLoaded", async function () {
   const shareModal        = document.getElementById('share-modal');
   const shareModalCloseX  = document.getElementById('share-modal-close-icon');
   const shareModalClose   = document.getElementById('share-modal-close');
+  const shareErrorModal   = document.getElementById('share-error-modal');
+  const shareErrorMessage = document.getElementById('share-error-message');
+  const shareErrorClose   = document.getElementById('share-error-close');
+  const shareErrorCloseX  = document.getElementById('share-error-close-icon');
   const shareInviteSection = document.getElementById('share-invite-section');
   const shareUrlInput     = document.getElementById('share-url-input');
   const shareGenerateBtn  = document.getElementById('share-generate-btn');
@@ -11796,6 +11800,20 @@ document.addEventListener("DOMContentLoaded", async function () {
   function setShareInviteState(text) {
     if (shareInviteState) {
       shareInviteState.textContent = text;
+    }
+  }
+
+  function showShareErrorModal(message) {
+    if (shareErrorMessage) {
+      shareErrorMessage.textContent = message || 'The share link could not be generated.';
+    }
+    if (shareErrorModal) {
+      openAppModal(shareErrorModal, {
+        focusTarget: shareErrorClose,
+        onClose: function() {
+          closeAppModal(shareErrorModal);
+        }
+      });
     }
   }
 
@@ -11909,8 +11927,11 @@ document.addEventListener("DOMContentLoaded", async function () {
         generatedShareSnapshotUrl = '';
         shareUrlInput.value = 'Failed to create share link.';
         shareCopyBtn.disabled = true;
+        if (shareInviteSection) {
+          shareInviteSection.dataset.state = 'error';
+        }
         setShareInviteState('Link failed');
-        alert('Failed to create share link: ' + error.message);
+        showShareErrorModal('Failed to create share link: ' + error.message);
       } finally {
         shareGenerateBtn.disabled = false;
         shareGenerateBtn.innerHTML = originalHTML;
@@ -11944,6 +11965,16 @@ document.addEventListener("DOMContentLoaded", async function () {
   shareModal.addEventListener('click', function (e) {
     if (e.target === shareModal) closeShareModal();
   });
+  if (shareErrorClose) {
+    shareErrorClose.addEventListener('click', function() {
+      closeAppModal(shareErrorModal);
+    });
+  }
+  if (shareErrorCloseX) {
+    shareErrorCloseX.addEventListener('click', function() {
+      closeAppModal(shareErrorModal);
+    });
+  }
 
   // ============================================
   // Live Share (Yjs CRDT + Cloudflare room WebSocket)

--- a/script.js
+++ b/script.js
@@ -11740,6 +11740,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const shareModal        = document.getElementById('share-modal');
   const shareModalCloseX  = document.getElementById('share-modal-close-icon');
   const shareModalClose   = document.getElementById('share-modal-close');
+  const shareInviteSection = document.getElementById('share-invite-section');
   const shareUrlInput     = document.getElementById('share-url-input');
   const shareGenerateBtn  = document.getElementById('share-generate-btn');
   const shareCopyBtn      = document.getElementById('share-copy-btn');
@@ -11801,16 +11802,20 @@ document.addEventListener("DOMContentLoaded", async function () {
   function resetShareSnapshotLink() {
     generatedShareSnapshotUrl = '';
     shareUrlInput.value = '';
-    shareUrlInput.placeholder = 'Click Share to create a snapshot link';
+    shareUrlInput.placeholder = 'Share link appears here';
     shareCopyBtn.disabled = true;
+    if (shareInviteSection) {
+      shareInviteSection.hidden = true;
+      delete shareInviteSection.dataset.state;
+    }
     if (shareGenerateBtn) {
       shareGenerateBtn.disabled = false;
-      shareGenerateBtn.innerHTML = '<i class="bi bi-share"></i><span>Share</span>';
+      shareGenerateBtn.textContent = 'Share';
     }
     if (shareCopyBtn) {
       shareCopyBtn.innerHTML = '<i class="bi bi-clipboard"></i><span>Copy</span>';
     }
-    setShareInviteState('Created after clicking Share');
+    setShareInviteState('Ready to copy');
   }
 
   async function createShareSnapshotLink() {
@@ -11883,7 +11888,11 @@ document.addEventListener("DOMContentLoaded", async function () {
       const originalHTML = shareGenerateBtn.innerHTML;
       shareGenerateBtn.disabled = true;
       shareCopyBtn.disabled = true;
-      shareGenerateBtn.innerHTML = '<i class="bi bi-hourglass-split"></i><span>Sharing...</span>';
+      shareGenerateBtn.textContent = 'Sharing...';
+      if (shareInviteSection) {
+        shareInviteSection.hidden = false;
+        shareInviteSection.dataset.state = 'active';
+      }
       shareUrlInput.value = 'Creating snapshot link...';
       setShareInviteState('Creating link');
       try {
@@ -11891,6 +11900,9 @@ document.addEventListener("DOMContentLoaded", async function () {
         generatedShareSnapshotUrl = url;
         shareUrlInput.value = url;
         shareCopyBtn.disabled = false;
+        if (shareInviteSection) {
+          shareInviteSection.dataset.state = 'active';
+        }
         setShareInviteState('Ready to copy');
       } catch (error) {
         console.error('Share link generation failed:', error);

--- a/script.js
+++ b/script.js
@@ -12004,10 +12004,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     try {
       await copyTextToClipboard(generatedShareSnapshotUrl);
       shareUrlInput.value = generatedShareSnapshotUrl;
-      const hashIndex = generatedShareSnapshotUrl.indexOf('#');
-      if (hashIndex !== -1) {
-        window.location.hash = generatedShareSnapshotUrl.slice(hashIndex + 1);
-      }
       shareCopyBtn.innerHTML = '<i class="bi bi-check-lg"></i><span>Copied</span>';
       setTimeout(() => { shareCopyBtn.innerHTML = originalHTML; }, 2000);
     } catch (error) {

--- a/script.js
+++ b/script.js
@@ -199,6 +199,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   // View Mode State - Story 1.1
   let currentViewMode = 'split'; // 'editor', 'split', or 'preview'
   const shareSnapshotViewOnlyTabIds = new Set();
+  const SHARE_SNAPSHOT_TAB_KIND = 'share-snapshot';
   const APP_VERSION = '3.8.1';
   let activeModal = null;
   let lastFocusedElement = null;
@@ -275,6 +276,29 @@ document.addEventListener("DOMContentLoaded", async function () {
     return Boolean(activeTabId && shareSnapshotViewOnlyTabIds.has(activeTabId));
   }
 
+  function isShareSnapshotTab(tab) {
+    return Boolean(tab && tab.kind === SHARE_SNAPSHOT_TAB_KIND);
+  }
+
+  function isShareSnapshotTabId(tabId) {
+    return Boolean(tabs.find(function(tab) {
+      return tab.id === tabId && isShareSnapshotTab(tab);
+    }));
+  }
+
+  function stripTemporaryTabs(tabsArr) {
+    return (tabsArr || []).filter(function(tab) {
+      return !isShareSnapshotTab(tab);
+    });
+  }
+
+  function blockShareSnapshotSourceAccess() {
+    if (!isShareSnapshotViewOnlyActive()) return false;
+    alert('This shared snapshot is view only. The Markdown source cannot be downloaded or copied.');
+    announceToScreenReader('This shared snapshot is view only.');
+    return true;
+  }
+
   function getEditorReadOnlyMessage() {
     if (isShareSnapshotViewOnlyActive()) {
       return 'This shared snapshot is view only.';
@@ -287,6 +311,10 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function applyShareSnapshotAccessMode(mode) {
     if (!activeTabId) return;
+    const tab = tabs.find(function(t) { return t.id === activeTabId; });
+    if (tab && isShareSnapshotTab(tab)) {
+      tab.shareSnapshotMode = mode === 'edit' ? 'edit' : 'view';
+    }
     if (mode === 'view') {
       shareSnapshotViewOnlyTabIds.add(activeTabId);
     } else {
@@ -2145,7 +2173,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function loadTabsFromStorage() {
     try {
-      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      return stripTemporaryTabs(JSON.parse(localStorage.getItem(STORAGE_KEY)) || []);
     } catch (e) {
       return [];
     }
@@ -2161,7 +2189,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function getTabsForStorage(tabsArr) {
-    const sourceTabs = tabsArr || tabs;
+    const sourceTabs = stripTemporaryTabs(tabsArr || tabs);
     if (!liveCollaboration) {
       return sourceTabs;
     }
@@ -2203,6 +2231,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function saveActiveTabId(id) {
+    if (isShareSnapshotTabId(id)) return;
     saveStorageItem(ACTIVE_TAB_KEY, id);
   }
 
@@ -2269,6 +2298,11 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function runTabMenuAction(tabId, action, isMobileMenu) {
+    const tab = tabs.find(function(t) { return t.id === tabId; });
+    if (isShareSnapshotTab(tab) && action === 'duplicate') {
+      alert('Shared snapshot tabs are temporary and cannot be duplicated.');
+      return;
+    }
     if (action === 'rename') {
       if (isMobileMenu) closeMobileMenu();
       renameTab(tabId);
@@ -2302,10 +2336,14 @@ document.addEventListener("DOMContentLoaded", async function () {
     dropdown.className = 'tab-menu-dropdown';
     dropdown.setAttribute('data-tab-menu-dropdown', 'true');
     dropdown.setAttribute('role', 'menu');
+    const duplicateAction = isShareSnapshotTab(tab)
+      ? ''
+      : '<button type="button" class="tab-menu-item" role="menuitem" data-action="duplicate"><i class="bi bi-files"></i> Duplicate</button>';
+    const closeLabel = isShareSnapshotTab(tab) ? 'Close' : 'Delete';
     dropdown.innerHTML =
       '<button type="button" class="tab-menu-item" role="menuitem" data-action="rename"><i class="bi bi-pencil"></i> Rename</button>' +
-      '<button type="button" class="tab-menu-item" role="menuitem" data-action="duplicate"><i class="bi bi-files"></i> Duplicate</button>' +
-      '<button type="button" class="tab-menu-item tab-menu-item-danger" role="menuitem" data-action="delete"><i class="bi bi-trash"></i> Delete</button>';
+      duplicateAction +
+      '<button type="button" class="tab-menu-item tab-menu-item-danger" role="menuitem" data-action="delete"><i class="bi bi-trash"></i> ' + closeLabel + '</button>';
 
     menuBtn.addEventListener('click', function(e) {
       e.preventDefault();
@@ -2677,6 +2715,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     const idx = tabs.findIndex(function(t) { return t.id === tabId; });
     if (idx === -1) return;
+    shareSnapshotViewOnlyTabIds.delete(tabId);
     
     // Clean up history of the closed tab
     if (tabHistories[tabId]) {
@@ -2768,6 +2807,10 @@ document.addEventListener("DOMContentLoaded", async function () {
   function duplicateTab(tabId) {
     const tab = tabs.find(function(t) { return t.id === tabId; });
     if (!tab) return;
+    if (isShareSnapshotTab(tab)) {
+      alert('Shared snapshot tabs are temporary and cannot be duplicated.');
+      return;
+    }
     if (tabs.length >= 20) {
       alert('Maximum of 20 tabs reached. Please close an existing tab to open a new one.');
       return;
@@ -9720,6 +9763,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   });
 
   exportMd.addEventListener("click", function () {
+    if (blockShareSnapshotSourceAccess()) return;
     if (typeof Neutralino !== 'undefined') {
       nativeSaveMarkdown();
       return;
@@ -11652,6 +11696,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   });
 
   copyMarkdownButton.addEventListener("click", function () {
+    if (blockShareSnapshotSourceAccess()) return;
     try {
       const markdownText = markdownEditor.value;
       copyToClipboard(markdownText);
@@ -11769,6 +11814,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       return false;
     }
     const snapshotTab = createTab(typeof content === 'string' ? content : '', getSafeShareSnapshotTitle(title), viewMode);
+    snapshotTab.kind = SHARE_SNAPSHOT_TAB_KIND;
+    snapshotTab.temporary = true;
+    snapshotTab.shareSnapshotMode = shareMode;
     tabs.push(snapshotTab);
     switchTab(snapshotTab.id);
     applyShareSnapshotAccessMode(shareMode);
@@ -12290,6 +12338,32 @@ document.addEventListener("DOMContentLoaded", async function () {
         delete button.dataset.shareSnapshotDisabled;
         button.disabled = false;
         button.setAttribute('aria-disabled', 'false');
+      }
+    });
+
+    [exportMd, mobileExportMd, copyMarkdownButton, mobileCopyMarkdown].forEach(function(button) {
+      if (!button) return;
+      if (snapshotViewOnly) {
+        if (button.dataset.shareSnapshotSourceDisabled !== 'true') {
+          button.dataset.shareSnapshotOriginalTitle = button.getAttribute('title') || '';
+        }
+        button.dataset.shareSnapshotSourceDisabled = 'true';
+        button.disabled = true;
+        button.classList.add('disabled');
+        button.setAttribute('aria-disabled', 'true');
+        button.title = 'Markdown source is unavailable for view-only snapshots';
+      } else if (button.dataset.shareSnapshotSourceDisabled === 'true') {
+        const originalTitle = button.dataset.shareSnapshotOriginalTitle || '';
+        delete button.dataset.shareSnapshotSourceDisabled;
+        delete button.dataset.shareSnapshotOriginalTitle;
+        button.disabled = false;
+        button.classList.remove('disabled');
+        button.setAttribute('aria-disabled', 'false');
+        if (originalTitle) {
+          button.setAttribute('title', originalTitle);
+        } else {
+          button.removeAttribute('title');
+        }
       }
     });
 

--- a/script.js
+++ b/script.js
@@ -12397,7 +12397,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         button.disabled = true;
         button.classList.add('disabled');
         button.setAttribute('aria-disabled', 'true');
-        button.title = 'Shared snapshot tabs cannot be shared again';
+        button.title = 'Share Snapshot';
       } else if (button.dataset.shareSnapshotReshareDisabled === 'true') {
         const originalTitle = button.dataset.shareSnapshotOriginalTitle || '';
         delete button.dataset.shareSnapshotReshareDisabled;
@@ -12423,7 +12423,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         button.disabled = true;
         button.classList.add('disabled');
         button.setAttribute('aria-disabled', 'true');
-        button.title = 'Shared snapshot tabs cannot start Live Share';
+        button.title = 'Live Share';
       } else if (button.dataset.shareSnapshotLiveDisabled === 'true') {
         const originalTitle = button.dataset.shareSnapshotOriginalTitle || '';
         delete button.dataset.shareSnapshotLiveDisabled;

--- a/script.js
+++ b/script.js
@@ -2097,9 +2097,16 @@ document.addEventListener("DOMContentLoaded", async function () {
   let saveTabStateTimeout = null;
   let untitledCounter = 0;
   let liveCollaboration = null;
+  let liveShareUiReady = false;
   let liveCollaborationModulesPromise = null;
   const LIVE_EDIT_ORIGIN = Symbol("markdown-viewer-live-local-edit");
   const LIVE_RELAY_ORIGIN = Symbol("markdown-viewer-live-relay");
+
+  function refreshLiveEditorUi() {
+    if (!liveShareUiReady) return;
+    updateLiveAccessDisplay();
+    updateLiveEditorAccess();
+  }
 
   function getExportFilename(extension, fallback) {
     const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
@@ -2610,6 +2617,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     updateUndoRedoButtons();
     
     restoreViewMode(tab.viewMode);
+    refreshLiveEditorUi();
     renderMarkdown();
     requestAnimationFrame(function() {
       markdownEditor.scrollTop = tab.scrollPos || 0;
@@ -2659,6 +2667,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       saveActiveTabId(activeTabId);
       markdownEditor.value = '';
       restoreViewMode('split');
+      refreshLiveEditorUi();
       renderMarkdown();
     } else if (activeTabId === tabId) {
       const newIdx = Math.max(0, idx - 1);
@@ -2667,6 +2676,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const newActiveTab = tabs[newIdx];
       markdownEditor.value = newActiveTab.content;
       restoreViewMode(newActiveTab.viewMode);
+      refreshLiveEditorUi();
       renderMarkdown();
       requestAnimationFrame(function() {
         markdownEditor.scrollTop = newActiveTab.scrollPos || 0;
@@ -2770,6 +2780,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       saveTabsToStorage(tabs);
       markdownEditor.value = sampleMarkdown;
       restoreViewMode('split');
+      refreshLiveEditorUi();
       renderMarkdown();
       renderTabBar(tabs, activeTabId);
     }
@@ -2822,6 +2833,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     initTabHistory(activeTabId, activeTab.content);
     updateUndoRedoButtons();
     restoreViewMode(activeTab.viewMode);
+    refreshLiveEditorUi();
     renderMarkdown();
     const editorPane = document.querySelector('.editor-pane');
     if (editorPane) {
@@ -5015,6 +5027,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function replaceEditorRange(start, end, replacement, selectStart, selectEnd) {
+    if (!canMutateEditor()) return;
     pushProgrammaticHistoryState();
     markdownEditor.focus();
     markdownEditor.setRangeText(replacement, start, end, 'end');
@@ -5173,6 +5186,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function handleListEnter(e) {
+    if (!canMutateEditor()) return false;
     if (e.key !== 'Enter' || e.shiftKey || markdownEditor.selectionStart !== markdownEditor.selectionEnd) {
       return false;
     }
@@ -5368,6 +5382,15 @@ document.addEventListener("DOMContentLoaded", async function () {
     const undoBtn = document.querySelector('[data-md-action="undo"]');
     const redoBtn = document.querySelector('[data-md-action="redo"]');
     if (!undoBtn || !redoBtn) return;
+    if (!canMutateEditor()) {
+      undoBtn.disabled = true;
+      redoBtn.disabled = true;
+      undoBtn.classList.add('disabled');
+      redoBtn.classList.add('disabled');
+      undoBtn.setAttribute('aria-disabled', 'true');
+      redoBtn.setAttribute('aria-disabled', 'true');
+      return;
+    }
     
     const tabId = activeTabId;
     const hist = getOrCreateTabHistory(tabId);
@@ -5383,6 +5406,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function executeUndo() {
+    if (!canMutateEditor()) return;
     if (typingTimeout) {
       clearTimeout(typingTimeout);
       typingTimeout = null;
@@ -5436,6 +5460,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function executeRedo() {
+    if (!canMutateEditor()) return;
     if (typingTimeout) {
       clearTimeout(typingTimeout);
       typingTimeout = null;
@@ -9058,6 +9083,10 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function runMarkdownTool(action, button) {
+    if (!canMutateEditor() && isLiveMutatingAction(action)) {
+      announceToScreenReader('This Live Share session is view only.');
+      return;
+    }
     if (action === 'undo') {
       executeUndo();
       return;
@@ -9398,6 +9427,18 @@ document.addEventListener("DOMContentLoaded", async function () {
   });
 
   markdownEditor.addEventListener("input", function(e) {
+    if (!canMutateEditor() && liveCollaboration && !liveCollaboration.isApplyingRemoteChange) {
+      const restoredMarkdown = liveCollaboration.lastMarkdown || '';
+      if (markdownEditor.value !== restoredMarkdown) {
+        markdownEditor.value = restoredMarkdown;
+        lastPushedValue = restoredMarkdown;
+        renderMarkdown({ reason: 'live-readonly-restore', force: true });
+        updateDocumentStats();
+        scheduleLineNumberUpdate({ force: true });
+      }
+      announceToScreenReader('This Live Share session is view only.');
+      return;
+    }
     handleKeystrokeHistory(e);
     if (liveCollaboration && liveCollaboration.tabId === activeTabId && !liveCollaboration.isApplyingRemoteChange) {
       syncLiveLocalEditorChange(liveCollaboration.lastMarkdown || '', markdownEditor.value || '');
@@ -9421,6 +9462,12 @@ document.addEventListener("DOMContentLoaded", async function () {
   markdownEditor.addEventListener('mousedown', updateLastCursor);
   markdownEditor.addEventListener('mouseup', updateLastCursor);
   markdownEditor.addEventListener('focus', updateLastCursor);
+  markdownEditor.addEventListener('beforeinput', function(e) {
+    if (!canMutateEditor()) {
+      e.preventDefault();
+      announceToScreenReader('This Live Share session is view only.');
+    }
+  });
 
   initMarkdownFormatToolbar();
   initFindReplaceModal();
@@ -9428,6 +9475,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   
   // Editor key handlers for list continuation and indentation
   markdownEditor.addEventListener("keydown", function(e) {
+    if (!canMutateEditor()) return;
     if (handleListEnter(e)) {
       return;
     }
@@ -11863,6 +11911,9 @@ document.addEventListener("DOMContentLoaded", async function () {
   const LIVE_SHARE_AVATAR_LIMIT = 4;
   const LIVE_SHARE_PARTICIPANT_STALE_MS = 45000;
   const LIVE_SHARE_JOIN_TIMEOUT_MS = 8000;
+  const LIVE_SHARE_ACCESS_EDIT = 'edit';
+  const LIVE_SHARE_ACCESS_VIEW = 'view';
+  const LIVE_SHARE_NON_MUTATING_ACTIONS = ['fullscreen', 'find', 'help', 'info'];
   const LIVE_SHARE_ADJECTIVES = [
     'Acidic',
     'Awesome',
@@ -11913,6 +11964,11 @@ document.addEventListener("DOMContentLoaded", async function () {
   const liveShareStatusText   = document.getElementById('live-share-status-text');
   const liveShareParticipants = document.getElementById('live-share-participants');
   const liveShareActiveBadge  = document.getElementById('live-share-active-badge');
+  const liveShareAccessControl = document.getElementById('live-share-access-control');
+  const liveShareAccessRadios = document.querySelectorAll('input[name="live-share-access-mode"]');
+  const liveShareAccessStatus = document.getElementById('live-share-access-status');
+  const liveShareAccessLabel  = document.getElementById('live-share-access-label');
+  const liveShareAccessNote   = document.getElementById('live-share-access-note');
   const liveShareInviteSection = document.getElementById('live-share-invite-section');
   const liveShareInviteState  = document.getElementById('live-share-invite-state');
   const liveShareInviteHelp   = document.getElementById('live-share-invite-help');
@@ -11924,6 +11980,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const liveCursorsLayer      = document.getElementById('live-cursors-layer');
   let liveGeneratedDisplayName = null;
   let liveShareParticipantsPopover = null;
+  liveShareUiReady = true;
 
   function getRandomBase64Url(byteLength) {
     const bytes = new Uint8Array(byteLength);
@@ -12001,6 +12058,107 @@ document.addEventListener("DOMContentLoaded", async function () {
       hash |= 0;
     }
     return palette[Math.abs(hash) % palette.length];
+  }
+
+  function normalizeLiveAccessMode(mode) {
+    return mode === LIVE_SHARE_ACCESS_VIEW ? LIVE_SHARE_ACCESS_VIEW : LIVE_SHARE_ACCESS_EDIT;
+  }
+
+  function getSelectedLiveAccessMode() {
+    let selected = LIVE_SHARE_ACCESS_EDIT;
+    liveShareAccessRadios.forEach(function(radio) {
+      if (radio.checked) {
+        selected = radio.value;
+      }
+    });
+    return normalizeLiveAccessMode(selected);
+  }
+
+  function setSelectedLiveAccessMode(mode) {
+    const normalized = normalizeLiveAccessMode(mode);
+    liveShareAccessRadios.forEach(function(radio) {
+      radio.checked = radio.value === normalized;
+    });
+  }
+
+  function getCurrentLiveAccessMode() {
+    if (!liveCollaboration) return getSelectedLiveAccessMode();
+    return normalizeLiveAccessMode(liveCollaboration.accessMode || (liveCollaboration.sessionMap && liveCollaboration.sessionMap.get('accessMode')));
+  }
+
+  function isLiveViewOnlyParticipant() {
+    return Boolean(
+      liveCollaboration &&
+      !liveCollaboration.isHost &&
+      activeTabId === liveCollaboration.tabId &&
+      getCurrentLiveAccessMode() === LIVE_SHARE_ACCESS_VIEW
+    );
+  }
+
+  function canMutateEditor() {
+    return !isLiveViewOnlyParticipant();
+  }
+
+  function isLiveMutatingAction(action) {
+    return LIVE_SHARE_NON_MUTATING_ACTIONS.indexOf(action) === -1;
+  }
+
+  function updateLiveAccessDisplay() {
+    const mode = getCurrentLiveAccessMode();
+    const isActive = Boolean(liveCollaboration);
+    const label = mode === LIVE_SHARE_ACCESS_VIEW ? 'View only' : 'Can edit';
+    const isViewOnlyParticipant = isLiveViewOnlyParticipant();
+
+    if (liveShareAccessControl) {
+      liveShareAccessControl.hidden = isActive;
+    }
+    if (liveShareAccessStatus) {
+      liveShareAccessStatus.hidden = !isActive;
+      liveShareAccessStatus.dataset.mode = mode;
+    }
+    if (liveShareAccessLabel) {
+      liveShareAccessLabel.textContent = label;
+    }
+    if (liveShareAccessNote) {
+      liveShareAccessNote.textContent = isViewOnlyParticipant
+        ? 'This shared document is read-only for you.'
+        : (mode === LIVE_SHARE_ACCESS_VIEW
+          ? 'Collaborators can view updates but cannot edit.'
+          : 'Collaborators can edit this document.');
+    }
+    setSelectedLiveAccessMode(mode);
+  }
+
+  function updateLiveEditorAccess() {
+    const viewOnly = isLiveViewOnlyParticipant();
+    if (markdownEditor) {
+      markdownEditor.readOnly = viewOnly;
+      markdownEditor.setAttribute('aria-readonly', viewOnly ? 'true' : 'false');
+      markdownEditor.classList.toggle('live-share-readonly-editor', viewOnly);
+      markdownEditor.title = viewOnly ? 'Live Share is view only. You can read updates but cannot edit this document.' : '';
+    }
+
+    if (markdownFormatToolbar) {
+      markdownFormatToolbar.classList.toggle('is-live-view-only', viewOnly);
+      markdownFormatToolbar.querySelectorAll('[data-md-action]').forEach(function(button) {
+        const action = button.getAttribute('data-md-action');
+        const shouldDisable = viewOnly && isLiveMutatingAction(action);
+        if (shouldDisable) {
+          button.dataset.liveViewOnlyDisabled = 'true';
+          button.disabled = true;
+          button.classList.add('disabled');
+          button.setAttribute('aria-disabled', 'true');
+        } else if (button.dataset.liveViewOnlyDisabled === 'true') {
+          delete button.dataset.liveViewOnlyDisabled;
+          button.disabled = false;
+          button.classList.remove('disabled');
+          button.setAttribute('aria-disabled', 'false');
+        }
+      });
+      if (!viewOnly) {
+        updateUndoRedoButtons();
+      }
+    }
   }
 
   function getLiveRoomSocketUrl(roomId, secret) {
@@ -12127,6 +12285,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     const updateHandler = function(update, origin) {
       if (destroyed || origin === LIVE_RELAY_ORIGIN) return;
+      if (typeof options.canSendUpdate === 'function' && !options.canSendUpdate()) return;
       send({
         type: 'y-update',
         update: encodeLiveBytes(update)
@@ -12424,6 +12583,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       liveCollaboration.joinTimeoutId = null;
     }
     applyLiveSessionTitle(liveCollaboration.roomTitle);
+    updateLiveAccessDisplay();
+    updateLiveEditorAccess();
     return true;
   }
 
@@ -12575,6 +12736,8 @@ document.addEventListener("DOMContentLoaded", async function () {
   function updateLiveShareControls() {
     const isActive = Boolean(liveCollaboration);
     const isHost = isActive && liveCollaboration.isHost;
+    updateLiveAccessDisplay();
+    updateLiveEditorAccess();
     setLiveShareButtonActive(isActive);
     if (liveShareStartBtn) {
       liveShareStartBtn.disabled = isActive;
@@ -12607,6 +12770,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function syncLiveLocalEditorChange(oldValue, newValue) {
     if (!liveCollaboration || !liveCollaboration.yText) return;
+    if (!canMutateEditor()) return;
     if (oldValue === newValue) return;
 
     let start = 0;
@@ -12678,6 +12842,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     lastPushedValue = remoteMarkdown;
     renderMarkdown({ reason: 'live-remote', force: true });
+    updateLiveEditorAccess();
     updateDocumentStats();
     updateFindHighlights();
     scheduleLineNumberUpdate({ force: true });
@@ -12719,6 +12884,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       lastInputType = null;
       restoreViewMode(restored.viewMode || 'split');
       renderMarkdown({ reason: 'live-restore', force: true });
+      updateLiveAccessDisplay();
+      updateLiveEditorAccess();
       updateDocumentStats();
       updateFindHighlights();
       scheduleLineNumberUpdate({ force: true });
@@ -12748,6 +12915,8 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     restoreViewMode('split');
     renderMarkdown({ reason: 'live-seed', force: true });
+    updateLiveAccessDisplay();
+    updateLiveEditorAccess();
     updateDocumentStats();
     updateFindHighlights();
     scheduleLineNumberUpdate({ force: true });
@@ -12778,6 +12947,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     updateUndoRedoButtons();
     restoreViewMode(returnTab.viewMode || 'split');
     renderMarkdown({ reason: 'live-tab-remove', force: true });
+    updateLiveAccessDisplay();
+    updateLiveEditorAccess();
     updateDocumentStats();
     updateFindHighlights();
     scheduleLineNumberUpdate({ force: true });
@@ -12969,6 +13140,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     if ((message.type === 'y-update' || message.type === 'sync-state') && message.update) {
+      const hostParticipantId = liveCollaboration.sessionMap ? liveCollaboration.sessionMap.get('hostId') : null;
+      if (getCurrentLiveAccessMode() === LIVE_SHARE_ACCESS_VIEW && hostParticipantId && sender !== hostParticipantId) {
+        return;
+      }
       try {
         liveCollaboration.Y.applyUpdate(liveCollaboration.ydoc, decodeLiveBytes(message.update), LIVE_RELAY_ORIGIN);
         markLiveJoinSynced(liveCollaboration.yText ? liveCollaboration.yText.toString() : '');
@@ -13124,11 +13299,17 @@ document.addEventListener("DOMContentLoaded", async function () {
       }
     }
     const sessionTitle = getSafeLiveTitle(sessionMap.get('title') || options.title || 'Live Share');
+    const requestedAccessMode = normalizeLiveAccessMode(
+      isHost
+        ? (options.accessMode || getSelectedLiveAccessMode())
+        : (sessionMap.get('accessMode') || options.accessMode || LIVE_SHARE_ACCESS_VIEW)
+    );
     if (isHost && yText.length === 0) {
       yText.insert(0, markdownEditor.value || '');
     }
     if (isHost) {
       sessionMap.set('title', hostTitle);
+      sessionMap.set('accessMode', requestedAccessMode);
     }
 
     disconnectLiveCollaboration();
@@ -13174,6 +13355,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     const participants = new Map();
     participants.set(localParticipantId, localParticipant);
 
+    if (isHost) {
+      sessionMap.set('hostId', localParticipantId);
+    }
+
     liveCollaboration = {
       roomId,
       secret,
@@ -13191,6 +13376,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       hasReceivedRemoteState: false,
       joinTimeoutId: null,
       roomTitle: sessionTitle,
+      accessMode: requestedAccessMode,
       isApplyingRemoteChange: false,
       lastMarkdown: shouldDeferParticipantTab ? '' : markdownEditor.value,
       observer: null,
@@ -13223,6 +13409,15 @@ document.addEventListener("DOMContentLoaded", async function () {
       const updatedTitle = sessionMap.get('title');
       if (updatedTitle) {
         applyLiveSessionTitle(updatedTitle);
+      }
+      const updatedAccessMode = normalizeLiveAccessMode(sessionMap.get('accessMode'));
+      if (liveCollaboration.accessMode !== updatedAccessMode) {
+        liveCollaboration.accessMode = updatedAccessMode;
+        updateLiveShareControls();
+        updateLiveEditorAccess();
+        if (updatedAccessMode === LIVE_SHARE_ACCESS_VIEW && !liveCollaboration.isHost) {
+          announceToScreenReader('Live Share is view only.');
+        }
       }
       if (sessionMap.get('endedAt') && !liveCollaboration.isHost) {
         setLiveShareStatus('Live room ended by the host', 'idle');
@@ -13265,7 +13460,15 @@ document.addEventListener("DOMContentLoaded", async function () {
         return Boolean(
           liveCollaboration &&
           liveCollaboration.ydoc === ydoc &&
+          (liveCollaboration.isHost || getCurrentLiveAccessMode() === LIVE_SHARE_ACCESS_EDIT) &&
           (liveCollaboration.isHost || liveCollaboration.hasReceivedRemoteState || !liveCollaboration.pendingJoinTab)
+        );
+      },
+      canSendUpdate: function() {
+        return Boolean(
+          liveCollaboration &&
+          liveCollaboration.ydoc === ydoc &&
+          (liveCollaboration.isHost || getCurrentLiveAccessMode() === LIVE_SHARE_ACCESS_EDIT)
         );
       },
       onStatus: setLiveShareStatus,
@@ -13383,7 +13586,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   if (liveShareStartBtn) {
     liveShareStartBtn.addEventListener('click', function() {
       setLiveShareStatus('Starting live room...', 'connecting');
-      startLiveSession({ isHost: true }).catch(function(error) {
+      startLiveSession({ isHost: true, accessMode: getSelectedLiveAccessMode() }).catch(function(error) {
         console.error('Failed to start live session:', error);
         setLiveShareStatus('Unable to start live room', 'error');
         alert('Failed to start Live Share. Please check your connection and try again.');
@@ -13409,6 +13612,13 @@ document.addEventListener("DOMContentLoaded", async function () {
       updateLiveDisplayName(liveShareDisplayName.value);
     });
   }
+  liveShareAccessRadios.forEach(function(radio) {
+    radio.addEventListener('change', function() {
+      if (!liveCollaboration) {
+        updateLiveAccessDisplay();
+      }
+    });
+  });
   if (liveShareModalCloseX) {
     liveShareModalCloseX.addEventListener('click', closeLiveShareModal);
   }
@@ -13614,6 +13824,11 @@ document.addEventListener("DOMContentLoaded", async function () {
   document.addEventListener("keydown", function (e) {
     if (document.activeElement === markdownEditor) {
       const isCmdOrCtrl = e.ctrlKey || e.metaKey;
+      if (!canMutateEditor() && isCmdOrCtrl && ['z', 'y'].indexOf(e.key.toLowerCase()) !== -1) {
+        e.preventDefault();
+        announceToScreenReader('This Live Share session is view only.');
+        return;
+      }
       if (isCmdOrCtrl && !e.shiftKey && e.key.toLowerCase() === 'z') {
         e.preventDefault();
         executeUndo();

--- a/script.js
+++ b/script.js
@@ -11756,8 +11756,34 @@ document.addEventListener("DOMContentLoaded", async function () {
     return activeTab && activeTab.title ? activeTab.title : 'Markdown document';
   }
 
+  function getSafeShareSnapshotTitle(title) {
+    const cleanTitle = String(title || '').trim().replace(/\s+/g, ' ');
+    return cleanTitle || 'Shared Snapshot';
+  }
+
+  function openShareSnapshotTab(content, title, mode) {
+    const shareMode = mode === 'edit' ? 'edit' : 'view';
+    const viewMode = shareMode === 'edit' ? 'split' : 'preview';
+    if (tabs.length >= 20) {
+      alert('The shared snapshot could not be opened because the tab limit has been reached.');
+      return false;
+    }
+    const snapshotTab = createTab(typeof content === 'string' ? content : '', getSafeShareSnapshotTitle(title), viewMode);
+    tabs.push(snapshotTab);
+    switchTab(snapshotTab.id);
+    applyShareSnapshotAccessMode(shareMode);
+    setViewMode(viewMode);
+    saveCurrentTabState();
+    renderTabBar(tabs, activeTabId);
+    return true;
+  }
+
   function getShareHashForMode(id, mode) {
     return 'id=' + encodeURIComponent(id) + (mode === 'edit' ? '&edit=1' : '');
+  }
+
+  function getShareSnapshotTitleParam(title) {
+    return '&title=' + encodeURIComponent(getSafeShareSnapshotTitle(title));
   }
 
   function shouldUseServerShare(markdownText, legacyUrl) {
@@ -11796,7 +11822,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       console.error('Share encoding failed:', e);
       return null;
     }
-    const base = getPublicAppBaseUrl() + '#share=' + encoded;
+    const base = getPublicAppBaseUrl() + '#share=' + encoded + getShareSnapshotTitleParam(getActiveShareTitle());
     return mode === 'edit' ? base + '&edit=1' : base;
   }
 
@@ -13846,11 +13872,11 @@ document.addEventListener("DOMContentLoaded", async function () {
       }
 
       const shareMode = payload && payload.mode === 'edit' ? 'edit' : 'view';
-      markdownEditor.value = payload && typeof payload.content === 'string' ? payload.content : '';
-      applyShareSnapshotAccessMode(shareMode);
-      renderMarkdown({ reason: 'document-load', showSkeleton: true });
-      setViewMode(shareMode === 'edit' ? 'split' : 'preview');
-      saveCurrentTabState();
+      openShareSnapshotTab(
+        payload && typeof payload.content === 'string' ? payload.content : '',
+        payload && payload.title,
+        shareMode
+      );
     } catch (e) {
       console.error('Failed to load stored shared content:', e);
       alert('Network error while loading shared content.');
@@ -13882,18 +13908,15 @@ document.addEventListener("DOMContentLoaded", async function () {
     const ampIdx = rest.indexOf('&');
     const encoded = ampIdx === -1 ? rest : rest.slice(0, ampIdx);
     const params = ampIdx === -1 ? '' : rest.slice(ampIdx + 1);
-    const isEdit = params.split('&').includes('edit=1');
+    const shareParams = new URLSearchParams(params);
+    const isEdit = shareParams.get('edit') === '1';
+    const sharedTitle = shareParams.get('title') || 'Shared Snapshot';
 
     if (!encoded) return;
     try {
       const decoded = decodeMarkdownFromShare(encoded);
       const shareMode = isEdit ? 'edit' : 'view';
-      markdownEditor.value = decoded;
-      applyShareSnapshotAccessMode(shareMode);
-      renderMarkdown({ reason: 'document-load', showSkeleton: true });
-      // Apply the correct view mode: edit=1 → split, default → preview only
-      setViewMode(shareMode === 'edit' ? 'split' : 'preview');
-      saveCurrentTabState();
+      openShareSnapshotTab(decoded, sharedTitle, shareMode);
     } catch (e) {
       console.error("Failed to load shared content:", e);
       alert("The shared URL could not be decoded. It may be corrupted or incomplete.");

--- a/styles.css
+++ b/styles.css
@@ -140,27 +140,35 @@ body {
 /* Custom scrollbar */
 .editor-pane::-webkit-scrollbar,
 .preview-pane::-webkit-scrollbar,
-#markdown-editor::-webkit-scrollbar {
+#markdown-editor::-webkit-scrollbar,
+#live-share-modal .modal-body::-webkit-scrollbar,
+.live-share-participant-popover::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
 .editor-pane::-webkit-scrollbar-track,
 .preview-pane::-webkit-scrollbar-track,
-#markdown-editor::-webkit-scrollbar-track {
+#markdown-editor::-webkit-scrollbar-track,
+#live-share-modal .modal-body::-webkit-scrollbar-track,
+.live-share-participant-popover::-webkit-scrollbar-track {
   background: var(--scrollbar-track);
 }
 
 .editor-pane::-webkit-scrollbar-thumb,
 .preview-pane::-webkit-scrollbar-thumb,
-#markdown-editor::-webkit-scrollbar-thumb {
+#markdown-editor::-webkit-scrollbar-thumb,
+#live-share-modal .modal-body::-webkit-scrollbar-thumb,
+.live-share-participant-popover::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb);
   border-radius: 4px;
 }
 
 .editor-pane::-webkit-scrollbar-thumb:hover,
 .preview-pane::-webkit-scrollbar-thumb:hover,
-#markdown-editor::-webkit-scrollbar-thumb:hover {
+#markdown-editor::-webkit-scrollbar-thumb:hover,
+#live-share-modal .modal-body::-webkit-scrollbar-thumb:hover,
+.live-share-participant-popover::-webkit-scrollbar-thumb:hover {
   background: var(--button-active);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3566,6 +3566,28 @@ a:focus {
   background: #fffbf4;
 }
 
+[data-theme="dark"] .live-share-access-status,
+[data-theme="dark"] .live-share-access-status[data-mode="edit"],
+[data-theme="dark"] .live-share-access-status[data-mode="view"] {
+  border-color: rgba(187, 128, 9, 0.45);
+  background: rgba(187, 128, 9, 0.10);
+  color: #c9d1d9;
+}
+
+[data-theme="dark"] .live-share-access-icon {
+  background: rgba(187, 128, 9, 0.18);
+  color: #d29922;
+}
+
+[data-theme="dark"] .live-share-access-title,
+[data-theme="dark"] .live-share-access-status strong {
+  color: #e6edf3;
+}
+
+[data-theme="dark"] .live-share-access-status #live-share-access-note {
+  color: #8b949e;
+}
+
 .live-share-readonly-editor {
   cursor: default;
   background:

--- a/styles.css
+++ b/styles.css
@@ -3370,7 +3370,6 @@ a:focus {
   background: rgba(26, 127, 55, 0.1);
   color: #16833a;
   font-size: 12px;
-  font-weight: 700;
   line-height: 1.2;
   white-space: nowrap;
 }
@@ -3445,15 +3444,15 @@ a:focus {
 .live-share-access-status {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
   width: 100%;
-  min-height: 58px;
-  padding: 10px 14px;
+  min-height: 44px;
+  padding: 6px 12px;
   border: 1px solid #ead6b3;
   border-radius: 10px;
   background: #fffbf4;
   color: #526174;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.35;
 }
 
@@ -3465,12 +3464,12 @@ a:focus {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: #fff1d9;
   color: #bf8700;
-  font-size: 18px;
+  font-size: 16px;
   flex: 0 0 auto;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3247,6 +3247,58 @@ a:focus {
   opacity: 1;
 }
 
+#share-modal .share-mode-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+#share-modal .share-mode-card {
+  align-items: flex-start;
+  gap: 9px;
+  min-width: 0;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--button-bg);
+}
+
+#share-modal .share-mode-card:hover,
+#share-modal .share-mode-card.is-selected {
+  border-color: var(--accent-color);
+  background: rgba(3, 102, 214, 0.08);
+}
+
+#share-modal .share-mode-card input[type="radio"] {
+  display: block;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  accent-color: var(--accent-color);
+}
+
+#share-modal .share-card-icon,
+#share-modal .share-card-check {
+  display: none;
+}
+
+#share-modal .share-card-body {
+  display: grid;
+  gap: 2px;
+}
+
+#share-modal .share-card-title {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+#share-modal .share-card-desc {
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+#share-modal .share-snapshot-invite {
+  margin-top: 2px;
+}
+
 .share-url-row {
   display: flex;
   gap: 8px;
@@ -3741,6 +3793,7 @@ button.live-share-participant-overflow {
 }
 
 @media (max-width: 560px) {
+  #share-modal .share-mode-cards,
   .live-share-access-options {
     grid-template-columns: 1fr;
   }

--- a/styles.css
+++ b/styles.css
@@ -3462,6 +3462,11 @@ a:focus {
   color: var(--text-color);
 }
 
+.live-share-access-status[data-mode="edit"] {
+  border-color: rgba(26, 127, 55, 0.32);
+  background: rgba(26, 127, 55, 0.08);
+}
+
 .live-share-access-status[data-mode="view"] {
   border-color: rgba(191, 135, 0, 0.32);
   background: rgba(191, 135, 0, 0.08);

--- a/styles.css
+++ b/styles.css
@@ -3386,6 +3386,100 @@ a:focus {
   box-shadow: 0 0 0 4px rgba(26, 127, 55, 0.12);
 }
 
+.live-share-access-control {
+  display: grid;
+  gap: 8px;
+}
+
+.live-share-access-control[hidden] {
+  display: none;
+}
+
+.live-share-access-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.live-share-access-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--button-bg);
+  cursor: pointer;
+}
+
+.live-share-access-option:has(input:checked) {
+  border-color: var(--accent-color);
+  background: rgba(3, 102, 214, 0.08);
+}
+
+.live-share-access-option input {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.live-share-access-option-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.live-share-access-option-title {
+  color: var(--text-color);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.live-share-access-option-desc {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.live-share-access-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--editor-bg);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.live-share-access-status[hidden] {
+  display: none;
+}
+
+.live-share-access-status strong {
+  color: var(--text-color);
+}
+
+.live-share-access-status[data-mode="view"] {
+  border-color: rgba(191, 135, 0, 0.32);
+  background: rgba(191, 135, 0, 0.08);
+}
+
+.live-share-readonly-editor {
+  cursor: default;
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(191, 135, 0, 0.035),
+      rgba(191, 135, 0, 0.035) 8px,
+      transparent 8px,
+      transparent 16px
+    ),
+    var(--editor-bg);
+}
+
 .live-share-section-title {
   font-size: 12px;
   font-weight: 700;
@@ -3614,6 +3708,17 @@ button.live-share-participant-overflow {
 }
 
 @media (max-width: 560px) {
+  .live-share-access-options,
+  .live-share-access-status {
+    grid-template-columns: 1fr;
+  }
+
+  .live-share-access-status {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
   .live-share-invite-header {
     align-items: flex-start;
     flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -1115,11 +1115,12 @@ a:focus {
   height: auto;
   max-height: 100vh;
   max-height: 100dvh;
+  box-sizing: border-box;
   background-color: var(--bg-color);
   box-shadow: -2px 0 10px rgba(0, 0, 0, 0.2);
   transition: right 0.3s ease;
   overflow-y: auto;
-  padding: 1rem;
+  padding: 1rem 1rem 0.35rem;
   display: flex;
   flex-direction: column;
   z-index: 1002;
@@ -1188,7 +1189,9 @@ a:focus {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  flex-grow: 0;
+  flex: 0 0 auto;
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
 
 /* each menu item */

--- a/styles.css
+++ b/styles.css
@@ -1112,7 +1112,7 @@ a:focus {
   top: 0;
   right: -300px;
   width: 280px;
-  height: auto;
+  height: fit-content;
   max-height: 100vh;
   max-height: 100dvh;
   box-sizing: border-box;
@@ -1128,6 +1128,11 @@ a:focus {
 
 .mobile-menu-panel.active {
   right: 0;
+}
+
+.mobile-menu-panel > :last-child,
+.mobile-menu-items > :last-child {
+  margin-bottom: 0;
 }
 
 /* translucent overlay behind panel */

--- a/styles.css
+++ b/styles.css
@@ -3713,6 +3713,11 @@ button.live-share-participant-overflow {
   background: rgba(3, 102, 214, 0.05);
 }
 
+.live-share-invite[data-state="error"] {
+  border-color: rgba(207, 34, 46, 0.55);
+  background: rgba(207, 34, 46, 0.06);
+}
+
 .live-share-invite-header {
   display: flex;
   align-items: center;
@@ -3730,6 +3735,14 @@ button.live-share-participant-overflow {
 .live-share-invite[data-state="active"] .live-share-invite-state,
 .live-share-invite[data-state="joined"] .live-share-invite-state {
   color: var(--accent-color);
+}
+
+.live-share-invite[data-state="error"] .live-share-invite-state {
+  color: var(--color-danger-fg);
+}
+
+.share-snapshot-invite[data-state="error"] .share-url-input {
+  border-color: rgba(207, 34, 46, 0.45);
 }
 
 .live-share-copy-btn {

--- a/styles.css
+++ b/styles.css
@@ -3320,6 +3320,7 @@ a:focus {
   padding: 6px 10px;
 }
 
+.share-generate-btn:disabled,
 .share-copy-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/styles.css
+++ b/styles.css
@@ -3848,14 +3848,35 @@ button.live-share-participant-overflow {
   }
 
   .live-share-access-status {
-    flex-wrap: wrap;
-    gap: 8px 10px;
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr);
+    align-items: center;
+    column-gap: 8px;
+    row-gap: 2px;
+    min-height: 0;
+    padding: 8px 10px;
+  }
+
+  .live-share-access-icon {
+    grid-row: 1 / span 2;
+    width: 24px;
+    height: 24px;
+    font-size: 13px;
+  }
+
+  .live-share-access-title {
+    min-width: 0;
+    white-space: normal;
+    font-size: 11px;
+    line-height: 1.25;
   }
 
   .live-share-access-status #live-share-access-note {
-    flex-basis: 100%;
-    margin-left: 44px;
+    min-width: 0;
+    margin-left: 0;
     text-align: left;
+    font-size: 11px;
+    line-height: 1.25;
   }
 
   .live-share-invite-header {

--- a/styles.css
+++ b/styles.css
@@ -1104,7 +1104,9 @@ a:focus {
   top: 0;
   right: -300px;
   width: 280px;
-  height: 100vh;
+  height: auto;
+  max-height: 100vh;
+  max-height: 100dvh;
   background-color: var(--bg-color);
   box-shadow: -2px 0 10px rgba(0, 0, 0, 0.2);
   transition: right 0.3s ease;
@@ -1178,7 +1180,7 @@ a:focus {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  flex-grow: 1;
+  flex-grow: 0;
 }
 
 /* each menu item */

--- a/styles.css
+++ b/styles.css
@@ -3362,15 +3362,16 @@ a:focus {
 .live-share-active-badge {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   width: fit-content;
-  padding: 4px 9px;
-  border: 1px solid rgba(26, 127, 55, 0.28);
+  padding: 5px 13px;
+  border: 0;
   border-radius: 999px;
-  background: var(--editor-bg);
-  color: #1a7f37;
+  background: rgba(26, 127, 55, 0.1);
+  color: #16833a;
   font-size: 12px;
   font-weight: 700;
+  line-height: 1.2;
   white-space: nowrap;
 }
 
@@ -3382,8 +3383,8 @@ a:focus {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #1a7f37;
-  box-shadow: 0 0 0 4px rgba(26, 127, 55, 0.12);
+  background: #00a344;
+  box-shadow: 0 0 0 5px rgba(0, 163, 68, 0.13);
 }
 
 .live-share-access-control {
@@ -3444,32 +3445,60 @@ a:focus {
 .live-share-access-status {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 9px 11px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--editor-bg);
-  color: var(--text-secondary);
-  font-size: 12px;
+  gap: 14px;
+  width: 100%;
+  min-height: 58px;
+  padding: 10px 14px;
+  border: 1px solid #ead6b3;
+  border-radius: 10px;
+  background: #fffbf4;
+  color: #526174;
+  font-size: 13px;
+  line-height: 1.35;
 }
 
 .live-share-access-status[hidden] {
   display: none;
 }
 
+.live-share-access-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff1d9;
+  color: #bf8700;
+  font-size: 18px;
+  flex: 0 0 auto;
+}
+
+.live-share-access-title {
+  color: #3f4d63;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .live-share-access-status strong {
-  color: var(--text-color);
+  color: #34425a;
+  font-weight: 800;
+}
+
+.live-share-access-status #live-share-access-note {
+  margin-left: auto;
+  color: #526174;
+  text-align: right;
 }
 
 .live-share-access-status[data-mode="edit"] {
-  border-color: rgba(191, 135, 0, 0.32);
-  background: rgba(191, 135, 0, 0.08);
+  border-color: #ead6b3;
+  background: #fffbf4;
 }
 
 .live-share-access-status[data-mode="view"] {
-  border-color: rgba(191, 135, 0, 0.32);
-  background: rgba(191, 135, 0, 0.08);
+  border-color: #ead6b3;
+  background: #fffbf4;
 }
 
 .live-share-readonly-editor {
@@ -3713,15 +3742,19 @@ button.live-share-participant-overflow {
 }
 
 @media (max-width: 560px) {
-  .live-share-access-options,
-  .live-share-access-status {
+  .live-share-access-options {
     grid-template-columns: 1fr;
   }
 
   .live-share-access-status {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 4px;
+    flex-wrap: wrap;
+    gap: 8px 10px;
+  }
+
+  .live-share-access-status #live-share-access-note {
+    flex-basis: 100%;
+    margin-left: 44px;
+    text-align: left;
   }
 
   .live-share-invite-header {

--- a/styles.css
+++ b/styles.css
@@ -3463,8 +3463,8 @@ a:focus {
 }
 
 .live-share-access-status[data-mode="edit"] {
-  border-color: rgba(26, 127, 55, 0.32);
-  background: rgba(26, 127, 55, 0.08);
+  border-color: rgba(191, 135, 0, 0.32);
+  background: rgba(191, 135, 0, 0.08);
 }
 
 .live-share-access-status[data-mode="view"] {


### PR DESCRIPTION
## Summary
- Add host-selected Live Share access modes: Can edit and View only.
- Enforce view-only Live Share participant behavior by blocking editor input, formatting commands, undo/redo, and outbound Yjs updates.
- Refresh the Live Share active-session and access-status UI.
- Update Share Snapshot with a clearer Share -> Copy flow, Live Share-style copy-link panel, footer action buttons, and custom error handling.
- Enforce Share Snapshot access mode: view-only snapshot links stay preview-only/read-only, while Can edit links open editable.
- Open Share Snapshot links in a separate tab named from the shared document title, matching the Live Share join behavior.
- Show Share Snapshot generation failures in an in-app modal and mark the link panel with a red error state.

## Validation
- `node --check script.js`
- `git diff --check`
- Local browser smoke on `http://127.0.0.1:8139/index.html` for Live Share and Share Snapshot modal flows.