### PR TITLE
fix(mobile): polish menu shared states

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,8 +311,9 @@
                                 <i class="bi bi-share me-2"></i> Share Snapshot
                             </button>
 
-                            <button id="mobile-live-share-button" class="mobile-menu-item" title="Live Share">
-                                <i class="bi bi-broadcast me-2"></i> Live Share
+                            <button id="mobile-live-share-button" class="mobile-menu-item mobile-live-share-item" title="Live Share">
+                                <span class="mobile-menu-item-label"><i class="bi bi-broadcast me-2"></i><span id="mobile-live-share-label">Live Share</span></span>
+                                <span id="mobile-live-share-participants" class="live-share-toolbar-participants mobile-live-share-participants" aria-label="Live Share participants" hidden></span>
                             </button>
                             
                             <div class="mobile-menu-item dropdown w-100 p-0 border-0">

--- a/script.js
+++ b/script.js
@@ -314,10 +314,14 @@ document.addEventListener("DOMContentLoaded", async function () {
     return Boolean(liveCollaboration && activeTabId === liveCollaboration.tabId);
   }
 
+  function isLiveShareHostDocumentActive() {
+    return Boolean(isLiveShareDocumentActive() && liveCollaboration.isHost);
+  }
+
   function blockLiveDocumentShareSnapshot() {
-    if (!isLiveShareDocumentActive()) return false;
-    alert('Live Share documents cannot be shared as snapshots.');
-    announceToScreenReader('Live Share documents cannot be shared as snapshots.');
+    if (!isLiveShareDocumentActive() || isLiveShareHostDocumentActive()) return false;
+    alert('Only the Live Share host can share snapshots from a live document.');
+    announceToScreenReader('Only the Live Share host can share snapshots from a live document.');
     return true;
   }
 
@@ -372,6 +376,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const mobileShareButton   = document.getElementById("mobile-share-button");
   const liveShareButton     = document.getElementById("live-share-button");
   const mobileLiveShareButton = document.getElementById("mobile-live-share-button");
+  const mobileLiveShareParticipants = document.getElementById("mobile-live-share-participants");
   const githubImportModal = document.getElementById("github-import-modal");
   const githubImportTitle = document.getElementById("github-import-title");
   const githubImportUrlInput = document.getElementById("github-import-url");
@@ -12338,6 +12343,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const snapshotViewOnly = isShareSnapshotViewOnlyActive();
     const snapshotActive = isShareSnapshotActive();
     const liveShareDocumentActive = isLiveShareDocumentActive();
+    const liveShareGuestDocumentActive = liveShareDocumentActive && !isLiveShareHostDocumentActive();
     const viewOnly = isLiveViewOnlyParticipant() || snapshotViewOnly;
     if (markdownEditor) {
       markdownEditor.readOnly = viewOnly;
@@ -12402,7 +12408,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     [shareButton, mobileShareButton].forEach(function(button) {
       if (!button) return;
-      if (snapshotActive || liveShareDocumentActive) {
+      if (snapshotActive || liveShareGuestDocumentActive) {
         if (button.dataset.shareSnapshotReshareDisabled !== 'true') {
           button.dataset.shareSnapshotOriginalTitle = button.getAttribute('title') || '';
         }
@@ -13043,6 +13049,10 @@ document.addEventListener("DOMContentLoaded", async function () {
         showLiveParticipantsPopover(event.currentTarget, allParticipants);
       }
     });
+    renderLiveParticipantAvatars(mobileLiveShareParticipants, participants, {
+      showNames: false,
+      limit: 3
+    });
     updateLiveShareGuidance(true, participantCount);
     setLiveShareStatus(status, state);
   }
@@ -13074,6 +13084,10 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (liveShareToolbarParticipants) {
         liveShareToolbarParticipants.textContent = '';
         liveShareToolbarParticipants.hidden = true;
+      }
+      if (mobileLiveShareParticipants) {
+        mobileLiveShareParticipants.textContent = '';
+        mobileLiveShareParticipants.hidden = true;
       }
       if (liveShareUrlInput) liveShareUrlInput.value = '';
       updateLiveShareGuidance(false, 0);
@@ -16129,7 +16143,14 @@ document.addEventListener("DOMContentLoaded", async function () {
     const mShareBtn = document.getElementById('mobile-share-button');
     if (mShareBtn) mShareBtn.innerHTML = `<i class="bi bi-share me-2"></i>${dict.shareSnapshot || 'Share Snapshot'}`;
     const mLiveShareBtn = document.getElementById('mobile-live-share-button');
-    if (mLiveShareBtn) mLiveShareBtn.innerHTML = `<i class="bi bi-broadcast me-2"></i>${dict.liveShare || 'Live Share'}`;
+    if (mLiveShareBtn) {
+      const mobileLiveShareLabel = document.getElementById('mobile-live-share-label');
+      if (mobileLiveShareLabel) {
+        mobileLiveShareLabel.textContent = dict.liveShare || 'Live Share';
+      } else {
+        mLiveShareBtn.innerHTML = `<i class="bi bi-broadcast me-2"></i>${dict.liveShare || 'Live Share'}`;
+      }
+    }
 
     // Document Reset
     const tabResetBtn = document.getElementById('tab-reset-btn');

--- a/styles.css
+++ b/styles.css
@@ -1223,6 +1223,38 @@ a:focus {
   background-color: var(--button-active);
 }
 
+.mobile-menu-item:disabled,
+.mobile-menu-item.disabled,
+.mobile-menu-item[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.mobile-menu-item:disabled:hover,
+.mobile-menu-item.disabled:hover,
+.mobile-menu-item[aria-disabled="true"]:hover,
+.mobile-menu-item:disabled:active,
+.mobile-menu-item.disabled:active,
+.mobile-menu-item[aria-disabled="true"]:active {
+  background-color: var(--button-bg);
+}
+
+.mobile-live-share-item {
+  justify-content: space-between;
+}
+
+.mobile-menu-item-label {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.mobile-live-share-participants {
+  flex-shrink: 0;
+  margin-left: auto;
+  margin-right: 0;
+}
+
 /* close button override */
 #close-mobile-menu.tool-button {
   padding: 0.25rem 0.5rem;
@@ -3946,6 +3978,10 @@ html[lang="ko"] .markdown-body h1, html[lang="ko"] .markdown-body h2, html[lang=
   opacity: 1;
   transform: translateY(0) scale(1);
   visibility: visible;
+}
+
+.mobile-menu-items .dropdown-menu:not(.show) {
+  display: none;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- remove the extra mobile drawer scroll space caused by hidden dropdown menus contributing layout height
- show Live Share participant avatars/count inside the mobile/tablet Live Share menu item
- apply disabled styling and hover behavior to mobile menu actions that are disabled in shared/view-only states
- allow Live Share hosts to create Share Snapshot links while keeping guest Live Share documents blocked

## Root Cause
The global dropdown animation kept hidden dropdown menus as `display: block`, so the mobile language dropdown still affected drawer scroll height while invisible. The mobile Live Share action also had no participant container, mobile menu buttons did not have the disabled visual rules used by desktop toolbar buttons, and the Live Share snapshot guard blocked hosts and guests the same way.

## Validation
- Read `wiki/Contributing.md` before preparing the change
- `node --check script.js`
- `git diff --check`
- Served locally on `http://127.0.0.1:8081` and verified the drawer bottom gap dropped to normal padding with the hidden mobile language dropdown no longer contributing scroll height