### PR TITLE
docs(wiki): update documentation and SEO wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
   <h1>Markdown Viewer</h1>
 
-  **A Markdown Editor That Lives in Your Browser, Desktop, and a Single URL.**
+  **A Premium Browser-Based Markdown Editor, Viewer, and Reader.**
 
-  *Fast GitHub-style Markdown editing with live preview, diagrams, LaTeX, syntax highlighting, PDF export, and multi-tab support across web, desktop, and Docker.*
+  *Open, read, edit, and preview `.md` files with split-screen live preview, sync scrolling, GitHub-Flavored Markdown, diagrams, LaTeX, syntax highlighting, PDF/HTML/PNG export, and multi-tab support across web, desktop, and Docker.*
 
   [![License](https://img.shields.io/github/license/ThisIs-Developer/Markdown-Viewer?style=flat-square&color=2ea043)](https://github.com/ThisIs-Developer/Markdown-Viewer/blob/main/LICENSE)
   [![Latest Release](https://img.shields.io/github/v/release/ThisIs-Developer/Markdown-Viewer?style=flat-square&color=3178C6)](https://github.com/ThisIs-Developer/Markdown-Viewer/releases)
@@ -43,6 +43,7 @@
   <br />
 
   - [About the Project](#about-the-project)
+  - [Current Behavior and Privacy](#current-behavior-and-privacy)
   - [Key Features](#key-features)
   - [System Architecture](#system-architecture)
     - [High-Level Architecture Diagram](#high-level-architecture-diagram)
@@ -63,19 +64,29 @@
 
 ## About the Project
 
-**Markdown Viewer** is an advanced, fully client-side editing suite and previewer optimized for a professional documentation workflow. Running completely inside the browser, it renders GitHub-Flavored Markdown (GFM), math formulas, and architectural diagrams in real time. 
+**Markdown Viewer** is a premium browser-based Markdown editor, viewer, reader, and previewer optimized for professional documentation workflows. It opens local `.md` and `.markdown` files, lets you write in plain Markdown, and renders GitHub-Flavored Markdown (GFM), math formulas, diagrams, code blocks, tables, and other rich Markdown content in a split-screen live preview with sync scrolling.
 
-Designed with privacy and performance at its core, the application performs all parsing in a background worker thread, employs incremental DOM patching to minimize browser repaints, and supports native offline capabilities via a Service Worker proxy. It is also packaged as a lightweight native desktop shell using the Neutralinojs framework.
+Designed with privacy and performance at its core, the application keeps ordinary editing, previewing, autosave, and most exports on your device, performs heavy parsing in a background worker thread, uses incremental DOM patching to minimize browser repaints, and supports offline-capable PWA behavior after the web build has cached its assets. It is also packaged as a lightweight native desktop shell using the Neutralinojs framework.
+
+---
+
+## Current Behavior and Privacy
+
+Markdown Viewer is not a cloud workspace. Normal typing, preview rendering, local file import, tab autosave, theme settings, and most exports happen on your device. No account is required. The app does not implement analytics, telemetry, ads, or tracking cookies.
+
+Some user-triggered features do use the network:
+
+- **GitHub import** fetches public Markdown files from GitHub.
+- **Remote diagram renderers** can receive diagram source for PlantUML, D2, Graphviz, Vega-Lite, WaveDrom, and some diagram previews.
+- **Share Snapshot** creates point-in-time links. Small documents stay compressed in the URL hash. Larger documents are stored in Cloudflare KV for 90 days through `/api/share`.
+- **Live Share** creates temporary real-time rooms through a Cloudflare Durable Object. It relays Yjs updates, display names, presence, and cursors while the room is active; it is not permanent document storage.
+- **CDN libraries and external document assets** can be requested by the browser unless you use the prepared desktop bundle or self-host the needed assets.
+
+For the full feature, limitation, and data-handling reference, read the [wiki feature guide](wiki/Features.md).
 
 ---
 
 ## Key Features
-
-### 📐 LaTeX Math Notation
-Render inline and display mathematical formulas natively using the MathJax typesetting engine.
-<p align="center">
-  <img src="https://github.com/user-attachments/assets/4a3c79e4-4a30-4fcf-8769-fb8867ba6f18" alt="LaTeX Math Notation" width="90%" />
-</p>
 
 ### 📊 Interactive Mermaid Diagrams
 Generate flowcharts, Gantt charts, and sequence diagrams with zoom, pan, and SVG export controls.
@@ -90,11 +101,35 @@ Render complex architectural diagrams and visualizations instantly with a clean,
 - **D2**: Script clean, modern diagrams-as-code layout structures.
 - **Graphviz**: Visualize network topologies, trees, and directed graphs via DOT script notation.
 - **Vega-Lite**: Describe declarative charts, data plots, and statistical visualizations.
-- **Wavedrom**: Draw digital timing diagrams and waveform representations.
 - **Markmap**: Generate interactive mindmaps from nested markdown lists.
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/027e0bcb-d149-46bb-adf5-0ece02ffaaac" alt="Client-Side PlantUML Diagrams" width="90%" />
+</p>
+
+### 🌊 WaveDrom Timing Diagrams
+Draw digital timing diagrams and waveform representations for hardware notes, protocol docs, and signal-heavy technical writing.
+
+### 🎼 ABC Music Player & Sheet Music Viewer
+Render ABC notation into sheet music with synchronized audio playback, note highlighting, and PNG/SVG export options.
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/a57db33c-0502-47a8-8f91-7c06946c34a9" controls width="800"></video>
+  <img src="https://github.com/user-attachments/assets/4341040b-eddd-40fa-8d1f-ba6ec9ac1010" alt="ABC Music Notation & Audio Synthesis" width="90%" />
+</p>
+
+### 🤝 Live Share Temporary Rooms
+Start a temporary real-time room for collaborative editing or view-only review. Live Share relays updates through Cloudflare Durable Objects and does not create permanent document storage.
+
+### 🔗 Share Snapshot Links
+Create point-in-time links in view-only or editable mode. Small snapshots stay in the URL hash; larger snapshots use Cloudflare KV for 90 days.
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/3ce03da2-2df0-4662-8ed0-67ddb4c48c84" alt="Share Snapshot modal" width="90%" />
+</p>
+
+### 📐 LaTeX Math Notation
+Render inline and display mathematical formulas natively using the MathJax typesetting engine.
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/4a3c79e4-4a30-4fcf-8769-fb8867ba6f18" alt="LaTeX Math Notation" width="90%" />
 </p>
 
 ### 🗺️ Interactive Map Renderers
@@ -103,7 +138,7 @@ Parse and visualize GeoJSON and TopoJSON map files directly inside your preview 
   <img src="https://github.com/user-attachments/assets/33df24e1-c1d8-4b8f-ac79-49813ab767c9" alt="Interactive Map Renderers" width="90%" />
 </p>
 
-### 📦 STL 3D Model Renderer ([View Release Demo v3.9.0](https://github.com/ThisIs-Developer/Markdown-Viewer/releases/tag/v3.9.0))
+### 📦 STL 3D Model Renderer
 Render and interact with STL (ASCII/Binary) files featuring perspective controls, flat shading, and reset controls.
 <p align="center">
   <img src="https://github.com/user-attachments/assets/343b4d3d-5891-4aa9-bba5-1229e7a17fdd" alt="STL 3D Model Renderer" width="90%" />
@@ -111,17 +146,10 @@ Render and interact with STL (ASCII/Binary) files featuring perspective controls
   <img src="https://github.com/user-attachments/assets/aef963a2-bdc5-4348-976b-68e8d01bbc6f" alt="STL 3D Model Renderer" width="90%" />
 </p>
 
-### 🎼 ABC Music Player & Sheet Music Viewer ([Listen Now!](https://markdownviewer.pages.dev/#share=eJyFUlFv0zAQfs-v-LSXgRTapRvaFImHdIhN21oNVgFCQurFviQG164uDlWl_HicdJuAPfBytu-77_N3Z6_XaypV8jXPzpJVvmBtjWvxiRS3E9xc02TMzy051cSgD1BKP-kPeGU2vhOEhrEiCST_4PccWPAQhDn8BS3zoxfcI-yoBaGW4TrxG3LBKGzYei20IRiHsPMgFdooUO5H7la8NVWsW1CI5x2uhGsve9zxzrR4lZ2fv32TXWQXr1PsTGiw6dpYHdlPhIPJW-PqSZT9YKQNiNZcYA0KuPS_2AVckWh2g4colqUw4dGuIjGKQicMX2FJW2_ZuzxKHTpMh7T1O3gxtXEpuraTbTuaD414xxj7JdNyi26LJtp2zHoPYUvB-PguwcdGjVNs99CmdibsB7OrYQCW9qh4dKDReBlkSvFd3QR4F5ltoJonySK_7JOPeTY9e5fNTpK7uLtI5vmNbxyuyVosHtLY3OlpiqWX0HSbkmV4-uRb_tlYG0WwGId3L_4Hq4DZSXaOwsUOvojRnNzm7xM9QzXlaRydrjT6uOhjDXWsy8OpGpDHkh6q4AL1EPr_MUuqYuo4xh6suYI-Q98nagY1nU8LcKGKASrqAtWoiOqFYvm0T55N6GdrLxJl_IwVjz51XFQxV-i_J-v1-jdZqQvS&edit=1))
-Render ABC notation into beautiful sheet music with synchronized audio playback, note highlighting, and PNG/SVG export options—perfect for listening to music while writing.
+### 🖊️ Split-Screen Markdown Editor and Live Preview
+Type, paste, or open Markdown in the plain-text editor and watch it render in real time in the live preview pane.
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/a57db33c-0502-47a8-8f91-7c06946c34a9" controls width="800"></video>
-  <img src="https://github.com/user-attachments/assets/4341040b-eddd-40fa-8d1f-ba6ec9ac1010" alt="ABC Music Notation & Audio Synthesis" width="90%" />
-</p>
-
-### 🖊️ Decoupled Split-Screen Editing
-Type Markdown in the custom editor and watch it render in real-time in the live preview pane.
-<p align="center">
-  <img src="https://github.com/user-attachments/assets/5f1298a9-16e7-4c7d-96c6-967a7f914f7d" alt="Decoupled Split-Screen Editing" width="90%" />
+  <img src="https://github.com/user-attachments/assets/5f1298a9-16e7-4c7d-96c6-967a7f914f7d" alt="Split-screen Markdown editor with live preview" width="90%" />
 </p>
 
 ### 📑 Multi-Document Tab Workspace
@@ -137,10 +165,10 @@ Perform scoped searches using regular expressions, syntax scopes, and side-by-si
   <img src="https://github.com/user-attachments/assets/7ba183b1-0e58-450a-afc7-0f805657ba44" alt="Find & Replace with Diff Preview" width="90%" />
 </p>
 
-### 🛠️ Formatting Toolbar & Quick Modals
-Quickly insert markdown elements, tables, emojis, and symbols using dedicated formatting toolbar modals.
+### 🛠️ Markdown Formatting Toolbar & Quick Modals
+Quickly insert Markdown elements, tables, emojis, and symbols using dedicated toolbar modals while the document remains editable plain text. This is not a true in-place WYSIWYG editor; it is plain Markdown editing with live preview.
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/1ecb877d-31fe-4b63-b67b-e3faa39ae776" alt="Formatting Toolbar & Quick Modals" width="90%" />
+  <img src="https://github.com/user-attachments/assets/1ecb877d-31fe-4b63-b67b-e3faa39ae776" alt="Markdown formatting toolbar and quick modals" width="90%" />
 </p>
 
 ### 🌐 Multi-Language Translation (i18n)
@@ -149,20 +177,14 @@ Access a fully localized user interface with support for English, Simplified Chi
   <img src="https://github.com/user-attachments/assets/a4240b72-8353-47ad-b6f0-21ffee34335d" alt="Multi-Language Translation (i18n)" width="90%" />
 </p>
 
-### 📤 Layout-Aware PDF, HTML & PNG Export
+### 📤 Markdown to PDF, HTML & PNG Export
 Export your documents to raw Markdown, centered inline HTML, high-quality PNG images, or paginated PDF with re-engineered page breaks.
 <p align="center">
   <img src="https://github.com/user-attachments/assets/36a9710d-df23-4fc5-9193-c8d43ca96408" alt="Layout-Aware PDF, HTML & PNG Export" width="90%" />
 </p>
 
-### 🔗 Serverless Compressed URL Sharing ([Click to Try](https://markdownviewer.pages.dev/#share=eJx1kbtOIzEUhnue4pSm4CFISDbco2EiagOGmJhxZGcaqkx2V1DQ5QICxEUIIXEHgRQQqQZ6zysw2bCw4R32hCFQICpb9neO_8-nDzITkHDmBNdZeCxWIMWEkD19EB-Dp9Nis1Fu1k9atSUgE3whL_gsZzMQz3KHadb7VtBs7PzZb2DFUBpaq_utzeO_h1tAhmiefkKhVw5L5dA7Cr3d0DtDetiC1-rmy_VJu3YFZFgqRp2IbVeX__2uvlbX2r_q7fUKsjEL0lIV3DnXP9RAYopqLiJ4XPi7SCRQQuepfyEFJsWXUScCUlJQBJIWJBV1_APKsUNSMWf6HYhJZ166CpmBBAwwt6Cns0B-MLXQDZSi0ZdYGTA7wc_ACzxza-rmBojlas27nNkOinh8aa6DEuKDNgwWqMBrCeR9F4FxTjv9bAts_07l_AMGxHZV7iP0KFNZOtXJnR5BdaFzHAiuH0B8kT1s3C91mkzC0433fFTpzslWdIYXuHSo-GZQmX4we-YWw54Hq6aBPivocw4kk1OUO198glpQ-g8VBvRv&edit=1))
-Share view or edit mode documents database-free via zlib DEFLATE compressed URL hashes.
-<p align="center">
-  <img src="https://github.com/user-attachments/assets/3ce03da2-2df0-4662-8ed0-67ddb4c48c84" alt="Serverless Compressed URL Sharing" width="90%" />
-</p>
-
-### 📥 Multi-Source File Import
-Drag and drop local files, or import directories recursively directly from public GitHub repositories.
+### 📥 Open Local .md Files and Import from GitHub
+Drag and drop local `.md` or `.markdown` files, use the file picker, or import Markdown files from public GitHub repositories.
 <p align="center">
   <img src="https://github.com/user-attachments/assets/c0811f6b-584f-4a88-88cb-6e4604ae8789" alt="Multi-Source File Import" width="90%" />
   <img src="https://github.com/user-attachments/assets/f1039c97-e826-4dc5-83b2-ba57bfe57611" alt="File Import selection" width="90%" />
@@ -313,11 +335,12 @@ graph TD
 
 ## Getting Started & Installation
 
-### 💻 Option 1: Quick Local Run (No Installation/No Server)
-Because Markdown Viewer runs completely client-side utilizing standard HTML, CSS, and JavaScript, you can run it instantly directly from your filesystem:
+### 💻 Option 1: Quick Local Run (No Installation)
+Because Markdown Viewer uses Web Workers, Service Workers, and browser storage APIs, run it through a local HTTP server instead of opening `index.html` with `file://`:
 1. Clone or download the repository to your local machine.
-2. Open the repository folder in your system **File Manager**.
-3. Simply double-click **`index.html`** to open the editor directly in your default web browser.
+2. Open a terminal in the repository folder.
+3. Run `python -m http.server 8080` or `npx serve . -p 8080`.
+4. Open **[http://localhost:8080](http://localhost:8080)** in your browser.
 
 ---
 
@@ -360,10 +383,8 @@ You can compile and run a native standalone desktop app (Windows, macOS, or Linu
    # Synchronize resources with the main web app
    node prepare.js
 
-   # Build/compile the application for Windows and other systems
+   # Build/compile the release application
    npm run build
-   # Or build a standalone portable executable
-   npm run build:portable
    ```
 
 *Note: You can also download prebuilt standalone binaries directly from the [Releases](https://github.com/ThisIs-Developer/Markdown-Viewer/releases) page without compiling it yourself.*
@@ -430,26 +451,31 @@ Markdown-Viewer/
 
 | Library Name | Version | Role in App | Loading Method |
 | :--- | :--- | :--- | :--- |
-| **[Marked.js](https://marked.js.org/)** | 9.1.6 | Parses markdown content to HTML elements. | Defer (Upfront) |
-| **[Highlight.js](https://highlightjs.org/)** | 11.9.0 | Adds syntax highlighting to code sections. | Defer (Upfront) |
-| **[DOMPurify](https://github.com/cure53/DOMPurify)** | 3.0.9 | Sanitizes HTML outputs against XSS. | Defer (Upfront) |
-| **[FileSaver.js](https://github.com/eligrey/FileSaver.js/)** | 2.0.5 | Manages file saving on the client side. | Defer (Upfront) |
-| **[js-yaml](https://github.com/nodeca/js-yaml)** | 4.1.0 | Parses YAML frontmatter headers. | Defer (Upfront) |
-| **[Bootstrap](https://getbootstrap.com)** | 5.3.2 | Provides component structures and modal panels. | Upfront Script |
-| **[Bootstrap Icons](https://icons.getbootstrap.com/)** | 1.11.3 | Provides responsive vector symbols across formatting tools and headers. | Preloaded (Upfront) |
-| **[GitHub Markdown CSS](https://github.com/sindresorhus/github-markdown-css)** | 5.3.0 | Matches GitHub's exact light and dark typography rendering styles. | Upfront / Exports |
-| **[Mermaid.js](https://mermaid.js.org/)** | 11.15.0 | Renders interactive flowcharts and diagrams. | Lazy-loaded on diagram find |
-| **[MathJax](https://www.mathjax.org/)** | 3.2.2 | Renders mathematical LaTeX expressions. | Lazy-loaded on math find |
-| **[jsPDF](https://github.com/parallax/jsPDF)** | 2.5.1 | Generates paginated PDF documents client-side. | Lazy-loaded on PDF request |
-| **[html2canvas](https://html2canvas.hertzen.com/)** | 1.4.1 | Captures HTML layouts as canvas objects. | Lazy-loaded on PDF request |
-| **[pako.js](https://github.com/nodeca/pako)** | 2.1.0 | Handles DEFLATE compression for share links, PlantUML, and D2 diagrams. | Lazy-loaded on share, PlantUML, or D2 request |
-| **[JoyPixels](https://www.joypixels.com/)** | 9.0.1 | Renders standard emoji sets. | Lazy-loaded on emoji select |
-| **[Leaflet](https://leafletjs.com/)** | 1.9.4 | Powers interactive GeoJSON and TopoJSON map overlays. | Lazy-loaded on map detection |
-| **[TopoJSON](https://github.com/topojson/topojson)** | 3.0.2 | Parses TopoJSON structures into standard GeoJSON coordinates. | Lazy-loaded on topojson detection |
-| **[Three.js](https://threejs.org/)** | r128 | Renders STL 3D models with canvas viewports. | Lazy-loaded on STL file detection |
-| **[ABC Music Notation (abcjs)](https://www.abcjs.net/)** | 6.5.2 | Renders sheet music notation from raw text definitions. | Lazy-loaded on abc music detection |
-| **[PlantUML](https://plantuml.com/)** | - | External server rendering SVG diagrams from compressed markup. | Lazy-loaded on PlantUML detection |
-| **[Kroki / D2](https://kroki.io/)** | - | External server rendering D2 diagrams into theme-matched SVG. | Lazy-loaded on D2 detection |
+| **[Bootstrap](https://getbootstrap.com)** | 5.3.2 | Provides responsive layout, dropdowns, modals, and UI components. | Initial page load |
+| **[Bootstrap Icons](https://icons.getbootstrap.com/)** | 1.11.3 | Provides toolbar, header, modal, and action icons. | Initial page load |
+| **[GitHub Markdown CSS](https://github.com/sindresorhus/github-markdown-css)** | 5.3.0 | Provides GitHub-style preview typography for the rendered document. | Initial page load / exports |
+| **[Marked.js](https://marked.js.org/)** | 9.1.6 | Parses Markdown into HTML in the main thread and preview worker. | Initial page load / worker |
+| **[Highlight.js](https://highlightjs.org/)** | 11.9.0 | Adds syntax highlighting to fenced code blocks. | Initial page load / worker |
+| **[DOMPurify](https://github.com/cure53/DOMPurify)** | 3.0.9 | Sanitizes rendered HTML before it enters the preview. | Initial page load |
+| **[FileSaver.js](https://github.com/eligrey/FileSaver.js/)** | 2.0.5 | Handles browser downloads for exported files. | Initial page load |
+| **[js-yaml](https://github.com/nodeca/js-yaml)** | 4.1.0 | Parses YAML frontmatter for display and export handling. | Initial page load |
+| **[MathJax](https://www.mathjax.org/)** | 3.2.2 | Renders inline and display LaTeX math. | Lazy-loaded on math detection |
+| **[Mermaid.js](https://mermaid.js.org/)** | 11.15.0 | Renders Mermaid diagrams with zoom, copy, PNG, and SVG actions. | Lazy-loaded on Mermaid detection |
+| **[jsPDF](https://github.com/parallax/jsPDF)** | 2.5.1 | Builds the legacy raster PDF export. | Lazy-loaded on legacy PDF request |
+| **[html2canvas](https://html2canvas.hertzen.com/)** | 1.4.1 | Captures rendered HTML for legacy PDF and PNG export. | Lazy-loaded on PDF/PNG request |
+| **[pako.js](https://github.com/nodeca/pako)** | 2.1.0 | Handles DEFLATE compression for share links and diagram encoding. | Lazy-loaded on share or diagram request |
+| **[JoyPixels / emoji-toolkit](https://www.joypixels.com/)** | 9.0.1 | Converts emoji shortcodes and powers emoji UI rendering. | Lazy-loaded on emoji use |
+| **[ABCJS](https://www.abcjs.net/)** | 6.5.2 | Renders ABC music notation and playback. | Lazy-loaded on ABC notation detection |
+| **[Leaflet](https://leafletjs.com/)** | 1.9.4 | Renders interactive GeoJSON and TopoJSON maps. | Lazy-loaded on map detection |
+| **[TopoJSON](https://github.com/topojson/topojson)** | 3.0.2 | Converts TopoJSON data for map rendering. | Lazy-loaded on TopoJSON detection |
+| **[Three.js](https://threejs.org/)** | r128 | Renders STL 3D models. | Lazy-loaded on STL detection |
+| **STLLoader / OrbitControls** | Three r128 examples | Loads STL files and provides model orbit controls. | Lazy-loaded on STL detection |
+| **[D3](https://d3js.org/)** | 7 | Supports Markmap rendering. | Lazy-loaded on Markmap detection |
+| **[Markmap](https://markmap.js.org/)** | 0.18.12 | Renders Markmap mind maps from Markdown lists. | Lazy-loaded on Markmap detection |
+| **[Yjs](https://docs.yjs.dev/)** | 13.6.10 via esm.sh | Powers Live Share document synchronization. | Lazy-loaded on Live Share |
+| **[PlantUML](https://plantuml.com/)** | Remote service | Renders PlantUML diagrams when local desktop commands are unavailable. | Network request on PlantUML render |
+| **[Kroki](https://kroki.io/)** | Remote service | Renders D2, Graphviz, Vega-Lite, WaveDrom, and fallback diagram SVGs. | Network request on supported diagram render |
+| **[mermaid.ink](https://mermaid.ink/)** | Remote service | Provides preview/fallback Mermaid image rendering in selected flows. | Network request on selected diagram previews |
 
 ---
 
@@ -483,7 +509,9 @@ Thanks to everyone who has contributed to Markdown Viewer.
 
 ## 📈 Development Journey
 
-Markdown Viewer has grown from a lightweight Markdown parser into a full-featured, professional application with advanced rendering, workflow, and export capabilities. Compare the <a href="https://markdownviewer.pages.dev/" target="_blank" rel="noopener noreferrer">current version</a> with the <a href="https://a1b91221.markdownviewer.pages.dev/" target="_blank" rel="noopener noreferrer">original version</a> to see the progress in UI design, performance optimization, and feature depth.
+Markdown Viewer started as a small personal project on a PC: a simple Markdown viewer built with curiosity, mistakes, fixes, and a lot of care. The <a href="https://a1b91221.markdownviewer.pages.dev/" target="_blank" rel="noopener noreferrer">original version</a> is still online, and it remains the heart of the project.
+
+The current <a href="https://markdownviewer.pages.dev/" target="_blank" rel="noopener noreferrer">Markdown Viewer</a> grew through community feedback, issues, PRs, screenshots, GIFs, suggestions, and real documentation workflows. The technical progress matters, but the journey is also emotional: people helped shape the app into what it is today.
 
 ---
 

--- a/desktop-app/README.md
+++ b/desktop-app/README.md
@@ -1,97 +1,103 @@
-# Markdown Viewer Desktop App Port
+# Markdown Viewer Desktop App
 
-This is a desktop app port of [Markdown Viewer](https://github.com/ThisIs-Developer/Markdown-Viewer), see [README](../README.md). It is built using [Neutralinojs](https://github.com/neutralinojs/neutralinojs).
+This folder contains the Neutralino desktop wrapper for Markdown Viewer v3.9.0. It turns the browser-based Markdown editor, viewer, and reader into a desktop app for opening local `.md` files, using split live preview, exporting documents, and working with native file dialogs. It reuses the root web app and adds native window lifecycle handling, desktop storage mirroring, and an offline-prepared resource bundle.
+
+For the complete product behavior and privacy reference, see [../wiki/Features.md](../wiki/Features.md).
 
 ## Architecture
 
-The desktop app **shares** its core files (`script.js`, `styles.css`, `assets/`) with the browser version in the repo root. A build script (`prepare.js`) copies these files into `resources/` and injects Neutralinojs-specific additions into `index.html` at build time.
+The desktop app shares the same core product code as the browser version:
 
-Neutralinojs platform binaries are managed by `setup-binaries.js`, which downloads them on first use and caches them in `bin/` (gitignored). The download is version-locked to `cli.binaryVersion` in `neutralino.config.json` and only re-triggered when that version changes.
+- `../index.html`
+- `../script.js`
+- `../styles.css`
+- `../preview-worker.js`
+- `../assets/`
 
-Desktop-only files (not generated):
+`prepare.js` copies those files into `desktop-app/resources`, rewrites paths for Neutralino, downloads external libraries into `resources/libs`, verifies SHA-384 integrity where available, and strips web-only SEO metadata from the desktop HTML.
 
-- `resources/js/main.js` — Neutralinojs lifecycle, tray menu, window events
-- `resources/js/neutralino.js` — Neutralinojs client library
-- `neutralino.config.json` — App configuration
-- `setup-binaries.js` — Idempotent binary setup (downloads on first use)
+Desktop-only files:
+
+- `neutralino.config.json`: Neutralino runtime configuration and native API allowlist.
+- `setup-binaries.js`: Idempotent Neutralino binary setup.
+- `resources/js/main.js`: window close confirmation, tray setup, launch-file import, and external-open handling.
+- `resources/js/neutralino.js`: Neutralino client library.
+
+## Desktop Behavior
+
+- Local editing, preview, document tabs, exports, and settings stay on the local machine.
+- Normal app state is stored in localStorage and mirrored to Neutralino storage.
+- Native Markdown/HTML save and Markdown open flows use Neutralino dialogs and filesystem APIs.
+- A Markdown file passed as a launch argument is loaded into the editor.
+- The app asks before closing the window.
+- Prepared desktop resources load dynamic libraries from local `/libs/...` paths.
+
+Network features still use the network when invoked: GitHub import, stored Share Snapshot, Live Share, remote diagram rendering, external images, and external links.
 
 ## Development
 
-### Requirements
+Requirements:
 
-- [Node.js](https://nodejs.org/)
+- Node.js and npm.
+- Internet access for first setup and dependency preparation.
 
-### Setup
-
-No installation is required. The app is built and run using `npx` (via npm scripts).
-
-Neutralinojs platform binaries are downloaded automatically on first build or dev run. To manually trigger the download:
+Run:
 
 ```bash
+cd desktop-app
+npm install
 npm run setup
-```
-
-Binaries are cached in `bin/` (gitignored) and only re-downloaded when `cli.binaryVersion` in `neutralino.config.json` changes.
-
-### Running the app
-
-```bash
 npm run dev
 ```
 
-This automatically runs `setup` (downloads binaries if needed and prepares resources) before starting the app. Hot-reload is enabled by default. Enable the browser inspector by setting `"enableInspector": true` in `neutralino.config.json`.
+`npm run setup` downloads Neutralino binaries and runs `prepare.js`. Binaries are cached in `bin/` and refreshed when the configured Neutralino version changes.
 
-For more information, see the [Neutralinojs documentation](https://neutralino.js.org/docs/cli/neu-cli#installation).
-
-### Building the app
-
-**Default** - Build the portable Neutralino bundle:
+## Build
 
 ```bash
 npm run build
 ```
 
-Build output is placed in `dist/`.
+The current build script runs:
 
-Note: `npm run build` writes the portable app directory to
-`dist/markdown-viewer/`, including platform binaries and `resources.neu`. The
-GitHub release workflow archives that directory as a ZIP and also uploads the
-Windows x64 executable as a standalone asset.
+```bash
+npx -y @neutralinojs/neu@11.7.0 build --release --clean
+```
 
-For more information, see the [Neutralinojs documentation](https://neutralino.js.org/docs/cli/neu-cli#neu-build).
+Build output is written under `desktop-app/dist/`.
 
-### Building with Docker
+## Configuration Highlights
 
-Build binaries without installing Node.js locally:
+| Setting | Value |
+| :--- | :--- |
+| Application id | `com.markdownviewer.desktop` |
+| Version | `3.9.0` |
+| Document root | `/resources/` |
+| Default window | 1280 x 720 |
+| Minimum window | 400 x 200 |
+| Native API | Enabled |
+| Token security | One-time |
+| Logging | Disabled |
+| Neutralino binary/client version | 6.5.0 |
+
+Native APIs are intentionally allowlisted: app exit, open/save dialogs, message boxes, external URL open, tray setup, command execution, file read/write, and storage get/set.
+
+## Docker Build
+
+The desktop folder includes Docker files for building desktop artifacts in a container:
 
 ```bash
 docker compose up --build
 ```
 
-Build artifacts will be output to `desktop-app/output/`.
+Check the compose file for the mounted output path used by the current build.
 
 ## Releases
 
-Prebuilt binaries are automatically built and published as GitHub Releases when a tag matching `desktop-v*` is pushed (e.g., `desktop-v1.0.0`). See [`.github/workflows/desktop-build.yml`](../.github/workflows/desktop-build.yml).
+Prebuilt desktop assets are published through GitHub Releases. Release workflows run setup, preparation, build, and checksum generation.
 
-Each release includes:
-
-| Asset | Description |
-| ----- | ----------- |
-| `markdown-viewer-win_x64.exe` | Windows x64 executable |
-| `markdown-viewer-vX.Y.Z-portable.zip` | Portable bundle with `resources.neu` (all platforms) |
-| `source.tar.gz` | Desktop app source archive |
-| `SHA256SUMS.txt` | Checksums for all release assets |
+Unsigned desktop binaries may trigger Windows SmartScreen or macOS quarantine prompts. See [../wiki/Desktop-App.md](../wiki/Desktop-App.md) for platform launch notes.
 
 ## License
 
-**MIT**.
-
-The desktop version uses [Neutralinojs](https://github.com/neutralinojs/neutralinojs), which is also licensed under the MIT License.
-
-- [Neutralinojs](https://github.com/neutralinojs/neutralinojs): [LICENSE (MIT)](LICENSE)
-- [Markdown Viewer & Desktop Port](https://github.com/ThisIs-Developer/Markdown-Viewer): [LICENSE (MIT)](../LICENSE)
-
-## Contributors
-
-[![Contributors](https://contrib.rocks/image?repo=ThisIs-Developer/Markdown-Viewer)](https://github.com/ThisIs-Developer/Markdown-Viewer/graphs/contributors)
+Markdown Viewer is licensed under the Apache License 2.0. Neutralinojs is licensed under MIT; see the bundled Neutralino license file in this folder.

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-viewer-desktop",
   "version": "3.9.0",
   "private": true,
-  "description": "A premium client-side GitHub-style Markdown editor and live preview tool for desktop, featuring math rendering, diagrams, syntax highlighting, and PDF/HTML exports.",
+  "description": "A premium desktop Markdown editor, viewer, and reader for opening .md files with split live preview, math, diagrams, syntax highlighting, and PDF/HTML/PNG exports.",
   "scripts": {
     "setup": "node setup-binaries.js",
     "postsetup": "node prepare.js",

--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
 
     <!-- Primary Meta Tags -->
     <meta name="title" content="Markdown Viewer - Secure Online Markdown Editor and Previewer">
-    <meta name="description" content="Markdown Viewer is a powerful GitHub-style Markdown rendering tool with live preview, LaTeX math, Mermaid diagrams, syntax highlighting, dark mode, and export options to PDF, HTML, and MD—all fully client-side and secure.">
-    <meta name="keywords" content="Markdown Viewer, GitHub-style markdown, live preview, markdown editor, LaTeX support, Mermaid diagrams, PDF export, syntax highlighting, markdown to HTML, secure markdown tool, client-side markdown viewer, ThisIs-Developer, advanced markdown parser, future markdown viewer, next-gen markdown tool">
+    <meta name="description" content="Browser-based Markdown editor, viewer, and reader. Open .md files, use split live preview with sync scroll, GFM, math, Mermaid, and PDF/HTML/PNG export.">
+    <meta name="keywords" content="Markdown Viewer, browser-based markdown editor, online markdown editor, markdown viewer, markdown reader, markdown previewer, live markdown preview, split-screen markdown editor, side-by-side markdown preview, sync scroll markdown, open md file, open markdown file, GitHub-Flavored Markdown, GFM markdown, markdown to PDF, markdown to HTML, markdown to PNG, LaTeX markdown, Mermaid markdown, no signup markdown editor, markdown formatting toolbar">
     <meta name="author" content="ThisIs-Developer">
     <meta name="robots" content="index, follow, max-image-preview:large">
     <meta name="language" content="English">
@@ -52,7 +52,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://markdownviewer.pages.dev/">
     <meta property="og:title" content="Markdown Viewer - Secure Online Markdown Editor and Previewer">
-    <meta property="og:description" content="Markdown Viewer is a powerful GitHub-style Markdown rendering tool with live preview, LaTeX math, Mermaid diagrams, syntax highlighting, dark mode, and export options to PDF, HTML, and MD—all fully client-side and secure.">
+    <meta property="og:description" content="Open, read, edit, preview, and export Markdown files in a browser-based app with GFM, sync scroll, math, diagrams, and optional sharing.">
     <meta property="og:image" content="https://markdownviewer.pages.dev/assets/icon.jpg">
     <meta property="og:site_name" content="Markdown Viewer">
 
@@ -60,7 +60,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://markdownviewer.pages.dev/">
     <meta property="twitter:title" content="Markdown Viewer - Secure Online Markdown Editor and Previewer">
-    <meta property="twitter:description" content="Markdown Viewer is a powerful GitHub-style Markdown rendering tool with live preview, LaTeX math, Mermaid diagrams, syntax highlighting, dark mode, and export options to PDF, HTML, and MD—all fully client-side and secure.">
+    <meta property="twitter:description" content="Open, read, edit, preview, and export Markdown files in a browser-based app with GFM, sync scroll, math, diagrams, and optional sharing.">
     <meta property="twitter:image" content="https://markdownviewer.pages.dev/assets/icon.jpg">
 
     <!-- JSON-LD Structured Data Schema for Search Rich Snippets -->
@@ -71,17 +71,22 @@
       "name": "Markdown Viewer",
       "url": "https://markdownviewer.pages.dev/",
       "image": "https://markdownviewer.pages.dev/assets/icon.jpg",
-      "description": "A powerful GitHub-style Markdown rendering tool with live preview, LaTeX, Mermaid, syntax highlighting, and PDF export.",
+      "description": "A browser-based Markdown editor, viewer, and reader for opening .md files, writing plain Markdown, and using split-screen live preview with GitHub-Flavored Markdown, sync scrolling, LaTeX math, Mermaid diagrams, syntax highlighting, and PDF, HTML, PNG, or Markdown export.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "All",
       "browserRequirements": "Requires HTML5 compatible browser",
       "softwareVersion": "3.9.0",
       "featureList": [
-        "Client-side Markdown editing",
-        "GitHub-style live preview",
+        "Browser-based Markdown editor, viewer, and reader",
+        "Open local .md and .markdown files",
+        "Split-screen live Markdown preview",
+        "Sync scrolling between editor and preview",
+        "GitHub-Flavored Markdown support",
+        "Markdown formatting toolbar",
         "LaTeX math rendering",
         "Mermaid diagram rendering",
-        "PDF, HTML, PNG, and Markdown export"
+        "PDF, HTML, PNG, and Markdown export",
+        "Optional Share Snapshot and Live Share workflows"
       ],
       "author": {
         "@type": "Organization",
@@ -139,13 +144,13 @@
                 <!-- Right section: Toolbar -->
                 <div class="toolbar d-none d-md-flex header-right">
                     <div class="toolbar-group view-toolbar" role="group" aria-label="View mode">
-                        <button class="tool-button view-toggle-btn" data-view-mode="editor" aria-pressed="false" title="Editor only" aria-label="Editor only">
+                        <button class="tool-button view-toggle-btn" data-view-mode="editor" aria-pressed="false" title="Markdown editor only" aria-label="Markdown editor only">
                             <i class="bi bi-file-text"></i>
                         </button>
-                        <button class="tool-button view-toggle-btn is-active" data-view-mode="split" aria-pressed="true" title="Split view" aria-label="Split view">
+                        <button class="tool-button view-toggle-btn is-active" data-view-mode="split" aria-pressed="true" title="Split editor and live preview" aria-label="Split editor and live preview">
                             <i class="bi bi-layout-split"></i>
                         </button>
-                        <button class="tool-button view-toggle-btn" data-view-mode="preview" aria-pressed="false" title="Preview only" aria-label="Preview only">
+                        <button class="tool-button view-toggle-btn" data-view-mode="preview" aria-pressed="false" title="Markdown preview only" aria-label="Markdown preview only">
                             <i class="bi bi-eye"></i>
                         </button>
                     </div>
@@ -248,15 +253,15 @@
 
                         <!-- Story 1.4: Mobile View Mode Buttons -->
                         <div class="mobile-view-mode-group mb-3" role="group" aria-label="View mode">
-                            <button class="mobile-view-mode-btn" data-mode="editor" aria-pressed="false" title="Editor only">
+                            <button class="mobile-view-mode-btn" data-mode="editor" aria-pressed="false" title="Markdown editor only">
                                 <i class="bi bi-file-text"></i>
                                 <span>Editor</span>
                             </button>
-                            <button class="mobile-view-mode-btn active" data-mode="split" aria-pressed="true" title="Split view">
+                            <button class="mobile-view-mode-btn active" data-mode="split" aria-pressed="true" title="Split editor and live preview">
                                 <i class="bi bi-layout-split"></i>
                                 <span>Split</span>
                             </button>
-                            <button class="mobile-view-mode-btn" data-mode="preview" aria-pressed="false" title="Preview only">
+                            <button class="mobile-view-mode-btn" data-mode="preview" aria-pressed="false" title="Markdown preview only">
                                 <i class="bi bi-eye"></i>
                                 <span>Preview</span>
                             </button>
@@ -360,7 +365,7 @@
         </div>
 
         <!-- Markdown Formatting Toolbar -->
-        <div class="markdown-format-toolbar" id="markdown-format-toolbar" role="toolbar" aria-label="Markdown formatting toolbar">
+        <div class="markdown-format-toolbar" id="markdown-format-toolbar" role="toolbar" aria-label="Markdown formatting toolbar for plain-text editing">
           <div class="markdown-toolbar-group">
             <button type="button" class="markdown-tool-btn" data-md-action="undo" title="Undo" aria-label="Undo"><i class="bi bi-arrow-counterclockwise"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="redo" title="Redo" aria-label="Redo"><i class="bi bi-arrow-clockwise"></i></button>
@@ -667,7 +672,7 @@
                 <img src="assets/icon.jpg" alt="Markdown Viewer logo" class="about-logo" width="64" height="64" />
                 <div class="about-details">
                   <h3 class="about-title">Markdown Viewer</h3>
-                  <p class="about-description">A GitHub-style Markdown editor with live preview, diagrams, math, syntax highlighting, and export tools.</p>
+                  <p class="about-description">A browser-based Markdown editor, viewer, and reader for opening .md files, split-screen live preview, GFM, sync scroll, diagrams, math, syntax highlighting, and export tools.</p>
                   <p class="about-meta">Version <span id="about-version"></span> &bull; Apache License 2.0 &bull; Open source</p>
                 </div>
               </div>
@@ -1116,7 +1121,7 @@
                     <div class="skeleton-placeholder skeleton-line skeleton-w92"></div>
                     <div class="skeleton-placeholder skeleton-line skeleton-w45"></div>
                 </div>
-                <textarea id="markdown-editor" placeholder="Type or paste your Markdown here..."></textarea>
+                <textarea id="markdown-editor" placeholder="Type, paste, or import Markdown here..." aria-label="Markdown editor input with live preview"></textarea>
                 <div class="drop-hint" aria-hidden="true">
                     <i class="bi bi-cloud-arrow-up me-1"></i>Drop a .md file anywhere to open it
                 </div>
@@ -1125,7 +1130,7 @@
             <div class="resize-divider" role="separator" aria-orientation="vertical" aria-label="Resize panes" tabindex="0">
                 <div class="resize-divider-handle"></div>
             </div>
-            <div class="preview-pane">
+            <div class="preview-pane" role="region" aria-label="Rendered Markdown live preview">
                 <div id="markdown-preview" class="markdown-body">
                     <!-- Initial dynamic article skeleton loader -->
                     <div class="skeleton-preview-container" id="markdown-preview-skeleton" aria-hidden="true">
@@ -1223,7 +1228,7 @@
 
     <textarea id="default-markdown" hidden aria-hidden="true">---
 title: Welcome to Markdown Viewer
-description: A GitHub-style Markdown renderer with live preview, math, diagrams, and export support.
+description: Browser-based Markdown editor, viewer, and reader with .md file opening, live preview, GFM, sync scroll, math, diagrams, and export support.
 author: ThisIs-Developer
 tags: ["markdown", "preview", "mermaid", "latex", "open-source"]
 ---
@@ -1231,8 +1236,9 @@ tags: ["markdown", "preview", "mermaid", "latex", "open-source"]
 # Welcome to Markdown Viewer
 
 ## ✨ Key Features
-- **Live Preview** with GitHub styling
-- **Smart Import/Export** (MD, HTML, PDF)
+- **Split-Screen Live Markdown Preview** with GitHub-style rendering and sync scroll
+- **Open Local .md and .markdown Files** by picker or drag and drop
+- **Smart Import/Export** (MD, HTML, PDF, PNG)
 - **Mermaid Diagrams** for visual documentation
 - **LaTeX Math Support** for scientific notation
 - **Emoji Support** 😄 👍 🎉
@@ -1387,7 +1393,7 @@ Quote someone famous:
 
 ## 🛡️ Security Note
 
-This is a fully client-side application. Your content never leaves your browser and stays secure on your device.
+Markdown Viewer keeps normal editing, previewing, and autosave on your device. Content can leave your device only when you use network features such as GitHub import, remote diagram rendering, Share Snapshot, Live Share, external images, or CDN-hosted libraries.
 </textarea>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" defer></script>

--- a/locales/README_ja.md
+++ b/locales/README_ja.md
@@ -31,6 +31,10 @@
 
 </div>
 
+> Current documentation note: this localized README is a summary. The complete and current v3.9.0 feature, limitation, storage, sharing, and privacy documentation for the premium browser-based Markdown editor/viewer is maintained in [the English wiki](../wiki/Home.md), especially [Features](../wiki/Features.md), [Usage Guide](../wiki/Usage-Guide.md), and [FAQ](../wiki/FAQ.md).
+>
+> Important current behavior: Markdown Viewer can open local `.md` and `.markdown` files, use split live preview with sync scrolling, and export to Markdown, HTML, PDF, and PNG. Normal editing and autosave stay on your device. GitHub import contacts GitHub. Remote diagram renderers may receive diagram source. Small Share Snapshot links keep content in the URL hash; larger snapshots use Cloudflare KV for 90 days. Live Share uses a temporary Cloudflare Durable Object room and is not permanent document storage.
+
 <p align="center">
   <img src="https://github.com/user-attachments/assets/20358a0c-e6c9-4e24-ad26-8a5b2f48d538" alt="Markdown Viewer - GFMレンダリング、タブ付きマルチドキュメントワークスペース、ダークテーマに対応した、リアルタイム分割画面Markdownエディタ&プレビューア" width="100%" />
 </p>
@@ -357,8 +361,6 @@ docker compose up -d
 
    # Windows やその他のシステム向けにアプリケーションをビルド/コンパイルする
    npm run build
-   # または、スタンドアロンのポータブル実行可能ファイルをビルドする
-   npm run build:portable
    ```
 
 *注意：自身でコンパイルすることなく、[リリース](https://github.com/ThisIs-Developer/Markdown-Viewer/releases) ページから直接ビルド済みのスタンドアロンバイナリをダウンロードすることも可能です。*

--- a/locales/README_ko.md
+++ b/locales/README_ko.md
@@ -31,6 +31,10 @@
 
 </div>
 
+> Current documentation note: this localized README is a summary. The complete and current v3.9.0 feature, limitation, storage, sharing, and privacy documentation for the premium browser-based Markdown editor/viewer is maintained in [the English wiki](../wiki/Home.md), especially [Features](../wiki/Features.md), [Usage Guide](../wiki/Usage-Guide.md), and [FAQ](../wiki/FAQ.md).
+>
+> Important current behavior: Markdown Viewer can open local `.md` and `.markdown` files, use split live preview with sync scrolling, and export to Markdown, HTML, PDF, and PNG. Normal editing and autosave stay on your device. GitHub import contacts GitHub. Remote diagram renderers may receive diagram source. Small Share Snapshot links keep content in the URL hash; larger snapshots use Cloudflare KV for 90 days. Live Share uses a temporary Cloudflare Durable Object room and is not permanent document storage.
+
 <p align="center">
   <img src="https://github.com/user-attachments/assets/20358a0c-e6c9-4e24-ad26-8a5b2f48d538" alt="Markdown Viewer - GFM 렌더링, 탭 방식의 다중 문서 작업 공간 및 다크 테마를 지원하는 실시간 분할 화면 Markdown 에디터 및 미리보기 창" width="100%" />
 </p>
@@ -357,8 +361,6 @@ docker compose up -d
 
    # Windows 및 기타 시스템용 애플리케이션 빌드/컴파일
    npm run build
-   # 또는 독립형 포터블 실행 파일 빌드
-   npm run build:portable
    ```
 
 *참고: 직접 컴파일하지 않고 [릴리스](https://github.com/ThisIs-Developer/Markdown-Viewer/releases) 페이지에서 미리 빌드된 독립형 바이너리를 직접 다운로드할 수도 있습니다.*

--- a/locales/README_zh.md
+++ b/locales/README_zh.md
@@ -31,6 +31,10 @@
 
 </div>
 
+> Current documentation note: this localized README is a summary. The complete and current v3.9.0 feature, limitation, storage, sharing, and privacy documentation for the premium browser-based Markdown editor/viewer is maintained in [the English wiki](../wiki/Home.md), especially [Features](../wiki/Features.md), [Usage Guide](../wiki/Usage-Guide.md), and [FAQ](../wiki/FAQ.md).
+>
+> Important current behavior: Markdown Viewer can open local `.md` and `.markdown` files, use split live preview with sync scrolling, and export to Markdown, HTML, PDF, and PNG. Normal editing and autosave stay on your device. GitHub import contacts GitHub. Remote diagram renderers may receive diagram source. Small Share Snapshot links keep content in the URL hash; larger snapshots use Cloudflare KV for 90 days. Live Share uses a temporary Cloudflare Durable Object room and is not permanent document storage.
+
 <p align="center">
   <img src="https://github.com/user-attachments/assets/20358a0c-e6c9-4e24-ad26-8a5b2f48d538" alt="Markdown Viewer - 实时分屏 Markdown 编辑器及预览器，支持 GFM 渲染、标签式多文档工作区及暗黑主题" width="100%" />
 </p>
@@ -357,8 +361,6 @@ docker compose up -d
 
    # 为 Windows 和其他系统构建/编译应用
    npm run build
-   # 或构建独立的便携式可执行文件
-   npm run build:portable
    ```
 
 *注意：您也可以直接从[发布 (Releases)](https://github.com/ThisIs-Developer/Markdown-Viewer/releases)页面下载预构建的独立二进制文件，而无需自己编译。*

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Markdown Viewer",
   "short_name": "Markdown Viewer",
-  "description": "A premium client-side GitHub-style Markdown editor and live preview tool.",
+  "description": "Premium browser-based Markdown editor, viewer, and reader for opening .md files with split live preview, sync scroll, GFM, math, diagrams, and PDF/HTML/PNG export.",
   "id": "/",
   "start_url": "./index.html?utm_source=pwa",
   "scope": "./",

--- a/script.js
+++ b/script.js
@@ -2185,7 +2185,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       templateText = defaultMarkdownTemplate.textContent ? defaultMarkdownTemplate.textContent.trim() : '';
     }
   }
-  const sampleMarkdown = templateText || '# Welcome to Markdown Viewer\n\nStart typing your markdown here...';
+  const sampleMarkdown = templateText || '# Welcome to Markdown Viewer\n\nStart typing, pasting, or importing Markdown to use the live preview...';
 
   if (!markdownEditor.value) {
     markdownEditor.value = sampleMarkdown;

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,194 +1,203 @@
-# System & Build Configuration
+# Configuration
 
-This page details the configuration variables, local storage structures, container files, and desktop configuration parameters for **Markdown Viewer** (v3.9.0).
+This page documents the runtime, storage, dependency, Docker, Cloudflare, and desktop configuration used by Markdown Viewer v3.9.0.
 
----
+## Browser and Desktop Storage
 
-## Table of Contents
-
-- [Client-Side LocalStorage Keys](#client-side-localstorage-keys)
-- [CDN Library Integrations](#cdn-library-integrations)
-- [Nginx Container Configuration](#nginx-container-configuration)
-- [Docker Compose Service Schema](#docker-compose-service-schema)
-- [NeutralinoJS Desktop Configuration](#neutralinojs-desktop-configuration)
-- [Desktop App Package Scripts](#desktop-app-package-scripts)
-- [GitHub Actions Workflows](#github-actions-workflows)
-
----
-
-## Client-Side LocalStorage Keys
-
-The web application stores user preferences and document states directly in the browser's `localStorage`.
-
-| LocalStorage Key | Type | Default Value | Description |
-| :--- | :--- | :--- | :--- |
-| `theme` | `"light"` \| `"dark"` | System preference | Renders light or dark colors. |
-| `syncScroll` | `"true"` \| `"false"` | `"true"` | Controls editor-preview scroll sync. |
-| `viewMode` | `"split"` \| `"editor"` \| `"preview"` | `"split"` | Sets the default editing layout. |
-| `markdown_tabs` | `JSON string` | Sample tab schema | Array of document objects (ID, title, content, scroll position, view mode). |
-
----
-
-## CDN Library Integrations
-
-Markdown Viewer loads large dependencies from CDNs. To update a library or pin it to a specific version, modify the script or link tag in the head of `index.html`:
-
-| Library Name | Version | CDN Service Provider | Core URL |
-| :--- | :--- | :--- | :--- |
-| **Marked.js** | `9.1.6` | jsDelivr | `https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js` |
-| **Highlight.js** | `11.9.0` | cdnjs | `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js` |
-| **DOMPurify** | `3.0.9` | jsDelivr | `https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js` |
-| **MathJax** | `3.2.2` | jsDelivr | `https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js` |
-| **Mermaid** | `11.15.0` | jsDelivr | `https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js` |
-| **jsPDF** | `2.5.1` | cdnjs | `https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js` |
-| **html2canvas** | `1.4.1` | cdnjs | `https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js` |
-| **Pako** | `2.1.0` | cdnjs | `https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js` |
-| **js-yaml** | `4.1.0` | cdnjs | `https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js` |
-| **FileSaver.js** | `2.0.5` | cdnjs | `https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js` |
-| **Bootstrap** | `5.3.2` | jsDelivr | `https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.js` |
-
----
-
-## Nginx Container Configuration
-
-The container image is built using `nginx:alpine`. Static web files are served from `/usr/share/nginx/html/`.
-
-### Embedded Nginx Configuration (`/etc/nginx/conf.d/default.conf`)
-```nginx
-server {
-    listen 80;
-    server_name localhost;
-    root /usr/share/nginx/html;
-    index index.html;
-
-    # SPA Routing Fallback
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    # Static Assets Caching (1 year)
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # Security Headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-}
-```
-
----
-
-## Docker Compose Service Schema
-
-The `docker-compose.yml` file defines how the container runs locally:
-
-```yaml
-services:
-  markdown-viewer:
-    image: ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-    container_name: markdown-viewer
-    ports:
-      - "8080:80"
-    restart: unless-stopped
-```
-
-To build and run a local image instead of pulling the pre-built container from the registry, replace the `image` key with `build: .`:
-```yaml
-services:
-  markdown-viewer:
-    build: .
-    container_name: markdown-viewer
-    ports:
-      - "8080:80"
-    restart: unless-stopped
-```
-
----
-
-## NeutralinoJS Desktop Configuration
-
-The desktop application uses the NeutralinoJS framework, which is configured in `desktop-app/neutralino.config.json`.
-
-```json
-{
-  "applicationId": "js.neutralino.markdownviewer",
-  "version": "1.2.0",
-  "defaultMode": "window",
-  "enableServer": true,
-  "enableNativeAPI": true,
-  "tokenSecurity": "one-time",
-  "logging": {
-    "enabled": true,
-    "writeToLogFile": true
-  },
-  "nativeAllowList": [
-    "app.*",
-    "os.*",
-    "debug.*",
-    "filesystem.*"
-  ],
-  "window": {
-    "title": "Markdown Viewer",
-    "width": 1000,
-    "minWidth": 800,
-    "height": 700,
-    "minHeight": 500,
-    "resizable": true,
-    "maximize": false,
-    "center": true
-  },
-  "modes": {
-    "window": {
-      "index": "/index.html",
-      "icon": "/resources/assets/icon.jpg"
-    }
-  },
-  "cli": {
-    "binaryName": "markdown-viewer",
-    "resourcesPath": "/resources/",
-    "extensionsPath": "/extensions/",
-    "clientLibrary": "/resources/js/neutralino.js",
-    "binaryVersion": "6.5.0",
-    "clientVersion": "11.7.0"
-  }
-}
-```
-
-### Key Window Settings
-*   `width` / `height`: The default launch window size in pixels ($1000 \times 700$).
-*   `minWidth` / `minHeight`: Restricts window scaling below $800 \times 500$ to prevent UI layout issues.
-*   `nativeAllowList`: Grants the application permission to access OS and filesystem APIs (e.g. `filesystem.*` is required for loading and saving local files).
-
----
-
-## Desktop App Package Scripts
-
-The `desktop-app/package.json` file contains scripts for development, packaging, and dependency updates:
-
-| Script Name | Command | Description |
+| Key | Location | Purpose |
 | :--- | :--- | :--- |
-| `setup` | `node setup-binaries.js` | Downloads Neutralino platform-specific runtimes. |
-| `dev` | `npx @neutralinojs/neu run` | Starts the desktop app in hot-reload development mode. |
-| `prepare` | `node prepare.js` | Copies core files from the project root into the desktop build directory. |
-| `build` | `node build-windows.js` | Compiles a single-file executable for Windows. |
-| `build:portable` | `npx @neutralinojs/neu build --release` | Packages the application into zip files for Windows, Linux, and macOS. |
+| `markdownViewerTabs` | `localStorage`, mirrored to Neutralino storage in desktop | Normal saved tabs. Temporary share/live tabs are excluded. |
+| `markdownViewerActiveTab` | `localStorage`, mirrored in desktop | Active tab id. |
+| `markdownViewerUntitledCounter` | `localStorage`, mirrored in desktop | Next Untitled document number. |
+| `markdownViewerGlobalState` | `localStorage`, mirrored in desktop | Theme, direction, view mode, scroll sync, and other global UI preferences. |
+| `app-lang` | `localStorage` | Selected UI language. |
+| `find-replace-docked` | `localStorage` | Find and Replace panel dock preference. |
 
----
+The desktop app starts by copying known Neutralino storage values back into `localStorage`, then writes through `saveStorageItem()` to keep both layers aligned.
 
-## GitHub Actions Workflows
+Temporary shared content is intentionally not persisted:
 
-The repository uses two GitHub Actions workflows:
+- Share Snapshot tabs have `kind: "share-snapshot"`.
+- Live Share participant/host tabs are stripped or restored when leaving the session.
 
-### 1. Docker Build & Publish (`docker-publish.yml`)
-*   **Triggers:** Pushes to the `main` branch, or pull requests.
-*   **Registry:** GitHub Container Registry (`ghcr.io`).
-*   **Target Architectures:** `linux/amd64` and `linux/arm64` (multi-arch build).
-*   **Tags:** `latest` for main branch releases, and commit-sha tags for development runs.
+## Client Libraries
 
-### 2. Desktop Compiler (`desktop-build.yml`)
-*   **Triggers:** Pushing Git tags that match the pattern `desktop-v*` (e.g. `desktop-v1.2.0`).
-*   **Action:** Runs on Node LTS, runs the `setup`, `prepare`, and `build:portable` scripts, and generates checksums.
-*   **Release:** Automatically creates a draft release on GitHub and uploads the compiled binaries as assets.
+The web build loads core libraries from CDN with Subresource Integrity where checked into `index.html`. Larger feature libraries are lazy-loaded from `script.js` only when needed.
+
+| Library | Version / Source | Used For | Load Behavior |
+| :--- | :--- | :--- | :--- |
+| Bootstrap | 5.3.2 | UI components | Initial page load |
+| Bootstrap Icons | 1.11.3 | Icons | Initial page load |
+| github-markdown-css | 5.3.0 | Preview styling | Initial page load |
+| Marked | 9.1.6 | Markdown parsing | Initial page load and worker |
+| Highlight.js | 11.9.0 | Code highlighting | Initial page load and worker |
+| DOMPurify | 3.0.9 | HTML sanitization | Initial page load |
+| FileSaver.js | 2.0.5 | Browser downloads | Initial page load |
+| js-yaml | 4.1.0 | Frontmatter parsing | Initial page load |
+| MathJax | 3.2.2 | LaTeX math | Lazy |
+| Mermaid | 11.15.0 | Mermaid diagrams | Lazy |
+| jsPDF | 2.5.1 | Legacy raster PDF | Lazy |
+| html2canvas | 1.4.1 | PDF/PNG capture | Lazy |
+| Pako | 2.1.0 | Share compression, diagram encoding | Lazy |
+| JoyPixels / emoji-toolkit | 9.0.1 | Emoji shortcodes | Lazy |
+| ABCJS | 6.5.2 | ABC notation and playback | Lazy |
+| Leaflet | 1.9.4 | GeoJSON/TopoJSON maps | Lazy |
+| TopoJSON | 3.0.2 | TopoJSON conversion | Lazy |
+| Three.js | r128 | STL 3D rendering | Lazy |
+| STLLoader / OrbitControls | Three r128 examples | STL loading and controls | Lazy |
+| D3 | 7 | Markmap | Lazy |
+| Markmap | 0.18.12 | Markmap diagrams | Lazy |
+| Yjs | 13.6.10 via esm.sh | Live Share document sync | Lazy |
+
+When running inside Neutralino, dynamic library URLs are rewritten to local `/libs/...` files prepared by `desktop-app/prepare.js`.
+
+## Rendering Thresholds and Limits
+
+| Setting | Value |
+| :--- | :--- |
+| Large document threshold | 15,000 characters |
+| Huge document threshold | 100,000 characters |
+| Worker render threshold | 50,000 characters |
+| Worker timeout | 12 seconds |
+| Small render debounce | 100 ms |
+| Large render debounce | 160 ms |
+| Huge render debounce | 240 ms |
+| Minimum split pane width | 20% |
+| Line-height cache size | 5,000 entries |
+| GitHub importer shown files | 30 |
+| Share URL warning ceiling | 32,000 characters |
+| Legacy share URL ceiling | 4,096 characters |
+| Server share threshold | 3,000 bytes |
+| Stored Share Snapshot max content | 500,000 characters |
+| Stored Share Snapshot TTL | 90 days |
+| Live Share max participants | 64 |
+| Live Share max message | 1 MB |
+
+## Sanitization
+
+The main preview path calls DOMPurify with additional tags and attributes needed by renderers:
+
+- Additional tags include `mjx-container` and `input`.
+- Additional attributes include `id`, `class`, `style`, `align`, `type`, `checked`, `disabled`, `data-original-code`, `role`, `aria-labelledby`, and `aria-describedby`.
+- Allowed URI schemes include HTTP(S), `mailto:`, `tel:`, `blob:`, relative URLs, and safe non-script values.
+
+Export paths use similar expanded sanitizer settings for SVG/math capture. Scripts and unsafe event handlers are still removed.
+
+## Service Worker and PWA
+
+`sw.js` uses cache name `markdown-viewer-cache-v3.9.0`.
+
+Critical assets:
+
+- `/`
+- `/index.html`
+- `/styles.css`
+- `/script.js`
+- `/preview-worker.js`
+- `/manifest.json`
+- `/assets/icon.jpg`
+
+Local shell assets use network-first behavior with cache fallback for update-sensitive paths. CDN assets from cdnjs and jsDelivr use cache-first behavior after first successful fetch. The service worker removes old `markdown-viewer-cache-*` caches on activation.
+
+Service workers require HTTPS or localhost. They do not work from `file://`.
+
+## Cloudflare Configuration
+
+`wrangler.toml` configures the Pages project:
+
+```toml
+name = "markdown-viewer"
+pages_build_output_dir = "."
+compatibility_date = "2025-04-30"
+
+[[kv_namespaces]]
+binding = "SHARE_KV"
+id = "c820d2705f5742858a27b91b88f544bd"
+
+[[durable_objects.bindings]]
+name = "LIVE_ROOMS"
+class_name = "LiveRoom"
+script_name = "markdown-viewer-live-room"
+```
+
+`SHARE_KV` stores large Share Snapshot records for 90 days. `LIVE_ROOMS` routes Live Share WebSocket rooms to Durable Objects. Share Snapshot and Live Share are separate systems.
+
+`wrangler.live-room.toml` deploys `workers/live-room-worker.js` with the `LiveRoom` Durable Object migration.
+
+## Share API
+
+`functions/api/share/[[id]].js` supports:
+
+- `OPTIONS` for CORS preflight.
+- `POST /api/share` to create a stored snapshot.
+- `GET /api/share/<id>` to load a stored snapshot.
+
+Responses set `Cache-Control: no-store` and `Access-Control-Allow-Origin: *`. Stored records contain content, mode, title, createdAt, and size. Invalid ids, missing content, oversized content, missing KV binding, and unknown routes return JSON errors.
+
+## Live Room API
+
+`functions/live-room/[[room]].js` supports WebSocket upgrades only. It validates room and secret length, requires `LIVE_ROOMS`, and forwards to a Durable Object chosen by `roomName + ":" + secret`.
+
+See [Live Share Cloudflare](Live-Share-Cloudflare) for runtime flow and limits.
+
+## Docker and Nginx
+
+The root Docker build serves static files with Nginx on port 80. The repository includes `docker-compose.yml` exposing `8080:80`.
+
+Security headers configured in Docker/Nginx documentation include:
+
+- `X-Frame-Options: SAMEORIGIN`
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+
+Self-hosters should make sure `preview-worker.js`, `sw.js`, `manifest.json`, `script.js`, `styles.css`, `assets/`, `workers/`, and `functions/` or their Cloudflare equivalents are deployed according to the features they intend to use.
+
+## Neutralino Desktop Configuration
+
+Current `desktop-app/neutralino.config.json` highlights:
+
+| Setting | Value |
+| :--- | :--- |
+| `applicationId` | `com.markdownviewer.desktop` |
+| `version` | `3.9.0` |
+| `documentRoot` | `/resources/` |
+| `url` | `/` |
+| `enableServer` | `true` |
+| `enableNativeAPI` | `true` |
+| `tokenSecurity` | `one-time` |
+| Default window | 1280 x 720 |
+| Minimum window | 400 x 200 |
+| Logging | disabled |
+| Binary name | `markdown-viewer` |
+| Neutralino binary/client version | 6.5.0 |
+
+Native allowlist:
+
+- `app.exit`
+- `os.showOpenDialog`
+- `os.showSaveDialog`
+- `os.showMessageBox`
+- `os.open`
+- `os.setTray`
+- `os.execCommand`
+- `filesystem.readFile`
+- `filesystem.writeFile`
+- `storage.setData`
+- `storage.getData`
+
+The browser/chrome modes block filesystem and/or OS APIs more aggressively.
+
+## Desktop Build Scripts
+
+`desktop-app/package.json` contains:
+
+| Script | Command Purpose |
+| :--- | :--- |
+| `setup` | Runs `setup-binaries.js` to install Neutralino binaries. |
+| `postsetup` | Runs `prepare.js`. |
+| `predev` | Runs setup before development. |
+| `dev` | Runs `npx -y @neutralinojs/neu@11.7.0 run`. |
+| `prebuild` | Runs setup before build. |
+| `build` | Runs `npx -y @neutralinojs/neu@11.7.0 build --release --clean` and removes the release zip if present. |
+
+`prepare.js` copies root app files into `desktop-app/resources`, downloads and verifies libraries, rewrites dynamic library paths, strips web-only SEO metadata, and prepares an offline-capable desktop resource bundle.

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,179 +1,111 @@
-# Contributing Guidelines
+# Contributing
 
-Thank you for your interest in contributing to **Markdown Viewer**! We welcome contributions, including bug reports, feature requests, documentation improvements, and code updates.
+Thanks for helping improve Markdown Viewer. Contributions can include bug reports, documentation fixes, renderer improvements, accessibility work, desktop packaging, deployment fixes, tests, and translations.
 
----
+## Before Changing Code
 
-## Table of Contents
+- Read [Features](Features) to understand current user-facing behavior and privacy boundaries.
+- Check `CHANGELOG.md` for historical context.
+- Keep changes scoped to the feature or bug you are working on.
+- Do not remove user-facing behavior from docs unless the code no longer implements it.
 
-- [Code of Conduct](#code-of-conduct)
-- [Reporting Bugs & Issues](#reporting-bugs--issues)
-- [Security Disclosures](#security-disclosures)
-- [Development Setup](#development-setup)
-  - [Web Application](#web-application)
-  - [Desktop Application](#desktop-application)
-- [Code Style Guidelines](#code-style-guidelines)
-  - [HTML Style](#html-style)
-  - [CSS Style](#css-style)
-  - [JavaScript Style](#javascript-style)
-- [Commit Message Conventions](#commit-message-conventions)
-- [Pull Request & Code Review Process](#pull-request--code-review-process)
-- [Repository Structure](#repository-structure)
+## Local Web Development
 
----
+The root app has no required build step.
 
-## Code of Conduct
-
-By participating in this project, you agree to maintain a respectful, professional, and inclusive environment. Please be kind and constructive in all communication and code reviews.
-
----
-
-## Reporting Bugs & Issues
-
-1.  Search the [GitHub Issue Tracker](https://github.com/ThisIs-Developer/Markdown-Viewer/issues) to verify the bug has not already been reported.
-2.  If it is a new bug, open an issue including:
-    *   A clear, descriptive title.
-    *   Detailed steps to reproduce the bug.
-    *   Expected vs. actual behavior.
-    *   Your operating system and browser versions.
-    *   Any relevant screenshots or console error messages.
-
----
-
-## Security Disclosures
-
-If you discover a security vulnerability, please report it responsibly:
-*   Do not open a public issue.
-*   Submit a private advisory via GitHub Security Advisories if enabled for the repository.
-*   Alternatively, contact the project maintainers directly with details of the vulnerability and a minimal reproduction.
-
----
-
-## Development Setup
-
-### Web Application
-The core web app requires no build step. To serve `index.html` on localhost (`127.0.0.1`) and run it locally:
-
-1.  Clone the repository:
-    ```bash
-    git clone https://github.com/ThisIs-Developer/Markdown-Viewer.git
-    cd Markdown-Viewer
-    ```
-2.  Serve the root directory using a local web server:
-    ```bash
-    # Serve with Python (built-in, no dependencies)
-    python3 -m http.server 8080
-    # or
-    # Serve with Node.js serve
-    npx serve . -p 8080
-    ```
-3.  Open **http://localhost:8080** or **http://127.0.0.1:8080** in your browser and edit files like `index.html`, `script.js`, or `styles.css`.
-
-### Desktop Application
-To set up the NeutralinoJS desktop environment:
-
-1.  Navigate to the desktop directory:
-    ```bash
-    cd Markdown-Viewer/desktop-app
-    ```
-2.  Install dependencies:
-    ```bash
-    npm install
-    ```
-3.  Download the Neutralino runtime binaries:
-    ```bash
-    node setup-binaries.js
-    ```
-4.  Copy the latest frontend assets into the desktop directory:
-    ```bash
-    node prepare.js
-    ```
-5.  Start the app in development mode with hot-reload:
-    ```bash
-    npm run dev
-    ```
-
----
-
-## Code Style Guidelines
-
-### HTML Style
-*   Use **2-space indentation**.
-*   Write semantic HTML5 tags (`<header>`, `<main>`, `<section>`, etc.) and ensure they are nested correctly.
-*   Include `aria-*` attributes and roles to maintain accessibility.
-*   Do not write inline CSS styles; place all styles in `styles.css`.
-
-### CSS Style
-*   Use **2-space indentation**.
-*   Use CSS variables (custom properties) on `:root` and `[data-theme="dark"]` to manage colors, borders, and margins.
-*   Scope transitions to specific properties (e.g. `transition: background-color 0.2s`) to avoid repainting the entire viewport during theme switches.
-*   Group style sheets logically using clear comments (e.g. `/* --- Editor Layout --- */`).
-
-### JavaScript Style
-*   Use **2-space indentation** and insert semicolons.
-*   Use Vanilla ES6 JavaScript without external frameworks.
-*   Use `const` for constant references and `let` for variables. Do not use `var`.
-*   Offload CPU-intensive parsing or formatting logic to the Web Worker (`preview-worker.js`) to keep the main UI thread responsive.
-*   Debounce event handlers that trigger rendering or layout calculations.
-
----
-
-## Commit Message Conventions
-
-We use the **Conventional Commits** standard to organize project changes. Commit messages must use the following format:
-
-```
-<type>(<scope>): <description>
-
-[body]
-[footer]
+```bash
+git clone https://github.com/ThisIs-Developer/Markdown-Viewer.git
+cd Markdown-Viewer
+python -m http.server 8080
 ```
 
-### Commit Types:
-*   `feat`: A new user-facing feature.
-*   `fix`: A bug fix.
-*   `docs`: Changes to documentation files (such as the wiki or README).
-*   `style`: Formatting updates (whitespace, semicolons) that do not affect code logic.
-*   `refactor`: Code restructuring that neither fixes a bug nor adds a feature.
-*   `perf`: Performance-related optimizations.
-*   `chore`: Tasks like updating dependencies, build configurations, or CI files.
+Open `http://localhost:8080`.
 
-### Commit Examples:
-*   `feat(editor): add keyboard shortcut for fullscreen mode`
-*   `fix(pdf): correct page breaks in long tables`
-*   `docs(wiki): add Mermaid diagrams formatting guide`
-*   `chore(deps): update marked.js version to 9.1.6`
+Use a local HTTP server, not `file://`, because Web Workers and Service Workers depend on browser origin rules.
 
----
+## Desktop Development
 
-## Pull Request & Code Review Process
+```bash
+cd desktop-app
+npm install
+npm run setup
+npm run dev
+```
 
-1.  Fork the repository and create a new feature branch from `main`:
-    ```bash
-    git checkout -b feature/my-feature-name
-    ```
-2.  Make your changes, verify your code style, and test them across modern browsers (Chrome, Firefox, Safari, Edge).
-3.  Commit your updates following the [Commit Message Conventions](#commit-message-conventions).
-4.  Rebase your branch to ensure it is up to date with the upstream `main` branch before submitting:
-    ```bash
-    git fetch upstream
-    git rebase upstream/main
-    ```
-5.  Open a Pull Request pointing to the upstream repository's `main` branch. Complete the pull request template with details of the changes and any related issues.
-6.  A project maintainer will review your pull request. Please address any review comments before the code is merged. Once approved, the pull request will be squash-merged.
+Run `npm run setup` or `node prepare.js` after changing root assets that the desktop build consumes. Desktop generated resource files should match the root app after preparation.
 
----
+## Cloudflare Features
 
-## Repository Structure
+Stored Share Snapshot requires `SHARE_KV`. Live Share requires `LIVE_ROOMS` and the `LiveRoom` Durable Object.
 
-Below is an overview of the key folders and files in the repository:
+When changing share or live behavior, update:
 
-*   `index.html`: The entry-point HTML page.
-*   `script.js`: The main controller and UI interaction script.
-*   `preview-worker.js`: The background Web Worker script that compiles Markdown.
-*   `styles.css`: CSS styles and themes.
-*   `sw.js`: The Service Worker cache proxy script.
-*   `Dockerfile` / `docker-compose.yml`: Docker configuration files.
-*   `assets/`: Image assets and diagrams.
-*   `wiki/`: Document source files for this wiki.
-*   `desktop-app/`: NeutralinoJS application source files.
+- `script.js`
+- `functions/api/share/[[id]].js`
+- `functions/live-room/[[room]].js`
+- `workers/live-room-worker.js`
+- `wiki/Features.md`
+- `wiki/Live-Share-Cloudflare.md`
+- `wiki/FAQ.md`
+
+## Code Style
+
+- Use plain JavaScript, HTML, and CSS unless a focused dependency is already part of the app.
+- Keep browser compatibility in mind.
+- Keep expensive work off the hot typing path.
+- Sanitize rendered HTML before insertion.
+- Preserve accessibility attributes and keyboard behavior.
+- Keep desktop native API permissions as narrow as possible.
+- Use clear names and comments only where they explain non-obvious logic.
+
+## Documentation Rules
+
+- Update existing wiki pages instead of creating new pages for small topics.
+- Document user-facing behavior, limits, data handling, and privacy implications.
+- Keep wording simple and direct.
+- If a feature sends data to a service, say so.
+- If a feature is local-only, say where it is stored.
+- Keep README summaries aligned with the wiki.
+
+## Commit Messages
+
+Conventional commit style is preferred:
+
+```text
+feat(editor): add table alignment option
+fix(pdf): prevent blank trailing raster page
+docs(wiki): clarify live share storage behavior
+perf(render): reduce line gutter layout work
+```
+
+Useful types include `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, and `chore`.
+
+## Pull Requests
+
+A good PR includes:
+
+- What changed.
+- Why it changed.
+- How it was tested.
+- Screenshots or recordings for UI changes.
+- Privacy/storage notes for share, import, live, renderer, or desktop changes.
+- Documentation updates when behavior changes.
+
+## Security Reports
+
+Please do not open public issues for vulnerabilities. Use GitHub Security Advisories if available or contact the maintainers privately with a minimal reproduction and impact notes.
+
+## Repository Map
+
+| Path | Purpose |
+| :--- | :--- |
+| `index.html` | App shell, toolbar, modals, default content, CDN tags. |
+| `script.js` | Main application logic. |
+| `preview-worker.js` | Worker Markdown rendering path. |
+| `styles.css` | Layout, themes, renderer styles, modals, responsive UI. |
+| `sw.js` | PWA/service-worker cache behavior. |
+| `functions/api/share/[[id]].js` | Stored Share Snapshot API. |
+| `functions/live-room/[[room]].js` | Cloudflare Pages Live Share WebSocket entry. |
+| `workers/live-room-worker.js` | Live Share Durable Object relay. |
+| `desktop-app/` | Neutralino desktop wrapper and build preparation. |
+| `wiki/` | Documentation source pages. |

--- a/wiki/Desktop-App.md
+++ b/wiki/Desktop-App.md
@@ -1,179 +1,130 @@
-# Desktop Application Guide
+# Desktop Application
 
-This page describes the architecture, development setup, build options, and platform installation procedures for the desktop version of **Markdown Viewer** (v3.9.0), powered by the **Neutralinojs** runtime framework.
+The desktop app wraps Markdown Viewer in Neutralino. It uses the same editor, preview, renderer, sharing, and export code as the web app, with native file dialogs and local desktop storage.
 
----
+## What Is Different From The Web App?
 
-## Table of Contents
+- Runs in a native Neutralino window.
+- Uses native open/save dialogs for Markdown and HTML.
+- Can read a Markdown file path passed as a launch argument.
+- Asks for confirmation before closing.
+- Mirrors selected localStorage values into Neutralino storage for restart persistence.
+- Uses a restricted native API allowlist.
+- Prepared builds load renderer libraries from local `/libs/...` files instead of CDNs.
 
-- [Overview](#overview)
-- [Workspace Directory Structure](#workspace-directory-structure)
-- [Prerequisites](#prerequisites)
-- [Local Development Setup](#local-development-setup)
-- [Running in Hot-Reload Dev Mode](#running-in-hot-reload-dev-mode)
-- [Building the Application](#building-the-application)
-- [Build Output Configurations](#build-output-configurations)
-- [Building with Docker Containerization](#building-with-docker-containerization)
-- [Platform-Specific Installation Guidelines](#platform-specific-installation-guidelines)
-  - [Windows](#windows)
-  - [Linux](#linux)
-  - [macOS](#macos)
+Network features remain network features: GitHub import, stored Share Snapshot, Live Share, remote diagram rendering, external images, and external links can still contact remote services.
 
----
+## Directory Structure
 
-## Overview
-
-The desktop version of Markdown Viewer wraps the core web application (HTML, CSS, JS) inside a lightweight native OS webview container using the **Neutralinojs** framework. 
-
-### Why Neutralinojs?
-*   **Minimal Footprint:** Unlike Electron, which bundles a full Chromium browser and Node.js instance, Neutralinojs uses the system's built-in webview. This results in an executable size of less than 15 MB (compared to 150+ MB for Electron).
-*   **Low Resource Usage:** Idle memory usage is typically under 50 MB.
-*   **Shared Codebase:** The desktop app uses the exact same core files (`script.js`, `styles.css`, `assets/`) as the web application.
-
----
-
-## Workspace Directory Structure
-
-The `desktop-app` directory contains the configuration files and build scripts for the desktop version:
-
-```
+```text
 desktop-app/
-├── package.json              # Contains npm build scripts
-├── neutralino.config.json    # Configures Neutralino window size, titles, and API permissions
-├── setup-binaries.js         # Script to download Neutralino binaries for target platforms
-├── prepare.js                # Copies core files from the root folder into the resources folder
-└── resources/                # Assets packaged into the desktop application
-    ├── index.html            # Compiled template page
-    ├── styles.css            # Stylesheet copied from the root folder
-    ├── js/
-    │   ├── main.js           # Handles desktop lifecycle events and tray menus
-    │   ├── script.js         # Copied from the root folder
-    │   └── neutralino.js     # Neutralino client API library
-    └── assets/               # Image assets copied from the root folder
+  neutralino.config.json
+  package.json
+  setup-binaries.js
+  prepare.js
+  resources/
+    index.html
+    styles.css
+    js/
+      main.js
+      script.js
+      preview-worker.js
+      neutralino.js
+    libs/
+    assets/
 ```
 
----
+`prepare.js` recreates the resource files from the root web app. Do not hand-edit generated resource copies unless you plan to rerun preparation.
 
-## Prerequisites
-
-To compile the desktop application from source, you will need:
-*   **Node.js** (v16.0.0 or later) and **npm** (installed automatically with Node).
-*   **An active internet connection** (only required during the initial setup to download Neutralino runtimes).
-
----
-
-## Local Development Setup
-
-To set up the desktop project directory locally:
-
-1.  Open your terminal and navigate to the `desktop-app` folder:
-    ```bash
-    cd Markdown-Viewer/desktop-app
-    ```
-2.  Install dependencies:
-    ```bash
-    npm install
-    ```
-3.  Download the required Neutralino framework binaries for Windows, Linux, and macOS:
-    ```bash
-    node setup-binaries.js
-    ```
-4.  Copy the latest frontend code from the repository root into the desktop build resources folder:
-    ```bash
-    node prepare.js
-    ```
-
----
-
-## Running in Hot-Reload Dev Mode
-
-To run the application locally in development mode:
+## Development
 
 ```bash
+cd desktop-app
+npm install
+npm run setup
 npm run dev
 ```
 
-This starts the desktop application in a new window. It enables a development server with **hot-reload**: edits to files in the `resources/` folder will immediately update the running application without requiring a manual rebuild.
+`npm run setup` downloads Neutralino binaries and runs `prepare.js`. Development runs the Neutralino app through `npx -y @neutralinojs/neu@11.7.0 run`.
 
----
+## Build
 
-## Building the Application
-
-You can package the application in three ways:
-
-### 1. Embedded Binary (Recommended for Windows)
-This builds a single, self-contained Windows executable file that has all application resources embedded inside the binary:
 ```bash
 npm run build
 ```
 
-### 2. Portable Distribution
-This builds the application with the binary and a separate `resources.neu` file. This is standard for multi-platform distributions:
-```bash
-npm run build:portable
-```
+The current package script runs Neutralino release build with `--clean` and removes `dist/markdown-viewer-release.zip` if it exists. Generated files appear under `desktop-app/dist/`.
 
-### 3. Build All Formats
-This compiles both the portable distribution ZIP file and the embedded Windows executable:
-```bash
-npm run build:all
-```
+## Runtime Configuration
 
----
+Important `neutralino.config.json` values:
 
-## Build Output Configurations
+| Setting | Current Value |
+| :--- | :--- |
+| Application id | `com.markdownviewer.desktop` |
+| Version | `3.9.0` |
+| Document root | `/resources/` |
+| Default mode | `window` |
+| Window size | 1280 x 720 |
+| Minimum size | 400 x 200 |
+| Native API | Enabled |
+| Token security | One-time |
+| Logging | Disabled |
+| Binary/client version | 6.5.0 |
 
-Compiled files are placed in the `desktop-app/dist/` directory:
+Allowed native APIs:
 
-```
-dist/
-├── markdown-viewer/                         # Contains portable binaries
-├── markdown-viewer-release.zip              # Compressed portable distribution
-└── windows-embedded/
-    └── markdown-viewer/
-        └── markdown-viewer-win_x64.exe      # Single-file Windows binary
-```
+- `app.exit`
+- `os.showOpenDialog`
+- `os.showSaveDialog`
+- `os.showMessageBox`
+- `os.open`
+- `os.setTray`
+- `os.execCommand`
+- `filesystem.readFile`
+- `filesystem.writeFile`
+- `storage.setData`
+- `storage.getData`
 
----
+Browser/chrome modes block filesystem and OS APIs more tightly.
 
-## Building with Docker Containerization
+## Desktop Preparation
 
-To package the application without installing Node.js locally, use the provided Docker Compose configuration to compile the binaries inside a container:
+`prepare.js`:
 
-```bash
-# Run from the desktop-app folder
-docker compose up --build
-```
+- Copies the root app into `desktop-app/resources`.
+- Copies assets.
+- Moves runtime scripts to the desktop resource structure.
+- Rewrites library URLs for Neutralino.
+- Downloads required external libraries to `resources/libs`.
+- Verifies SHA-384 integrity when SRI hashes are available.
+- Bundles Bootstrap icon fonts.
+- Strips web-only SEO/canonical/hreflang/schema metadata from the desktop HTML.
 
-The container downloads the required binaries, runs the build scripts, and saves the output to the host system's `dist/` directory using a volume mount.
+This is why the prepared desktop app can run core renderers offline after setup.
 
----
+## Platform Notes
 
-## Platform-Specific Installation Guidelines
+Windows may show SmartScreen warnings because binaries are unsigned.
 
-### Windows
-*   **Installation:** No installer is needed. Run `markdown-viewer-win_x64.exe` directly.
-*   **SmartScreen Warning:** Because the executable is unsigned, Windows SmartScreen may display a warning on first launch. Click **More info**, then select **Run anyway** to launch the application.
+Linux:
 
-### Linux
-Make the binary executable before running it:
 ```bash
 chmod +x markdown-viewer-linux_x64
 ./markdown-viewer-linux_x64
 ```
 
-### macOS
-macOS blocks unsigned binaries by default. To run the app, clear the quarantine flag and make the file executable:
+macOS:
 
 ```bash
-# Remove the macOS quarantine flag
 xattr -d com.apple.quarantine markdown-viewer-mac_universal
-
-# Grant execution permissions
 chmod +x markdown-viewer-mac_universal
-
-# Run the app
 ./markdown-viewer-mac_universal
 ```
 
-Alternatively, right-click the app binary in Finder, click **Open**, and select **Open** in the confirmation dialog.
+## Data Handling
+
+- Normal documents and settings are local to the machine.
+- Native file access happens through explicit open/save actions or launch arguments.
+- The app does not include analytics or telemetry.
+- Sharing/import/remote-rendering features use the same network behavior as the web app.

--- a/wiki/Development-Journey.md
+++ b/wiki/Development-Journey.md
@@ -1,88 +1,84 @@
-# Project Development Journey
+# Development Journey
 
-This page documents the development history, design decisions, and evolution of **Markdown Viewer** from its initial prototype to the current production release (v3.9.0).
+Markdown Viewer did not begin as a polished roadmap or a finished product. It began as a personal project on a PC: a small Markdown viewer made with curiosity, failed attempts, late fixes, and the simple hope that Markdown could feel easier to read, edit, and share.
 
----
+The [first public version](https://a1b91221.markdownviewer.pages.dev/) is still something to be proud of. It was much smaller than the current app, but it carried the heart of the project: type Markdown, see it render, and make documentation feel less painful. From there, every rough edge became a reason to keep improving.
 
-## Chronological Project Evolution
+The current version exists because people used it, questioned it, broke it, reported issues, shared screenshots and GIFs, suggested workflows, opened PRs, and explained what was confusing. The project grew through community help: feature requests, bug reports, conversations, and practical feedback from real writing and documentation work.
 
-Markdown Viewer was built to address a common need: a fast, privacy-focused Markdown editor that renders rich formatting, math equations, and diagrams client-side without relying on external databases.
+This page keeps the technical record too, but the journey is not only technical. Markdown Viewer came from care, persistence, and community trust. The changelog remains the detailed version-by-version history; this page explains how that work became the v3.9.0 product documented in the wiki.
 
-```
-+------------------------------------+
-|  Phase 1: Basic Renderer (V0.1)     |
-|  - Simple textarea & Marked parser |
-|  - High typing lag on large files  |
-+-----------------+------------------+
-                  |
-                  v
-+------------------------------------+
-|  Phase 2: Off-Thread Parser (V0.5) |
-|  - Shifted parsing to Web Worker   |
-|  - Added basic highlight.js syntax |
-+-----------------+------------------+
-                  |
-                  v
-+------------------------------------+
-|  Phase 3: Patching & Features (V1.0)|
-|  - Incremental DOM patching        |
-|  - MathJax & Mermaid integrations  |
-|  - Multi-document tab bar added    |
-+-----------------+------------------+
-                  |
-                  v
-+------------------------------------+
-|  Phase 4: Release & Desktop (v3.9.0)|
-|  - Cascade PDF layout pagination   |
-|  - Neutralinojs desktop app wrap   |
-|  - Service Worker offline cache    |
-+------------------------------------+
-```
+## High-Level Evolution
 
----
+| Phase | Main Work |
+| :--- | :--- |
+| Early renderer | Basic textarea and live Markdown preview. |
+| Performance foundation | Web Worker parsing, syntax highlighting, debounced rendering, and scroll sync fixes. |
+| Rich Markdown | MathJax, Mermaid, footnotes, alerts, extended Markdown, and sanitized HTML support. |
+| Workspace | Multi-document tabs, autosave, drag reordering, custom undo/redo, mobile parity, and reset flows. |
+| Export | Markdown, standalone HTML, PDF, PNG, diagram export toolbars, and PDF page-break planning. |
+| Desktop | Neutralino wrapper, native dialogs, launch-file support, storage persistence, and offline resource bundling. |
+| Sharing | Compressed URL snapshots, modal share UX, temporary KV-backed large snapshots, and Cloudflare Live Share rooms. |
+| Advanced renderers | PlantUML, D2, Graphviz, Vega-Lite, WaveDrom, Markmap, GeoJSON, TopoJSON, STL, and ABC notation. |
+| Hardening | DOMPurify, SRI, least-privilege desktop APIs, canvas taint protection, accessibility improvements, and service-worker caching. |
 
-## Detailed Version Comparison
+## Current Release Highlights
 
-To see the differences in user interface design, rendering performance, and feature set, you can compare the original prototype with the current production build:
+v3.9.0 separates sharing into two clear workflows:
 
-| Target Area | Initial Prototype (Original V0.1) | Current Production Release (v3.9.0) |
-| :--- | :--- | :--- |
-| **Hosting Link** | [a1b91221.markdownviewer.pages.dev](https://a1b91221.markdownviewer.pages.dev/) | [markdownviewer.pages.dev](https://markdownviewer.pages.dev/) |
-| **Parsing Thread** | Main UI Thread (blocked typing) | Dedicated Background Web Worker |
-| **DOM Rendering** | Full `innerHTML` write (slow reflow) | Incremental FNV-1a Hash DOM Patching |
-| **Scroll Sync** | Basic scroll mapping (caused loops) | Locked `requestAnimationFrame` Sync |
-| **Diagram Support** | None (code text only) | Interactive Mermaid SVGs with Zoom & Pan |
-| **Math Typesetting** | None | LaTeX MathJax rendering with accessibility cleanup |
-| **Tabbed Sessions** | Single document | Drag-and-drop tab bar with localStorage autosave |
-| **Export Formats** | Raw Markdown only | Markdown, Standalone HTML, and sandboxed PDF |
-| **App Wrapper** | Browser only | NeutralinoJS Desktop Application shell |
-| **Offline Mode** | No (required online refresh) | PWA Service Worker caching (Cache-First) |
-| **File Import** | None | Drag & drop file parser and GitHub repo importer |
+- Share Snapshot creates a read-only or editable point-in-time copy. Small documents stay inside the URL hash. Larger documents are stored in Cloudflare KV for 90 days.
+- Live Share creates a temporary Cloudflare Durable Object room for real-time Yjs collaboration. The room relays updates and presence while active and does not store the document as a permanent record.
 
----
+The release also fixed shared rendering so advanced content such as LaTeX, Mermaid, TopoJSON, and other renderers complete after shared content loads, and it fixed desktop startup resource preparation.
 
-## Key Development Milestones
+## Important Design Decisions
 
-### 1. Moving to Background Web Workers
-Early testing with files larger than 10 KB showed noticeable typing lag because the main thread had to compile Markdown and highlight syntax on every keystroke. 
-Moving the parser to `preview-worker.js` resolved this. The main thread now only processes user input and patches the DOM, while the background worker handles document compilation and syntax highlighting.
+### On-Device Core
 
-### 2. Upgrading to Incremental DOM Patching
-Using `element.innerHTML` on every keystroke caused the browser to rebuild the entire preview pane. This reset scroll positions, cleared focus states, and collapsed elements like `<details>` blocks. 
-To fix this, we implemented an FNV-1a hash matching system. The app now compares hashes of incoming blocks and only replaces the DOM nodes that have changed, preserving the overall page state.
+The project started with an on-device editing model. Normal editing, previewing, local file import, local autosave, and most exports run in the browser or desktop webview.
 
-### 3. Preventing Scroll Synchronization Loops
-Initially, syncing scrolls between the editor and preview created an infinite feedback loop. 
-We resolved this by adding scroll locks (`isEditorScrolling` and `isPreviewScrolling`) combined with scheduling scroll updates inside `requestAnimationFrame`. This ensures scroll sync is smooth and loop-free.
+### Explicit Network Boundaries
 
-### 4. Implementing Cascade PDF Layout Pagination
-Default PDF exports often slice images, diagrams, and text lines across page breaks. 
-We addressed this by building a cascade pagination engine in an off-screen sandbox. It converts SVG diagrams to rasters, pushes headings below page breaks, splits tables row-by-row while duplicating the headers, and downscales oversized elements to fit the page.
+As the product grew, some useful features required network access. The documentation now names those boundaries directly:
 
----
+- GitHub import contacts GitHub.
+- Remote diagram renderers can receive diagram source.
+- Stored Share Snapshot uploads a temporary copy to Cloudflare KV.
+- Live Share relays active collaboration data through Cloudflare Durable Objects.
+- CDN libraries and external document assets can be fetched by the browser.
 
-## Transparency & Data Policies
+### Performance Before Frameworks
 
-*   **100% Client-Side Processing:** All text parsing, diagram generation, mathematical typesetting, and file exports happen inside the client browser. No document data is ever sent to an external server.
-*   **Encrypted Hash Links:** The URL sharing feature uses local zlib/deflate compression via `Pako.js`. The compressed document is stored entirely in the URL hash fragment. Because hash fragments are not sent to servers in HTTP requests, your shared content remains private.
-*   **Security Auditing:** External dependencies (DOMPurify, Marked.js, etc.) are loaded with subresource integrity (SRI) hashes to prevent loading modified scripts.
+The app stays mostly vanilla JavaScript. Instead of adopting a frontend framework, it uses:
+
+- Debounced rendering.
+- Optional worker rendering for large documents.
+- Block hashing and segmented DOM patching.
+- Cached line-height calculations.
+- RequestAnimationFrame scroll sync.
+- Lazy loading for heavy libraries.
+
+### Desktop Without Electron
+
+Neutralino was chosen to keep desktop builds lighter than Electron and reuse the web app. Desktop-specific code is limited to lifecycle handling, native dialogs, storage mirroring, and resource preparation.
+
+## Changelog Themes
+
+The changelog records many small fixes. The recurring themes are:
+
+- Rendering correctness for math, footnotes, diagrams, tables, and shared documents.
+- Export reliability for PDFs, images, diagrams, and HTML.
+- Mobile and accessibility parity.
+- Safer desktop permissions and offline packaging.
+- Better privacy wording and sharing UX.
+- Reduced blocking work during typing and startup.
+
+## Current Data Policy Summary
+
+- No analytics, telemetry, ads, accounts, or cookies are implemented.
+- Normal documents are saved locally.
+- Temporary shared/live tabs are excluded from saved workspaces.
+- Small snapshot links keep content in the URL hash.
+- Stored snapshot links use Cloudflare KV for 90 days.
+- Live Share uses Cloudflare Durable Objects as temporary relays.
+- Remote renderer and import features send only the data needed for that feature.

--- a/wiki/Docker-Deployment.md
+++ b/wiki/Docker-Deployment.md
@@ -1,31 +1,10 @@
-# Docker Deployment Guide
+# Docker Deployment
 
-This page provides comprehensive documentation for containerizing, running, and proxying **Markdown Viewer** (v3.9.0) using Docker and Docker Compose.
+Markdown Viewer's Docker image serves the static web app with Nginx. It is useful for local networks, self-hosting, and reverse-proxy deployments.
 
----
-
-## Table of Contents
-
-- [Quick Start Command](#quick-start-command)
-- [Docker Run Command Reference](#docker-run-command-reference)
-- [Docker Compose Integration](#docker-compose-integration)
-- [Building the Image Locally](#building-the-image-locally)
-- [Production Nginx Settings & Security Headers](#production-nginx-settings--security-headers)
-- [Configuring the App at a Custom Sub-Path](#configuring-the-app-at-a-custom-sub-path)
-- [Reverse Proxy Server Integrations](#reverse-proxy-server-integrations)
-  - [Nginx Configuration](#nginx-configuration)
-  - [Caddy Configuration](#caddy-configuration)
-  - [Traefik Compose Labels](#traefik-compose-labels)
-- [CI/CD Deployment Automation](#cicd-deployment-automation)
-
----
-
-## Quick Start Command
-
-To spin up a local instance immediately:
+## Quick Start
 
 ```bash
-docker pull ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
 docker run -d \
   --name markdown-viewer \
   -p 8080:80 \
@@ -33,153 +12,89 @@ docker run -d \
   ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
 ```
 
-Open **http://localhost:8080** in your browser.
+Open `http://localhost:8080`.
 
----
+## Docker Compose
 
-## Docker Run Command Reference
+The repository includes:
 
-### Custom Port Mapping
-To map the container to a different host port (such as `8081`):
-```bash
-docker pull ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-docker run -d --name markdown-viewer -p 8081:80 ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
+```yaml
+services:
+  markdown-viewer:
+    build: .
+    ports:
+      - "8080:80"
 ```
 
-### Specifying Version Tags
-You can pin the container to a specific commit or release by replacing `latest` with the appropriate tag:
-```bash
-docker run -d --name markdown-viewer -p 8080:80 ghcr.io/thisis-developer/markdown-viewer:main
-```
+Run:
 
-Available image tags:
-*   `latest`: The latest stable build from the main branch.
-*   `main`: The most recent commit pushed to the main branch.
-*   `<commit-sha>` (e.g. `e3d7a1b`): A build pinned to a specific commit.
-
----
-
-## Docker Compose Integration
-
-The repository includes a default `docker-compose.yml` file for Compose-based deployments:
-
-### Starting the Services
 ```bash
 docker compose up -d
 ```
 
-### Stopping the Services
-```bash
-docker compose down
-```
+Rebuild after local source changes:
 
-### Rebuilding Containers
-To rebuild the image using local source code changes:
 ```bash
 docker compose up -d --build
 ```
 
-### Default `docker-compose.yml` Configuration
-```yaml
-services:
-  markdown-viewer:
-    image: ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-    container_name: markdown-viewer
-    ports:
-      - "8080:80"
-    restart: unless-stopped
+Stop:
+
+```bash
+docker compose down
 ```
 
----
+## Building Locally
 
-## Building the Image Locally
+```bash
+docker build -t markdown-viewer:local .
+docker run -d --name markdown-viewer-local -p 8080:80 markdown-viewer:local
+```
 
-To build a custom Docker image from the source code:
+The root `.dockerignore` excludes desktop build output and unrelated local files from the web container.
 
-1.  Clone the repository and navigate to the project directory:
-    ```bash
-    git clone https://github.com/ThisIs-Developer/Markdown-Viewer.git
-    cd Markdown-Viewer
-    ```
-2.  Build the Docker image:
-    ```bash
-    docker build -t markdown-viewer:local .
-    ```
-3.  Run the local container:
-    ```bash
-    docker run -d --name markdown-viewer-local -p 8080:80 markdown-viewer:local
-    ```
+## What The Container Provides
 
----
+The container serves the static browser app: editor, preview, local storage, imports, exports, PWA assets, and CDN-loaded renderers.
 
-## Production Nginx Settings & Security Headers
+The container alone does not provide Cloudflare KV or Durable Objects. Stored Share Snapshot and Live Share require Cloudflare deployment or equivalent compatible endpoints.
 
-The Docker image uses `nginx:alpine` and includes custom configurations to optimize caching and security:
+## Nginx and Headers
 
-### Core Configurations
-*   **Single-Page App (SPA) Routing:** Requests are redirected to `/index.html` to support client-side routing.
-*   **Static Asset Caching:** Cache-control headers are set to one year (`max-age=31536000`) for static files (JS, CSS, images, fonts).
-*   **Security Headers:** To protect the app from typical web vulnerabilities, Nginx is configured to inject the following headers:
+The Docker image uses `nginx:alpine`. Production deployments should keep these behaviors:
+
+- Serve `index.html`, `script.js`, `styles.css`, `preview-worker.js`, `sw.js`, `manifest.json`, and `assets/`.
+- Serve JavaScript files with correct MIME types.
+- Allow Service Worker registration from the app origin.
+- Send security headers such as:
 
 ```nginx
-# Prevents the app from being embedded in iframes on other domains (XSS and Clickjacking protection)
 add_header X-Frame-Options "SAMEORIGIN" always;
-
-# Blocks browsers from MIME-type sniffing
 add_header X-Content-Type-Options "nosniff" always;
-
-# Restricts referrer information sent with outbound links
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 ```
 
----
+Use long caching carefully. `sw.js`, `index.html`, `script.js`, and `styles.css` are update-sensitive; stale versions can keep old app behavior alive.
 
-## Configuring the App at a Custom Sub-Path
+## Reverse Proxy Examples
 
-To serve Markdown Viewer from a sub-path (e.g. `example.com/editor/`) instead of the root directory, update the Nginx configuration inside the `Dockerfile`:
-
-Modify the root location block in the Nginx config to use an alias for the sub-path:
-```nginx
-server {
-    listen 80;
-    root /usr/share/nginx/html;
-
-    location /editor/ {
-        alias /usr/share/nginx/html/;
-        try_files $uri $uri/ /editor/index.html;
-    }
-}
-```
-
-Rebuild the Docker image after applying these changes.
-
----
-
-## Reverse Proxy Server Integrations
-
-### Nginx Configuration
-To set up a reverse proxy with Nginx, use this server block to forward incoming requests to the Markdown Viewer container (running on port `8080`):
+Nginx:
 
 ```nginx
 server {
     listen 443 ssl;
     server_name markdown.example.com;
 
-    ssl_certificate     /etc/ssl/certs/markdown.pem;
-    ssl_certificate_key /etc/ssl/private/markdown.key;
-
     location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
 ```
 
-### Caddy Configuration
-Caddy automatically handles HTTPS and reverse proxy configurations. Update your `Caddyfile` with the following rule:
+Caddy:
 
 ```caddyfile
 markdown.example.com {
@@ -187,28 +102,33 @@ markdown.example.com {
 }
 ```
 
-### Traefik Compose Labels
-To use Traefik to route traffic to the Markdown Viewer container, add these labels to the service definition in your `docker-compose.yml` file:
+Traefik labels:
 
 ```yaml
-services:
-  markdown-viewer:
-    image: ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-    container_name: markdown-viewer
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.mdviewer.rule=Host(`markdown.example.com`)"
-      - "traefik.http.routers.mdviewer.entrypoints=websecure"
-      - "traefik.http.routers.mdviewer.tls.certresolver=letsencrypt"
-      - "traefik.http.services.mdviewer.loadbalancer.server.port=80"
-    restart: unless-stopped
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.mdviewer.rule=Host(`markdown.example.com`)"
+  - "traefik.http.routers.mdviewer.entrypoints=websecure"
+  - "traefik.http.routers.mdviewer.tls.certresolver=letsencrypt"
+  - "traefik.http.services.mdviewer.loadbalancer.server.port=80"
 ```
 
----
+## Custom Sub-Paths
 
-## CI/CD Deployment Automation
+Serving from a sub-path such as `/editor/` requires testing:
 
-The repository includes a GitHub Actions workflow (`.github/workflows/docker-publish.yml`) that automates container building and publishing:
+- Worker URL resolution for `preview-worker.js`.
+- Service Worker scope.
+- Manifest path.
+- Asset paths in `index.html`.
+- Dynamic library loading in `script.js`.
+- Share and Live Share public base URL behavior.
 
-*   **Pushes to `main`:** Builds and pushes multi-architecture images (`linux/amd64` and `linux/arm64`) to the GitHub Container Registry (`ghcr.io`).
-*   **Pull Requests:** Automatically builds the image to verify compile status and check for errors, without publishing it to the registry.
+Root hosting is the simplest and best-tested deployment mode.
+
+## Privacy Notes For Self-Hosting
+
+- Normal documents stay in the user's browser storage.
+- Your server will serve static assets and may log normal HTTP requests.
+- URL-hash Share Snapshot content is not sent to the server as an HTTP fragment, but users can paste links into other systems.
+- Stored Share Snapshot and Live Share need Cloudflare or compatible services and have their own data flows.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,99 +1,148 @@
-# Frequently Asked Questions (FAQ)
+# Frequently Asked Questions
 
-This FAQ answers common questions about using, deploying, and troubleshooting **Markdown Viewer** (v3.9.0).
-
----
-
-## Table of Contents
-
-- [General & Privacy](#general--privacy)
-- [Editor & Preview Features](#editor--preview-features)
-- [Installation & Deployment](#installation--deployment)
-- [Troubleshooting](#troubleshooting)
-
----
-
-## General & Privacy
+## General
 
 ### What is Markdown Viewer?
-Markdown Viewer is a client-side Markdown editing suite and live preview tool. It features off-thread Web Worker parsing, incremental DOM patching, responsive split views, interactive diagrams (Mermaid), and mathematical equation formatting (LaTeX).
 
-### Is Markdown Viewer free to use?
-Yes. It is free and open-source software licensed under the **Apache License 2.0**.
+Markdown Viewer is a premium browser-based Markdown editor, viewer, reader, and previewer for opening `.md` files, writing in plain Markdown, and using a split-screen live preview with sync scrolling. It also includes document tabs, rich Markdown rendering, math, diagrams, maps, STL models, ABC music notation, export tools, optional sharing, and a desktop app.
 
-### Do I need to create an account?
-No. The application is serverless and does not require registration, login, or subscription.
+### Is it free?
 
-### Does Markdown Viewer send my content to any servers?
-No. All parsing, rendering, typesetting, and exporting happen entirely on your computer inside the browser. No document text or metadata is uploaded to external servers.
+Yes. The project is open source under the Apache License 2.0.
 
-### Do you collect analytics or telemetry data?
-No. The application does not contain tracking scripts, telemetry code, cookies, or advertising pixels.
+### Do I need an account?
 
-### What information is stored in my browser?
-The app saves your settings (theme, view mode, scroll synchronization state) and open tab documents to your browser's local storage (`localStorage`). This enables auto-saving and restores your workspace when you reload the page.
+No. There is no login, subscription, account system, analytics identity, or cloud workspace account. You can use the editor as a no-signup Markdown reader and previewer.
 
-### How do I clear all local storage data?
-You can clear this data by using your browser's site settings or developer tools:
-1.  Open the browser console (press `F12`).
-2.  Navigate to the **Application** or **Storage** tab.
-3.  Select **Local Storage** and clear the records for the site.
-4.  Alternatively, click the **Reset** button in the tab bar to clear all documents.
+### Is it a WYSIWYG Markdown editor?
 
----
+Not in the strict sense. Markdown Viewer uses a plain-text Markdown editor plus a rendered live preview. The toolbar helps insert Markdown syntax, but you do not directly edit the rendered preview like a full rich text or Typora-style WYSIWYG editor.
 
-## Editor & Preview Features
+### Can it open local .md files?
 
-### Does the app support GitHub-Flavored Markdown (GFM)?
-Yes. It uses the `marked.js` library to support standard GFM features, including tables, task checklists, strikethrough, autolinks, and emoji shortcodes.
+Yes. You can open `.md` and `.markdown` files with the file picker or drag and drop. The desktop app can also open Markdown files through native file dialogs and command-line file arguments.
 
-### Can I write math formulas and LaTeX equations?
-Yes. The application uses MathJax to format equations. You can write inline equations using single dollar signs (`$E=mc^2$`) or block equations using double dollar signs (`$$...$$`). For more details, see the [Markdown Reference](Markdown-Reference) page.
+## Privacy and Data
 
-### Can I draw flowcharts and diagrams?
-Yes. You can write diagrams using Mermaid syntax inside fenced code blocks marked with `mermaid`. The preview pane displays these as interactive SVG diagrams. Double-click any diagram in the preview to open a zoomable, draggable modal.
+### Does my Markdown leave my device?
 
-### Why does the exported PDF look different from the live preview?
-Exporting to PDF uses `html2canvas` and `jsPDF` to capture screenshots of the preview pane page-by-page. While the app uses a sandboxing and pagination engine to adjust page breaks and scale elements, some complex CSS layouts, font styles, or wide code blocks may not render perfectly.
+Normal typing, previewing, local file import, tab autosave, and most exports happen on your device. Content can leave your device when you use explicit network features:
 
-> [!TIP]
-> For the highest PDF quality, use your browser's built-in print command (`Ctrl + P` or `Cmd + P`) and select "Save as PDF".
+- GitHub import contacts GitHub.
+- Remote diagram renderers can receive diagram source.
+- Large Share Snapshot links upload a temporary copy to Cloudflare KV.
+- Live Share relays real-time updates through Cloudflare Durable Objects.
+- External images, links, map tiles, and CDN libraries can be requested by the browser.
 
----
+### Do you collect analytics or telemetry?
 
-## Installation & Deployment
+No analytics, telemetry, ads, tracking pixels, or app-specific cookies are implemented in the codebase.
 
-### Can I run the application offline?
-*   **Web version:** The default build loads libraries (like MathJax and Mermaid) from external CDNs, requiring an active internet connection on first load. Once these files are cached by the Service Worker, the application can run offline.
-*   **Desktop version:** The desktop application requires internet access on first launch to cache CDN assets. To run fully offline from the start, download the CDN dependencies locally, update the script paths in `index.html`, and rebuild the application.
+### What does the app store locally?
 
-### How do I host Markdown Viewer on my own server?
-Copy the static assets (`index.html`, `script.js`, `preview-worker.js`, `styles.css`, `sw.js`, and `assets/`) and serve them using a static web server (such as Nginx, Apache, or Caddy). 
+The app stores normal tabs, active tab id, untitled-tab counter, theme/direction/view settings, language selection, scroll sync state, and Find and Replace dock preference. Web storage uses browser `localStorage`; the desktop app mirrors selected values into Neutralino storage.
 
-> [!WARNING]
-> Do not open the `index.html` file directly using the `file://` protocol in your browser. Security policies (CORS) block Web Workers from running from local files, which will break the preview parser.
+### Are Share Snapshot links private?
 
----
+They are bearer links. Anyone with the link can open the snapshot.
 
-## Troubleshooting
+Small snapshots keep compressed content inside the URL hash. Large snapshots use `/api/share`, which stores content, mode, title, creation time, and size in Cloudflare KV for 90 days. Editable snapshots are not collaborative; they only let the recipient edit their opened copy.
 
-### Why is the preview pane blank or not updating?
-1.  Check that JavaScript is enabled in your browser.
-2.  Open your browser console (`F12`) to check for scripts blocked by security policies or network errors.
-3.  Perform a hard refresh (`Ctrl + Shift + R` or `Cmd + Shift + R`) to clear cached script instances.
+### Is Live Share saved permanently?
 
-### Why are my math equations not formatting?
-MathJax loads dynamically when math markers are detected in your document. Ensure you have an active internet connection to download the library on first use, and check that your LaTeX syntax is correct.
+No. Live Share uses a temporary Cloudflare Durable Object room as a relay. It does not write the live document to KV or a database. While active, the room relays document updates, display names, presence, cursors, sync messages, leave messages, and session-end messages.
 
-### Why are my Mermaid diagrams showing syntax errors?
-Check that:
-*   The code block tag is written in lowercase as `mermaid`.
-*   Your diagram syntax is correct. You can verify your syntax using the [Mermaid Live Editor](https://mermaid.live).
+### Is Live Share end-to-end encrypted?
 
-### Why won't the desktop application launch on macOS?
-macOS blocks unsigned binaries by default. To run the app, clear the quarantine flag using your terminal:
+No end-to-end encryption is implemented. The room id and secret are included in the invite link, and the Cloudflare Durable Object relays messages. Treat Live Share links like private bearer links.
+
+### How do I clear local data?
+
+Use the app's Reset button to clear saved documents, or clear the site's storage from browser settings/developer tools. Clearing site data also removes cached app assets and any saved settings for that origin.
+
+## Editing and Rendering
+
+### What Markdown does it support?
+
+It supports standard Markdown, GitHub-Flavored Markdown (GFM), tables, task lists, footnotes, definition lists, superscript, subscript, highlight syntax, raw sanitized HTML, GitHub alerts, YAML frontmatter in exports, LaTeX math, Mermaid, PlantUML, D2, Graphviz, Vega-Lite, WaveDrom, Markmap, GeoJSON, TopoJSON, STL, and ABC notation.
+
+### Why do some diagrams need the internet?
+
+Mermaid, Markmap, maps, STL, ABC, and MathJax use client-side libraries. PlantUML, D2, Graphviz, Vega-Lite, WaveDrom, and some insertion previews can use remote renderers such as PlantUML, Kroki, or mermaid.ink. Those remote services need network access and receive the diagram source.
+
+### Why does the preview update in stages?
+
+Base Markdown renders first. Advanced content such as MathJax, diagrams, maps, STL, ABC, and remote renderers runs after the base HTML has been sanitized and inserted. On large documents the app may use a Web Worker and segmented DOM patching to keep typing responsive.
+
+### Why did a shared document open in a temporary tab?
+
+Share Snapshot and Live Share tabs are temporary by design. They are stripped from persistent tab storage so opening someone else's link does not silently save their document into your workspace.
+
+## Import and Export
+
+### Can I import local files?
+
+Yes. Import `.md`, `.markdown`, or `text/markdown` files through the file picker or drag and drop. The app scans the first 8 KB for null bytes and rejects likely binary files.
+
+### Can I import private GitHub repositories?
+
+No. The GitHub importer only uses public GitHub URLs and does not ask for tokens.
+
+### Why are only 30 GitHub files shown?
+
+The importer limits repository/folder results to the first 30 Markdown files to keep the modal and network requests manageable.
+
+### Which PDF export should I use?
+
+Use Browser Print for most documents. It is faster and better for long text. Use Legacy Raster PDF when you need the app's page-break planning for images, tables, math, and diagrams, but expect higher memory use and possible browser canvas limits.
+
+### Why are images missing from PDF or PNG export?
+
+Canvas-based exports require images to be loaded and CORS-compatible. A remote image that blocks cross-origin canvas capture may not appear in raster PDF/PNG output.
+
+### Why does exported PDF differ from the preview?
+
+Browser Print depends on the browser print engine. Legacy Raster PDF captures an off-screen layout to canvas, applies page-break changes, scales some content, and may move blocks to avoid bad page cuts. That can differ from the live preview.
+
+## Installation and Offline Use
+
+### Can I run it offline?
+
+Yes, with limits.
+
+- The web/PWA build can work offline after the app shell and CDN libraries have been loaded and cached.
+- First use of CDN-based libraries still requires network access unless they are already cached.
+- The prepared desktop build bundles external libraries into `resources/libs` and points dynamic library loading there.
+- Features that inherently use the network, such as GitHub import, stored Share Snapshot, Live Share, remote diagram rendering, and external images, still need connectivity.
+
+### Can I open `index.html` directly?
+
+Use a local server instead. `file://` can block Web Workers and Service Workers, which breaks important rendering and offline behavior. Run `python -m http.server 8080` or `npx serve . -p 8080`.
+
+### Why will the desktop app not launch on macOS?
+
+The binaries are unsigned, so macOS may quarantine them. You can right-click and choose Open, or run:
+
 ```bash
 xattr -d com.apple.quarantine markdown-viewer-mac_universal
 chmod +x markdown-viewer-mac_universal
+./markdown-viewer-mac_universal
 ```
-You can also right-click the binary in Finder, click **Open**, and confirm the launch prompt.
+
+## Troubleshooting
+
+### The preview is blank. What should I check?
+
+Check the browser console for blocked scripts or network errors, verify JavaScript is enabled, and hard refresh. If you are using `file://`, serve the app from localhost instead.
+
+### Math does not render. Why?
+
+MathJax loads when math markers are detected. Check your LaTeX syntax and network/cache state if this is the first time using math in the web build.
+
+### Mermaid or another diagram shows an error. What now?
+
+Check the fence language and diagram syntax. For remote diagram engines, also check network access to the renderer. Remote requests time out and retry, but they cannot render while the service is unreachable.
+
+### Live Share says the room expired.
+
+The room may have ended, the host may have left, the invite may be stale, or the participant may not have received initial sync within the join timeout. Ask the host to start a new session.

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,232 +1,486 @@
-# Detailed Features & Implementation Deep Dive
+# Features and Product Behavior
 
-This document details the features of **Markdown Viewer**, focusing on their architectural execution, performance strategies, and code-level configurations for version v3.9.0.
+This page is the source-of-truth feature reference for Markdown Viewer v3.9.0. It describes what the app does, how each feature behaves for users, the implementation limits that matter in practice, and what happens to document data.
 
----
+## Product Summary
 
-## Table of Contents
+Markdown Viewer is a premium browser-based Markdown editor, viewer, reader, and previewer for opening `.md` and `.markdown` files, writing plain Markdown, and reading a live GitHub-style preview. It runs as a static web app, a Progressive Web App, a Docker-hosted static site, and a Neutralino desktop app. The editor is built around a plain textarea, a split-screen rendered preview pane with sync scrolling, document tabs, import/export tools, sharing tools, rich Markdown renderers, and optional Cloudflare endpoints for Share Snapshot and Live Share.
 
-1.  [Off-Thread Web Worker Parser](#1-off-thread-web-worker-parser)
-2.  [Segmented DOM Patching Engine](#2-segmented-dom-patching-engine)
-3.  [Ratio-Based Proportional Scroll Synchronization](#3-ratio-based-proportional-scroll-synchronization)
-4.  [LaTeX Mathematical Typesetting](#4-latex-mathematical-typesetting)
-5.  [Interactive Mermaid Diagrams with Drag-to-Pan](#5-interactive-mermaid-diagrams-with-drag-to-pan)
-6.  [Cascade PDF Layout Pagination Sandbox](#6-cascade-pdf-layout-pagination-sandbox)
-7.  [Multi-Document Session Persistence & Drag Reordering](#7-multi-document-session-persistence--drag-reordering)
-8.  [Binary Safety Gutter & Multi-File Importer](#8-binary-safety-gutter--multi-file-importer)
-9.  [Serverless Sharing via Compressed Hash Fragments](#9-serverless-sharing-via-compressed-hash-fragments)
-10. [Performance, Security, and UI Variables](#10-performance-security-and-ui-variables)
+Most work happens in the browser or desktop webview. Markdown parsing, syntax highlighting, math rendering, diagram post-processing, PDF/PNG capture, tab storage, undo/redo, search, and formatting tools are client-side. The exceptions are explicit network features: GitHub import, emoji lookup, CDN library loading in the web build, remote diagram fallback services, large Share Snapshot storage, and Live Share relay rooms.
 
----
+## Main Workspace
 
-## 1. Off-Thread Web Worker Parser
+The app opens with a header, document tab bar, formatting toolbar, editor pane, resize divider, and preview pane.
 
-To prevent typing lag and main-thread blocks, Markdown Viewer offloads compilation to a background Web Worker (`preview-worker.js`).
+- Editor mode shows only the textarea.
+- Split mode shows the editor and preview side by side.
+- Preview mode shows only the rendered document.
+- On small screens, the mobile menu exposes the same core actions and the layout avoids a cramped split view.
+- A draggable divider resizes editor and preview in split mode and keeps both panes above 20% width.
+- The divider also supports keyboard adjustment with left and right arrow keys while split view is active.
+- The GitHub link in the header opens the source repository.
 
-### Size-Aware Debouncing
-The main thread throttles render requests based on the character length of the active document to conserve CPU cycles:
-*   **Small Documents (<10 KB):** 80ms render debounce.
-*   **Medium Documents (10 KB - 50 KB):** 150ms render debounce.
-*   **Large Documents (>50 KB):** 300ms render debounce.
+The editor includes line numbers, wrapped-line height handling, a highlight layer for find results, live cursor overlays during Live Share, and skeleton placeholders during initial or heavy rendering. Line-number calculations are cached so large documents do not force a full layout measurement on every keystroke.
 
-### Segmented Worker Parsing
-1.  **Block Splitting:** The worker splits incoming markdown strings by double-newlines (`\n\n`) while respecting boundary exclusions (like block math `$$` and code fences ` ``` `).
-2.  **FNV-1a Alphanumeric Hashing:** For each block, the worker computes a 32-bit FNV-1a hash. This is a non-cryptographic hash function designed for speed:
+## Document Tabs and Local Workspace Storage
 
-    $$H_i = (H_{i-1} \oplus d_i) \times p$$
+Users can work with multiple documents at once.
 
-    where $p = 16777619$ (FNV prime) and $H_0 = 2166136261$ (offset basis).
-3.  **Selective Compilation:** If the document doesn't use complex global footnotes or reference-style declarations, the worker compiles only changed blocks using `marked.js` and `highlight.js`. It returns an array of compiled HTML strings paired with their FNV-1a hashes.
+- New tabs can be created from the tab bar, mobile menu, imports, shared snapshots, and Live Share joins.
+- Tabs can be renamed, duplicated, deleted, and reordered by drag and drop.
+- The app enforces a practical tab limit of 20 tabs. Shared snapshots refuse to open when this limit has been reached.
+- Each normal tab stores a title, content, scroll position, view mode, and creation time.
+- The active tab id and untitled-document counter are stored separately.
+- Temporary Share Snapshot and Live Share tabs are deliberately excluded from persistent tab storage.
+- The Reset button clears the current saved workspace and returns the app to a clean starting state.
 
----
+Storage keys used by the current implementation include:
 
-## 2. Segmented DOM Patching Engine
+| Key | What It Stores |
+| :--- | :--- |
+| `markdownViewerTabs` | Normal saved document tabs. Temporary shared/live tabs are stripped before saving. |
+| `markdownViewerActiveTab` | The active tab id. |
+| `markdownViewerUntitledCounter` | Counter used for new Untitled tab names. |
+| `markdownViewerGlobalState` | Theme, direction, view preferences, scroll sync, and similar global UI state. |
+| `app-lang` | Selected interface language. |
+| `find-replace-docked` | Whether the Find and Replace panel is docked. |
 
-Updating the entire preview pane using `element.innerHTML` causes layout repaints, resets scrollbar offsets, wipes focus states, and collapses open toggle elements (like `<details>`). Markdown Viewer employs a custom patching controller:
+On the web, these values live in browser `localStorage`. In the desktop app, the code mirrors selected localStorage values into Neutralino storage, so preferences and workspace state survive desktop restarts.
 
-### Patching Algorithm
-1.  **Hash Comparison:** The main thread compares the hashes of the incoming HTML block array against the child nodes of the preview pane.
-2.  **Targeted Replacement:**
-    *   If a node's hash matches, it is skipped.
-    *   If a node's hash differs, the script replaces the corresponding child node in place using `replaceWith()`.
-    *   If the new array has more elements, new nodes are appended.
-    *   Extra trailing nodes are pruned.
-3.  **Layout Containment:** Every block is wrapped in a `<section>` container configured with modern CSS rules:
-    ```css
-    content-visibility: auto;
-    contain-intrinsic-size: auto 220px;
-    ```
-    This instructs the browser's layout engine to bypass formatting and rendering of off-screen markdown sections, reducing repaint and reflow overhead.
+## Editing and Formatting Tools
 
----
+The formatting toolbar inserts or transforms Markdown at the current selection. It is a helper for writing plain Markdown with live preview, not a full in-place WYSIWYG rich text editor.
 
-## 3. Ratio-Based Proportional Scroll Synchronization
+- Undo and redo use the app's custom per-tab history.
+- Clear document opens a confirmation modal.
+- Bold, italic, strikethrough, quote, inline code, code block, terminal block, horizontal rule, and headings H1-H6 insert standard Markdown.
+- Bulleted and numbered lists work on selected lines or the current line.
+- Pressing Enter inside a list continues the list; pressing Enter on an empty list item exits the list.
+- Tab inserts two spaces; Shift+Tab outdents selected lines.
+- Title case, uppercase, and lowercase transform selected text or the current line.
+- Alignment buttons insert left, center, or right aligned HTML blocks.
+- The direction toggle switches between left-to-right and right-to-left content direction.
+- Link, image, reference, table, emoji, symbol, alert, and diagram buttons open focused modals.
+- Date/time inserts a local timestamp.
+- Fullscreen uses the browser Fullscreen API when available.
+- Help and About buttons open informational modals.
 
-When editing in **Split View**, scrolling the editor textarea scrolls the HTML preview pane proportionally, and vice versa.
+View-only Share Snapshot tabs and view-only Live Share participant tabs block mutating tools and announce that the editor is read-only. Non-mutating actions such as fullscreen, find, help, and info remain available.
 
-### Math Formula
-Proportional scrolling is mapped using the scroll ratio:
+## Custom Undo and Redo
 
-$$R_{\text{scroll}} = \frac{\text{scrollTop}}{\text{scrollHeight} - \text{clientHeight}}$$
+The app keeps its own edit history for each tab so toolbar actions, typed edits, and programmatic changes can be undone consistently.
 
-The target container's scroll position is then calculated as:
+- `Ctrl+Z` or `Cmd+Z` undoes the previous edit in the active editor.
+- `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` redoes.
+- Undo and redo buttons are disabled when the current tab cannot be edited.
+- Cursor position is tracked so undo and redo feel close to native textarea behavior.
 
-$$\text{Target-scroll-top} = R_{\text{scroll}} \times (\text{Target-scroll-height} - \text{Target-client-height})$$
+## Find and Replace
 
-### Feedback Loop Prevention
-Since scrolling the target pane triggers its own scroll events, this can create an infinite update loop. To prevent this:
-*   The application implements state locks: `isEditorScrolling = true` and `isPreviewScrolling = true`.
-*   Scroll coordinates are updated within `requestAnimationFrame()`.
-*   A 50ms timeout releases the locks after scrolling stops.
+Find and Replace is a floating or docked panel with editor and preview highlighting.
 
----
+- Open it with the toolbar, `Ctrl+F`, or `Cmd+F`.
+- `Ctrl+H` or `Cmd+H` opens the panel focused on replacement.
+- It supports case-sensitive matching, whole-word matching, regular expressions, selection-only search, and replace-all.
+- Regex replacements can use numbered capture groups like `$1` and named groups like `$<name>`.
+- Preserve-case replacement adjusts replacement casing to match the matched text.
+- Search scope can be limited using a Marked lexer map, including headings, code blocks, Mermaid blocks, LaTeX blocks, or the entire document.
+- Diff preview shows the effect before bulk replacement.
+- The panel can be dragged, docked, undocked, and reset to a visible position. Its floating position is constrained to the viewport.
+- Find history and replace history are kept in memory for the current session, up to 10 entries each.
 
-## 4. LaTeX Mathematical Typesetting
+Limitations:
 
-LaTeX parsing uses **MathJax** loaded dynamically from a CDN.
+- AST scoping depends on Marked token boundaries. Very unusual Markdown can be classified as plain text.
+- Scope validation protects LaTeX delimiters and Mermaid block starts, but it cannot prove every replacement is semantically correct.
+- Preview highlighting works on visible text nodes and may skip text produced inside complex third-party SVG renderers.
 
-### Scanning and Typesetting
-*   The controller scans inputs using a regex test: `/\$\$|\$[^$]|\\\(|\\\[/`.
-*   If math markers are detected, the MathJax libraries are fetched.
-*   Once loaded, equations are rendered by calling:
-    ```javascript
-    MathJax.typesetPromise([previewElement]);
-    ```
+## Markdown Rendering
 
-### Accessibility Post-Processing
-By default, MathJax appends assistive MathML containers (`<mjx-assistive-mml>`) with `tabindex="0"`. This interrupts keyboard tab order. A post-processing script runs after typesetting:
-1.  It queries all `<mjx-assistive-mml>` tags in the preview.
-2.  It removes the `tabindex` attribute from each element.
-3.  These assistive nodes are hidden or stripped prior to PDF canvas capture to prevent overlapping text.
+Markdown is parsed with Marked and highlighted with Highlight.js. Rendered HTML is sanitized with DOMPurify before it is inserted into the preview.
 
----
+Supported Markdown behavior includes:
 
-## 5. Interactive Mermaid Diagrams with Drag-to-Pan
+- CommonMark-style headings, paragraphs, line breaks, emphasis, blockquotes, lists, code blocks, horizontal rules, links, images, and inline HTML.
+- GitHub-Flavored Markdown (GFM) features such as tables, task lists, strikethrough, and autolinks.
+- Heading ids generated from heading text for in-document anchor navigation.
+- Reference definitions and reference links.
+- Multi-paragraph footnotes with back references.
+- Definition lists using a term followed by `: definition`.
+- Superscript with `^text^`.
+- Subscript with `~text~`.
+- Highlight with `==text==`.
+- GitHub-style alert blocks for NOTE, TIP, IMPORTANT, WARNING, and CAUTION.
+- Emoji shortcodes processed through JoyPixels when the emoji library is available.
+- Raw HTML is allowed only after sanitization. Scripts and unsafe event handlers are removed.
 
-Mermaid code blocks are rendered as SVG diagrams with custom interactive features.
+The worker and main renderer both preserve block math, custom diagram shells, footnote state, definition lists, superscript, subscript, and highlight syntax so advanced blocks do not collapse during live updates.
 
-### Floating Action Toolbar
-Every rendered Mermaid diagram is wrapped in a container that appends a floating toolbar with four actions:
-1.  **Zoom modal:** Opens the diagram in a full-screen interactive modal.
-2.  **Download PNG:** Captures the SVG, draws it to a canvas element, and downloads it.
-3.  **Download SVG:** Serializes the SVG XML nodes and triggers a browser download.
-4.  **Copy Image:** Renders the diagram as a PNG blob and copies it to the system clipboard using the asynchronous Clipboard API:
-    ```javascript
-    navigator.clipboard.write([
-        new ClipboardItem({ "image/png": pngBlob })
-    ]);
-    ```
+## Web Worker and Preview Performance
 
-### Drag-to-Pan Mechanics
-Inside the zoom modal, the SVG transform matrix is updated during mouse events:
-*   **Scale:** Computed using mouse-wheel offsets:
+Rendering is designed to keep typing responsive.
 
-    $$\text{scale} = \max(0.1, \min(\text{scale} + \text{delta}, 10))$$
+- Small documents render on the main thread after a short debounce.
+- Very large documents can render in `preview-worker.js`.
+- The current worker threshold is 50,000 characters.
+- Render debounce is size-aware: 100 ms for typical documents, 160 ms for large documents, and 240 ms for huge documents.
+- Worker rendering has a 12 second timeout and falls back if worker rendering fails repeatedly.
+- When safe, the worker splits Markdown into blocks, hashes each block, and returns segmented HTML.
+- The main thread caches sanitized segments and patches only changed preview sections.
+- Segmented rendering is avoided when document constructs need global context, such as footnotes or reference-style definitions.
+- Preview sections use `content-visibility: auto` so off-screen content costs less to lay out.
 
-*   **Panning:** Tracks the difference between starting coordinates and current pointer coordinates:
+Limitations:
 
-    $$X_{\text{pan}} = X_{\text{current}} - X_{\text{dragStart}}$$
+- Huge documents still depend on browser memory and DOM limits.
+- Advanced renderers such as Mermaid, MathJax, maps, STL, ABC, and remote diagrams run after the base Markdown pass, so they can appear slightly later than text.
+- The app retries advanced post-processing when shared or live content loads before renderer libraries are ready.
 
-    $$Y_{\text{pan}} = Y_{\text{current}} - Y_{\text{dragStart}}$$
-*   **CSS Transform:** The updates are applied using hardware-accelerated CSS properties:
-    ```javascript
-    svg.style.transform = `translate(${modalPanX}px, ${modalPanY}px) scale(${modalZoomScale})`;
-    ```
+## Math Rendering
 
----
+MathJax renders LaTeX-style math.
 
-## 6. Cascade PDF Layout Pagination Sandbox
+- Inline math uses `$...$`.
+- Display math uses `$$...$$`, `\(...\)`, or `\[...\]`.
+- Fenced `math` code blocks are converted into display math.
+- Additional MathJax packages are configured for richer notation.
+- MathJax loads only when math-like text is detected.
+- After typesetting, the app removes or hides MathJax assistive markup from export captures so duplicate text does not appear in PDFs or PNGs.
 
-Exporting long, complex Markdown previews to PDF often leads to sliced text lines and cut-off images. Markdown Viewer uses a custom pagination engine:
+Limitations:
 
-### Pagination Pipeline
-1.  **Sandbox Cloning:** The preview DOM is cloned into an off-screen sandbox element (`.pdf-export` class) set to A4 width (210mm).
-2.  **SVG to Raster Conversion:** Because `html2canvas` struggles to render inline SVGs, all Mermaid diagrams are converted to Base64-encoded PNG image elements inside the sandbox.
-3.  **Cascade Pagination Loop:** The pagination engine executes up to 10 passes:
-    *   *Keep-with-Next Headings:* Headings within 70px of a page break are shifted down via margin-top spacers (`.pdf-page-break-spacer`).
-    *   *Table Splitting:* Split rows are shifted, and the table header (`<thead>`) is duplicated onto the subsequent page.
-    *   *Text Alignment:* Lines are shifted downward to align page cuts cleanly between font heights, avoiding sliced characters.
-    *   *Oversized Graphics:* Images exceeding page boundaries are downscaled (minimum scale 0.5) to fit.
-4.  **Compilation:** The stabilized sandbox is captured page-by-page using `html2canvas`, and the resulting canvases are compiled into a PDF via `jsPDF`.
+- The first math render in the web build may require downloading MathJax unless it is already cached.
+- Invalid LaTeX is shown according to MathJax behavior and may produce warnings or unrendered source.
+- A literal dollar sign should be escaped as `\$` when it is not intended to start math.
 
----
+## Diagrams, Charts, Maps, Models, and Music
 
-## 7. Multi-Document Session Persistence & Drag Reordering
+Markdown Viewer supports many fenced-code renderers.
 
-Markdown Viewer supports working with multiple documents simultaneously via a tabbed workspace.
+| Fence Language | Renderer | User Behavior | Network Notes |
+| :--- | :--- | :--- | :--- |
+| `mermaid` | Mermaid.js | Renders diagrams as SVG with zoom, copy, PNG, and SVG actions. | Client-side library. Diagram insertion previews may use mermaid.ink. |
+| `plantuml` | PlantUML/Kroki | Renders SVG and provides zoom, copy, PNG, and SVG actions. | Uses PlantUML server first, then Kroki fallback. |
+| `d2` | Kroki | Renders D2 SVG and provides zoom, copy, PNG, and SVG actions. | Uses Kroki. Some source is normalized for common SQL-table cases. |
+| `graphviz` / `dot` | Kroki | Renders Graphviz SVG and provides zoom, copy, PNG, and SVG actions. | Uses Kroki. |
+| `vega-lite` / `vegalite` | Kroki | Renders Vega-Lite charts. | Uses Kroki. |
+| `wavedrom` | Kroki | Renders WaveDrom timing diagrams. | Uses Kroki. |
+| `markmap` | Markmap, D3 | Renders a mind-map style SVG. | Client-side libraries. |
+| `geojson` | Leaflet | Renders an interactive map. | Client-side library; map tiles may require network depending on tile source. |
+| `topojson` | Leaflet and TopoJSON | Converts TopoJSON to GeoJSON and renders an interactive map. | Client-side library; map tiles may require network. |
+| `stl` | Three.js | Renders a 3D STL model with orbit controls, solid/surface-angle/wireframe modes, zoom modal, copy, and PNG export. | Client-side libraries. |
+| `abc` | ABCJS | Renders sheet music, supports playback, cursor sync, note highlighting, copy, PNG, and SVG export. | Client-side library; browser audio support required for playback. |
 
-### Tab State Schema
-The workspace is managed in a global `tabs` array:
-```javascript
-{
-  id: "tab_" + Date.now() + "_" + Math.random().toString(36).substring(2, 8),
-  title: "Document Title",
-  content: "# Markdown Content...",
-  scrollPos: 0,
-  viewMode: "split", // split | editor | preview
-  createdAt: 1718042710000
-}
-```
+Every diagram shell keeps the original source in a data attribute so the app can rerender after theme changes, shared document loading, and export preparation. Diagram PNG exports add a solid background when needed so transparent SVGs stay visible.
 
-### Save Pipeline
-*   **Debounced Save:** Document changes trigger an auto-save that is debounced by 500ms using a window timer to prevent blocking the UI thread with constant serialization.
-*   **Beforeunload Flush:** To ensure changes are saved when navigating away or closing the page, the state is flushed immediately during `beforeunload` and `visibilitychange` events (when the page is hidden).
+Limitations:
 
-### Drag-and-Drop Reordering
-*   Tab elements in the DOM are configured with `draggable="true"`.
-*   Drag events track the moving tab (`draggedTabId`).
-*   Releasing a tab over another swaps their indices in the state array, saves the updated array to `localStorage`, and updates the tab bar.
+- Remote diagram engines send diagram source to third-party rendering endpoints. Do not use those fences for private diagram text unless you trust the endpoint or provide your own deployment.
+- Remote render requests have a 15 second timeout and retry twice.
+- Clipboard image writing requires a secure context and browser support for `ClipboardItem`.
+- WebGL STL rendering depends on GPU/browser support. The app disposes old STL views to reduce memory leaks.
+- ABC audio playback depends on browser audio APIs and may be unavailable in some environments.
 
----
+## Diagram Insertion Modal
 
-## 8. Binary Safety Gutter & Multi-File Importer
+The diagram modal offers searchable templates grouped by engine. It shows source code and a live preview before insertion.
 
-### Binary File Guard
-To prevent importing corrupted binary files, the file reader scans the first 8 KB of any imported file:
-*   If a null byte (`\x00`) is found, the import is aborted, and an error is displayed.
+- Categories include Mermaid, PlantUML, D2, Graphviz, Vega-Lite, ABC notation, WaveDrom, and Markmap.
+- Template code is cleaned before insertion.
+- Previews are cached in the browser Cache API under `diagram-previews` when possible.
+- Remote preview generation can use Kroki or mermaid.ink depending on the template.
 
-### Multi-File GitHub Importer
-Users can import documents directly from public GitHub repositories:
-1.  **URL Parsing:** The importer resolves repo, branch, folder, or file paths from a pasted URL.
-2.  **API Requests:** It queries public GitHub APIs (`api.github.com/repos/.../contents/...`) to fetch file trees.
-3.  **File Browser Modal:** Users can preview the file tree in a modal, select the files they want, and import them all at once. Selected files are loaded into separate document tabs.
+## Imports
 
----
+Markdown Viewer can open `.md` and `.markdown` documents from local files, drag and drop, GitHub URLs, and desktop file arguments.
 
-## 9. Serverless Sharing via Compressed Hash Fragments
+Local file import:
 
-Markdown Viewer lets you share documents via links that contain the entire compressed document content, eliminating the need for a database.
+- Accepts `.md`, `.markdown`, and `text/markdown`.
+- Extension checks are case-insensitive.
+- Dragging a file over the app shows a full-window drop overlay.
+- The first 8 KB of a file are scanned for null bytes to avoid loading binary files as text.
+- Imported local files open in the active tab or a new tab depending on the action.
 
-### Encoding Pipeline
+GitHub import:
 
-$$\text{Markdown Text} \xrightarrow{\text{TextEncoder}} \text{Bytes} \xrightarrow{\text{Pako.deflate (zlib)}} \text{Compressed Bytes} \xrightarrow{\text{Base64-URL Encoding}} \text{URL Hash}$$
+- Accepts `github.com/owner/repo`, `github.com/owner/repo/tree/ref/path`, `github.com/owner/repo/blob/ref/path`, and `raw.githubusercontent.com` file URLs.
+- Direct Markdown file URLs import immediately.
+- Repository or folder URLs query GitHub's public API to find Markdown files.
+- The modal shows a tree and supports selecting multiple files.
+- Only the first 30 Markdown files are shown if a repository contains more.
+- Requests are rate-limited by the app to avoid hammering GitHub.
+- Selected files are fetched as raw content and opened as separate tabs.
 
-1.  The markdown text is encoded to bytes and compressed using `Pako.js` (DEFLATE).
-2.  The compressed bytes are converted to a Base64 string.
-3.  The string is made URL-safe by replacing `+` with `-`, `/` with `_`, and removing trailing `=` padding.
-4.  The hash is appended to the URL as `#share=<encoded_string>`.
-5.  A warning is displayed if the generated link exceeds 32,000 characters.
+Limitations and privacy:
 
----
+- Local file content is read in the browser or desktop app and is not uploaded by local import.
+- GitHub import sends repository and path information to GitHub and downloads public file contents from GitHub.
+- Private GitHub repositories are not supported because the app does not ask for tokens.
 
-## 10. Performance, Security, and UI Variables
+## Exports
 
-### Repaint & Transition Tuning
-*   Theme changes are managed using CSS variables.
-*   Transition animations are scoped to specific properties (`background-color`, `border-color`) rather than using `transition: all`.
-*   The background transition on the `<body>` element was removed to prevent repainting the entire viewport during theme shifts.
+Export filenames use the active tab title when possible.
 
-### Resizable Panes
-*   The divider between the editor and preview panes can be dragged horizontally.
-*   It updates the CSS grid layout dynamically using percentage variables.
-*   Drag limits prevent either pane from being scaled below 20% of the viewport width.
+Markdown export:
 
-### Sanitization and Security
-*   All compiled HTML is sanitized on the main thread using **DOMPurify** before being rendered:
-    ```javascript
-    const cleanHtml = DOMPurify.sanitize(rawHtml, {
-        USE_PROFILES: { html: true },
-        ADD_ATTR: ['target', 'draggable', 'contenteditable']
-    });
-    ```
-*   This strips inline script handlers (e.g. `onload`, `onclick`) and `<script>` elements to prevent Cross-Site Scripting (XSS) when importing or loading external markdown files.
+- Saves the raw Markdown text.
+- In the web app, it downloads through the browser.
+- In the desktop app, it uses a native save dialog and Neutralino filesystem writing.
+
+HTML export:
+
+- Creates a standalone HTML document from the current Markdown.
+- Includes GitHub-style Markdown CSS, syntax highlighting styles, alert styles, footnote styles, math/diagram support hooks, and frontmatter rendering.
+- YAML frontmatter is parsed and shown as a table before the document body.
+- HTML export uses sanitized rendered content.
+
+PDF export:
+
+- Opens a modal with two modes.
+- Browser Print is recommended. It calls `window.print()` and lets the browser or OS produce the PDF. It is faster and better for long text, but images and complex diagrams may differ by browser.
+- Legacy Raster PDF uses `html2canvas` and `jsPDF`. It clones the preview into an off-screen A4 sandbox, renders Mermaid and ABC to SVG/image form, typesets math, waits for images/fonts, applies page-break rules, captures the document to canvas, and saves a PDF.
+- The raster exporter shows progress and has a cancel button.
+- Raster export uses `allowTaint: false` and `useCORS: true` to avoid unsafe cross-origin canvas capture.
+
+PNG export:
+
+- Captures the rendered document into a PNG using `html2canvas`.
+- It uses a white/dark solid background based on theme and a high-resolution canvas.
+- It renders Mermaid, ABC, and MathJax in the off-screen capture before saving.
+
+Limitations:
+
+- Browser Print output is controlled by the browser and print settings.
+- Raster PDF and PNG are screenshots of rendered HTML, so very long documents can be memory-heavy.
+- Cross-origin images without CORS support may fail to appear in canvas-based PDF/PNG exports.
+- Advanced remote diagrams that have not rendered yet may need a moment before export.
+- Some complex CSS, wide tables, and large diagrams may be moved, scaled, or split differently from the live preview.
+
+## Sharing: Share Snapshot
+
+Share Snapshot creates a link to a point-in-time copy of the current document.
+
+Modes:
+
+- View only opens the shared content in preview mode with the editor hidden.
+- Editable opens the shared content in split mode so the recipient can edit their own copy.
+
+Storage behavior:
+
+- Small documents are compressed with Pako, base64url-encoded, and placed directly in the URL hash as `#share=...`.
+- Hash fragments are not sent to a web server as part of normal HTTP requests.
+- If the encoded legacy URL is too long, or if the Markdown is at least 3,000 bytes, the app stores the snapshot through `/api/share`.
+- Stored snapshots receive an id in `#id=...` form.
+- Stored snapshots are saved in Cloudflare KV for 90 days.
+- The server accepts up to 500,000 characters per stored snapshot.
+- Snapshot ids are random 10-character values using a reduced alphabet and must match the app's id pattern.
+- Stored snapshot responses use `Cache-Control: no-store`.
+- The Share API allows CORS for GET, POST, and OPTIONS.
+- Shared snapshot tabs are temporary and are not saved to the recipient's local workspace.
+
+Privacy implications:
+
+- URL-hash snapshots keep document content inside the link itself.
+- Anyone with a snapshot link can read the snapshot.
+- Editable snapshot links are not collaborative; they only let the recipient edit their local opened copy.
+- Stored snapshots upload document content, mode, title, creation time, and size to the configured Cloudflare KV namespace until expiry.
+- The app prevents sharing a temporary shared snapshot again, and prevents Share Snapshot from a Live Share document, to avoid confusing copies of copies.
+
+## Sharing: Live Share
+
+Live Share creates a temporary real-time collaboration room.
+
+User flow:
+
+- The host chooses a display name and an access mode.
+- Access can be Can edit or View only.
+- The app creates a random room id and a random secret.
+- The invite URL contains the room id, secret, and title. It does not embed the full Markdown body.
+- Participants open the link and join a temporary live tab.
+- Participants see presence avatars and live cursor indicators.
+- The host can end the session for everyone.
+- Participants can leave and return to their original tab state.
+- If a room has ended, expired, or has no active host, the participant sees an expired-room modal.
+
+Implementation:
+
+- The client uses Yjs for the shared document state.
+- Browser clients connect with WebSocket to `/live-room/<room-id>?secret=<secret>`.
+- Cloudflare Pages routes the WebSocket to a Durable Object named `LIVE_ROOMS`.
+- The Durable Object relays `hello`, `presence`, `sync-request`, `sync-state`, `y-update`, `leave`, and `session-end` messages.
+- The Durable Object does not write document state to KV or a database.
+- Room identity is derived from room id plus secret.
+
+Limits:
+
+- A live message can be at most 1 MB.
+- A live room can have at most 64 WebSocket participants.
+- Participant presence is considered stale after 45 seconds without updates.
+- Join waits up to 8 seconds for initial room state before showing an expired/unavailable room message.
+- The room exists only while the Durable Object instance and connected sessions are alive.
+
+Privacy implications:
+
+- Live Share document updates, display names, cursor positions, and presence are transmitted through the configured Cloudflare Durable Object.
+- Live room content is temporary relay state, not permanent document storage.
+- Anyone with the invite URL, including the secret, can join while the room is active.
+- View-only mode is enforced by the app and message handling; it is intended for normal use, not as a cryptographic access-control boundary against modified clients.
+
+## Clipboard and Copy Behavior
+
+- Copy Markdown copies the raw Markdown from the editor.
+- `Ctrl+C` or `Cmd+C` respects selected text in inputs/textareas and selected page text.
+- When no text selection is active, the app can copy the full Markdown document.
+- Diagram and ABC copy actions attempt to write PNG image data to the clipboard.
+- Clipboard APIs require browser permission and a secure context. The app falls back to a temporary textarea for text copying when needed.
+
+## Themes, Direction, and Localization
+
+Theme behavior:
+
+- The app supports light and dark themes.
+- Initial theme follows saved preference, then system preference.
+- Theme choices are saved in global state.
+- Diagrams, maps, STL views, and rendered blocks are updated after theme changes when possible.
+
+Direction behavior:
+
+- Users can switch content direction between LTR and RTL.
+- Direction affects editor and preview layout and is saved in global state.
+
+Localization:
+
+- The UI includes English, Simplified Chinese, Japanese, Korean, Brazilian Portuguese, Spanish, French, German, Russian, Italian, Turkish, Polish, Traditional Chinese, and Ukrainian.
+- Language is selected in this order: URL `?lang=`, hash query `?lang=`, saved `app-lang`, browser language, then English.
+- Selecting a language updates the URL query and saves `app-lang`.
+- Translations are static in `I18N_DICTS` inside `script.js`.
+- Some generated renderer messages and third-party output remain English.
+
+## Statistics
+
+The header and mobile menu show:
+
+- Estimated reading time.
+- Word count.
+- Character count.
+
+Reading time is based on a simple words-per-minute estimate. Counts update as the active document changes. Character count is a practical UI metric, not a byte-level file-size guarantee.
+
+## Keyboard and Accessibility
+
+Common shortcuts:
+
+| Action | Shortcut |
+| :--- | :--- |
+| Save/export Markdown | `Ctrl+S` / `Cmd+S` |
+| Find | `Ctrl+F` / `Cmd+F` |
+| Replace | `Ctrl+H` / `Cmd+H` |
+| Toggle scroll sync | `Ctrl+Shift+S` / `Cmd+Shift+S` in split mode |
+| Undo | `Ctrl+Z` / `Cmd+Z` |
+| Redo | `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` |
+| New tab | Desktop: `Ctrl+T` / `Cmd+T`; web and desktop: `Alt+Shift+T` |
+| Close tab | Desktop: `Ctrl+W` / `Cmd+W`; web and desktop: `Alt+Shift+W` |
+| Indent | `Tab` in the editor |
+| Outdent | `Shift+Tab` in the editor |
+| Close modals/panels | `Escape` |
+
+Accessibility behavior:
+
+- Tabs use ARIA tablist semantics and roving keyboard focus.
+- Tab bar supports ArrowLeft, ArrowRight, Home, End, Enter, and Space.
+- Modals trap focus and close with Escape or cancel buttons.
+- The resize divider is keyboard focusable.
+- Screen-reader announcements are used for imports, Live Share, read-only states, and other dynamic actions.
+- Touch targets were enlarged in earlier accessibility passes.
+
+## Offline, PWA, and Caching
+
+The web app registers `sw.js` when service workers are supported.
+
+- The service worker cache name is versioned as `markdown-viewer-cache-v3.9.0`.
+- Critical local assets include `/`, `index.html`, `styles.css`, `script.js`, `preview-worker.js`, `manifest.json`, and `assets/icon.jpg`.
+- Local shell assets use a network-first strategy for update-sensitive paths, falling back to cache when offline.
+- CDN assets from cdnjs and jsDelivr use cache-first behavior after first successful load.
+- The app manifest allows standalone PWA installation.
+
+Limitations:
+
+- Service workers require HTTPS or localhost.
+- First use of CDN-based renderers requires network access unless already cached.
+- Clearing site data removes the cached app shell and local documents.
+- Opening `index.html` through `file://` can break workers and service workers because of browser security rules.
+
+## Desktop App
+
+The desktop build wraps the same app in Neutralino.
+
+Desktop-specific behavior:
+
+- Uses a native window with minimum size 400 x 200 and default size 1280 x 720.
+- Uses one-time token security.
+- Logging is disabled in the current config.
+- Native APIs are allowlisted instead of fully open.
+- Allowed APIs include app exit, open/save dialogs, message boxes, external URL opening, tray setup, command execution, file read/write, and Neutralino storage get/set.
+- Local imports and exports use native open/save dialogs.
+- External Markdown file paths passed at launch can be loaded into the editor.
+- Closing the desktop window asks for confirmation before exiting.
+- Desktop resources are built by `desktop-app/prepare.js`.
+- `prepare.js` copies root assets, rewrites paths for `/resources/`, strips web-only SEO metadata, and downloads/bundles external libraries into `/resources/libs/`.
+- Downloaded desktop dependencies are checked against SHA-384 integrity values when SRI is available.
+- The desktop build points dynamic libraries to local `/libs/...` paths, making the prepared desktop app suitable for offline use.
+
+Privacy:
+
+- Desktop documents are stored on the local machine through localStorage and Neutralino storage.
+- Native file reads/writes happen only through user actions or explicit file arguments.
+- Share Snapshot, Live Share, GitHub import, remote diagram fallbacks, and external links still use the network when used.
+
+## Security Model
+
+Important protections:
+
+- DOMPurify sanitizes preview HTML before insertion.
+- Preview sanitization allows needed render attributes and safe URI patterns while blocking scripts and inline event handlers.
+- CDN scripts and styles in `index.html` use Subresource Integrity where checked in.
+- Desktop preparation verifies downloaded assets against SHA-384 integrity values when available.
+- Canvas exports use `allowTaint: false`.
+- The desktop native API allowlist follows least privilege for the app's current features.
+- Share and live endpoints return no-store responses for dynamic content.
+- The app does not include analytics, telemetry scripts, ad pixels, accounts, cookies, or subscription code.
+
+Security limitations:
+
+- Sanitization reduces XSS risk but cannot make every third-party renderer or browser bug impossible.
+- Remote diagram services receive diagram source for supported remote engines.
+- Links and images in Markdown can request external resources when rendered or clicked.
+- View-only Live Share relies on cooperative client enforcement and relay filtering, not end-to-end encryption.
+- Share Snapshot links are bearer links: possession of the URL grants access.
+
+## Data Handling Summary
+
+| Feature | Leaves Device? | Stored Where | Notes |
+| :--- | :--- | :--- | :--- |
+| Typing and local preview | No | Browser memory and saved tabs | Sanitized before preview insertion. |
+| Normal tab autosave | No | `localStorage` or desktop storage mirror | Cleared with site/app data or Reset. |
+| Local file import | No | Current tab/workspace | Reads selected files only. |
+| Markdown/HTML/PDF/PNG export | No, except remote assets already referenced | User download location | Browser may request external images/fonts used by content. |
+| GitHub import | Yes | GitHub API/raw URLs | Public repos only; no token flow. |
+| Emoji lookup | Yes | GitHub emoji API response in memory | Used for shortcode picker/lookup. |
+| CDN library loading | Yes | Browser/service-worker cache | Web build only, first use unless cached. |
+| Remote diagram engines | Yes | Third-party renderer response/cache | Source is sent to PlantUML, Kroki, or mermaid.ink depending on renderer/preview. |
+| Share Snapshot hash link | Only when user sends the link | Inside URL hash | Small documents are not uploaded by generation. |
+| Stored Share Snapshot | Yes | Cloudflare KV for 90 days | Content, mode, title, createdAt, and size. |
+| Live Share | Yes | Cloudflare Durable Object relay memory | Temporary while active; no KV/database write. |
+| Desktop native storage | No | Local app storage | Mirrors app state for restart persistence. |
+
+## Known Technical Limits
+
+- Browser storage quotas can reject very large saved workspaces.
+- The GitHub importer shows a maximum of 30 Markdown files.
+- Stored Share Snapshot content is limited to 500,000 characters.
+- Legacy raster PDF and PNG exports can fail on extremely tall documents because canvas size and memory are browser-limited.
+- Remote renderer availability depends on third-party services and network conditions.
+- The service worker cannot cache assets that have never been successfully fetched.
+- The desktop app depends on the platform webview and Neutralino runtime behavior.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,75 +1,55 @@
-# Welcome to the Markdown Viewer Wiki
+# Markdown Viewer Wiki
 
-Welcome to the official technical documentation and user wiki for the **Markdown Viewer** application (v3.9.0). This repository contains detailed configuration guides, architecture documents, installation instructions, and user manuals to help you customize, deploy, and contribute to this client-side Markdown editing suite.
+Welcome to the documentation for Markdown Viewer v3.9.0. Markdown Viewer is a premium browser-based Markdown editor, viewer, reader, and previewer for opening `.md` and `.markdown` files, writing plain Markdown, and reading a split-screen live preview with sync scrolling. It includes document tabs, rich renderers, Markdown-to-PDF/HTML/PNG exports, Share Snapshot links, Live Share rooms, a PWA-capable web build, Docker deployment, and a Neutralino desktop app.
 
----
+Most editing and rendering happens on your own device. The important exceptions are documented clearly: GitHub import contacts GitHub, remote diagram fallbacks contact third-party renderers, large Share Snapshot links use temporary Cloudflare KV storage, and Live Share relays temporary collaboration updates through Cloudflare Durable Objects.
 
-## 🚀 Quick Start Portal
+## Start Here
 
-To deploy or run a local instance of the application immediately, execute the corresponding command for your environment:
-
-| Deployment Method | Command | Default Access URL |
-| :--- | :--- | :--- |
-| **Docker (Pre-built)** | `docker pull ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0 && docker run -d -p 8080:80 ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0` | `http://localhost:8080` / `http://127.0.0.1:8080` |
-| **Docker Compose** | `git clone https://github.com/ThisIs-Developer/Markdown-Viewer.git && cd Markdown-Viewer && docker compose up -d` | `http://localhost:8080` / `http://127.0.0.1:8080` |
-| **Python Static Server** | `python3 -m http.server 8080` (Run inside repository root to serve `index.html` on localhost/`127.0.0.1`) | `http://localhost:8080` / `http://127.0.0.1:8080` |
-| **Node.js Static Server** | `npx serve . -p 8080` (Run inside repository root to serve `index.html` on localhost/`127.0.0.1`) | `http://localhost:8080` / `http://127.0.0.1:8080` |
-| **Desktop Application** | Download execution package from [GitHub Releases](https://github.com/ThisIs-Developer/Markdown-Viewer/releases) | Launch native binary |
-
----
-
-## 🗺️ Wiki Table of Contents
-
-Use the navigation map below to explore the technical documentation sections of this wiki:
-
-| Document / Section | Scope & Contents |
+| Need | Page |
 | :--- | :--- |
-| **[Features](Features)** | Under-the-hood engineering deep-dive on compilation workers, DOM patching, and proportional scroll synchronization. |
-| **[Installation](Installation)** | Detailed multi-platform setup instructions for Docker, Docker Compose, static web servers, and Neutralinojs compile pipelines. |
-| **[Usage Guide](Usage-Guide)** | Standard operations manual detailing tab workspaces, file importing rules, and complete keyboard shortcuts mapping. |
-| **[Configuration](Configuration)** | Analysis of localStorage schemas, CDN assets links, Docker Nginx blocks, and Neutralino desktop runtime settings. |
-| **[Docker Deployment](Docker-Deployment)** | Production Docker customization guide containing security headers, custom context paths, and reverse proxy files. |
-| **[Desktop App](Desktop-App)** | Build workflow documentation for packaging native desktop executable wrappers on Windows, Linux, and macOS. |
-| **[Development Journey](Development-Journey)** | Evolution milestones of the project, comparison matrices between early prototype and v3.9.0, and design history. |
-| **[Markdown Reference](Markdown-Reference)** | Exhaustive writing template guide for GFM extensions, MathJax LaTeX equations, and Mermaid charts. |
-| **[FAQ](FAQ)** | Frequently Asked Questions on local privacy, memory utilization, export troubleshooting, and desktop security warnings. |
-| **[Contributing](Contributing)** | Development environment configuration guides, 2-space styling parameters, conventional commits, and PR reviews. |
+| Learn every feature, limitation, and data-handling detail | [Features](Features) |
+| Use the editor day to day | [Usage Guide](Usage-Guide) |
+| Write supported Markdown, math, diagrams, maps, STL, and ABC notation | [Markdown Reference](Markdown-Reference) |
+| Install locally, in Docker, or as a desktop app | [Installation](Installation) |
+| Tune deployment and runtime settings | [Configuration](Configuration) |
+| Deploy with Docker and reverse proxies | [Docker Deployment](Docker-Deployment) |
+| Build and understand the Neutralino desktop app | [Desktop App](Desktop-App) |
+| Understand Live Share on Cloudflare | [Live Share Cloudflare](Live-Share-Cloudflare) |
+| Add or maintain interface languages | [Localization](Localization) |
+| Review project history and design decisions | [Development Journey](Development-Journey) |
+| Answer common privacy and troubleshooting questions | [FAQ](FAQ) |
+| Contribute changes | [Contributing](Contributing) |
 
----
+## Quick Run Options
 
-## 🛡️ Core Architectural Principles
+| Method | Command | URL |
+| :--- | :--- | :--- |
+| Python static server | `python -m http.server 8080` | `http://localhost:8080` |
+| Node static server | `npx serve . -p 8080` | `http://localhost:8080` |
+| Docker Compose | `docker compose up -d` | `http://localhost:8080` |
+| Docker image | `docker run -d --name markdown-viewer -p 8080:80 ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0` | `http://localhost:8080` |
+| Desktop app | Download from GitHub Releases or build from `desktop-app/` | Native window |
 
-Markdown Viewer is designed with four fundamental principles in mind:
+Run local web builds through `localhost` or another HTTP(S) server. Opening `index.html` with `file://` can break Web Workers and Service Workers because browsers block those APIs from local files.
 
-1.  **Zero-Server Privacy:** 100% client-side execution. The application has no tracking telemetry, cookie banners, analytical beacons, or external database integrations. Your content never leaves the browser.
-2.  **Off-Thread Processing:** Offloads intensive compiling and syntax coloring jobs from the main execution thread to dedicated Web Workers to ensure a 60fps typing experience even on files exceeding 100 KB.
-3.  **Visual Synchronization:** Renders layout and styles identical to GitHub's native Markdown representations, optimized dynamically for desktop, tablet, and mobile views.
-4.  **Local-First Persistence:** Integrates HTML5 Service Workers to intercept asset queries, serving core library script archives from the local browser storage to enable offline functionality.
+## Product Principles
 
----
+| Principle | What It Means |
+| :--- | :--- |
+| On-device editing | Normal typing, preview, tabs, exports, themes, and settings stay on the user's device. No account is required. |
+| Explicit network features | Any feature that sends content elsewhere is user-triggered or tied to a renderer/importer that is documented. |
+| Rich Markdown support | The live preview supports GFM tables/task lists, math, footnotes, alerts, diagrams, maps, STL, ABC notation, and more. |
+| Responsive performance | Large documents use debounced rendering, optional worker rendering, DOM patching, and cached measurements. |
+| Deploy anywhere | The app can run as static files, a PWA, a Docker container, or a Neutralino desktop app. |
 
-## 🛠️ Global Technology Stack
+## Privacy At A Glance
 
-| Dependency Library | Version | Caching Tier | Role & Features |
-| :--- | :--- | :--- | :--- |
-| **Marked.js** | `9.1.6` | Precached (Main/Worker) | Markdown syntax parser and GFM compiler. |
-| **Highlight.js** | `11.9.0` | Precached (Worker Thread) | Syntactical color parsing for 190+ programming languages. |
-| **DOMPurify** | `3.0.9` | Precached (Main Thread) | DOM tree cleaning for XSS injection vulnerability blocks. |
-| **MathJax** | `3.2.2` | Lazy Cached (Dynamic) | LaTeX typesetting rendering engine. |
-| **Mermaid.js** | `11.15.0` | Lazy Cached (Dynamic) | Flowcharts, sequences, and architectural diagram blocks builder. |
-| **jsPDF** | `2.5.1` | Lazy Cached (Dynamic) | Client-side paginated PDF document builder. |
-| **html2canvas** | `1.4.1` | Lazy Cached (Dynamic) | Compiles CSS element layouts to canvas raster grids. |
-| **Pako.js** | `2.1.0` | Lazy Cached (Dynamic) | zlib DEFLATE compressor for sharing link generation. |
-| **js-yaml** | `4.1.0` | Precached (Main Thread) | Frontmatter config metadata header parser. |
-| **FileSaver.js** | `2.0.5` | Precached (Main Thread) | Controls download streams from the browser sandbox. |
-| **Bootstrap** | `5.3.2` | Precached (CDN CSS/JS) | Controls general layouts, modal forms, and UI toggles. |
-| **Neutralinojs** | `6.5.0` | Native Bridge | Desktop operating system framework wrapper shell. |
+- No accounts, cookies, analytics, ads, or telemetry are implemented.
+- Normal documents and settings are stored in browser localStorage or local desktop storage.
+- Small Share Snapshot links keep compressed content in the URL hash.
+- Large Share Snapshot links upload the snapshot to Cloudflare KV for 90 days.
+- Live Share sends real-time updates, display names, cursors, and presence through a Cloudflare Durable Object while the room is active.
+- Remote diagram renderers receive diagram source when PlantUML, D2, Graphviz, Vega-Lite, WaveDrom, or some preview helpers need them.
 
----
-
-## 🔗 Project Resources
-
-*   💻 **[GitHub Source Repository](https://github.com/ThisIs-Developer/Markdown-Viewer)**
-*   📦 **[GitHub Releases & Executables](https://github.com/ThisIs-Developer/Markdown-Viewer/releases)**
-*   🐳 **[GitHub Package Container Registry](https://github.com/ThisIs-Developer/Markdown-Viewer/pkgs/container/markdown-viewer)**
-*   📜 **[Apache 2.0 Project License](https://github.com/ThisIs-Developer/Markdown-Viewer/blob/main/LICENSE)**
+For the complete table of data flows, see [Features](Features#data-handling-summary).

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,43 +1,42 @@
-# Installation & Deployment Guide
+# Installation and Deployment
 
-This page provides detailed installation, setup, and deployment guides for **Markdown Viewer** across all supported platforms.
+Markdown Viewer is a premium browser-based Markdown editor/viewer that can run as a static web app, a self-hosted Docker site, a Cloudflare deployment with optional sharing features, or a Neutralino desktop app. Choose the setup that matches how you want to open, read, edit, preview, and export Markdown files.
 
----
+## Requirements
 
-## Table of Contents
+| Target | Requirements |
+| :--- | :--- |
+| Local web | Modern browser and a local HTTP server. |
+| PWA/offline web | HTTPS or localhost for Service Worker support. |
+| Docker | Docker Engine and port access to the container. |
+| Cloudflare sharing/live | Cloudflare Pages, `SHARE_KV`, and `LIVE_ROOMS` Durable Object bindings. |
+| Desktop build | Node.js/npm, Neutralino binaries, and internet access during setup/prepare. |
 
-- [System Requirements](#system-requirements)
-- [Option 1: Docker Container (Recommended)](#option-1-docker-container-recommended)
-- [Option 2: Docker Compose Setup](#option-2-docker-compose-setup)
-- [Option 3: Self-Hosted Static Web Server](#option-3-self-hosted-static-web-server)
-- [Option 4: Neutralinojs Desktop Application](#option-4-neutralinojs-desktop-application)
-- [Air-Gapped & Offline Isolation Configuration](#air-gapped--offline-isolation-configuration)
+Do not rely on `file://` for normal use. Web Workers and Service Workers can be blocked from local files.
 
----
+## Quick Local Web Run
 
-## System Requirements
-
-### Web & Container Deployments
-*   **Modern Web Browsers:** Google Chrome 90+, Mozilla Firefox 90+, Microsoft Edge 90+, Apple Safari 15+. Note that PWA and Service Worker features require HTTPS or a `localhost` origin for security enforcement.
-*   **Docker Daemon:** Docker Engine 20.10+ (for Docker container deployment).
-*   **System Resources:** Minimum 512 MB RAM, 100 MB disk space.
-
-### Desktop Application Compilation
-*   **Operating Systems:** Windows 10+ (x64), Ubuntu 20.04+ (x64 / ARM64), macOS 11+ (Universal Apple Silicon/Intel).
-*   **Node.js Runtime Environment:** v16.0.0 or later (includes npm package manager).
-*   **System Resources:** Minimum 256 MB RAM, 50 MB disk space.
-
----
-
-## Option 1: Docker Container (Recommended)
-
-Deploy the application using the official Docker image hosted on the GitHub Container Registry (GHCR).
-
-### Running the Container
-Execute the following command to start a detached container that redirects host port `8080` to container port `80`:
+From the repository root:
 
 ```bash
-docker pull ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
+python -m http.server 8080
+```
+
+or:
+
+```bash
+npx serve . -p 8080
+```
+
+Open `http://localhost:8080`.
+
+This runs the editor, split live preview, sync scrolling, local storage, local `.md` file imports, exports, PWA registration, and CDN-loaded renderers. Cloudflare-only features such as stored Share Snapshot and Live Share require their matching deployed endpoints.
+
+## Docker
+
+Using the published image:
+
+```bash
 docker run -d \
   --name markdown-viewer \
   -p 8080:80 \
@@ -45,162 +44,114 @@ docker run -d \
   ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
 ```
 
-Open **http://localhost:8080** in your browser.
+Open `http://localhost:8080`.
 
-### Adjusting Ports
-To map the application to a different port (such as `9000`), modify the left side of the `-p` parameter:
+Using Compose from the repository root:
 
-```bash
-docker pull ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-docker run -d \
-  --name markdown-viewer \
-  -p 9000:80 \
-  --restart unless-stopped \
-  ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-```
-
-### Image Tags
-
-| Tag Name | Production Ready | Target Source Branch | Target Architecture |
-| :--- | :--- | :--- | :--- |
-| `latest` | Yes (Stable Release) | `main` branch (Release tag) | `linux/amd64`, `linux/arm64` |
-| `main` | No (Development) | `main` branch (Commit updates) | `linux/amd64`, `linux/arm64` |
-| `<commit-sha>` | Pinned | Specific Git commit hash | `linux/amd64`, `linux/arm64` |
-
----
-
-## Option 2: Docker Compose Setup
-
-For local deployments and multi-container environments, use Docker Compose.
-
-### 1. Clone the Codebase
-```bash
-git clone https://github.com/ThisIs-Developer/Markdown-Viewer.git
-cd Markdown-Viewer
-```
-
-### 2. Launch the Application
-Start the container using Compose:
 ```bash
 docker compose up -d
 ```
 
-### 3. Verify Container Status
-Confirm the container is running:
+To rebuild from local source:
+
 ```bash
-docker compose ps
+docker compose up -d --build
 ```
 
-### 4. Stop the Container
+The Docker image serves static files with Nginx. It does not magically provide Cloudflare KV or Durable Objects; deploy those separately if you want stored Share Snapshot or Live Share.
+
+## Static Hosting
+
+Serve at least these root files:
+
+- `index.html`
+- `script.js`
+- `styles.css`
+- `preview-worker.js`
+- `sw.js`
+- `manifest.json`
+- `assets/`
+
+For Cloudflare Pages with stored Share Snapshot and Live Share, also deploy:
+
+- `functions/api/share/[[id]].js`
+- `functions/live-room/[[room]].js`
+- `workers/live-room-worker.js`
+- `wrangler.toml`
+- `wrangler.live-room.toml`
+
+If you host under a sub-path, test worker, service-worker, manifest, and dynamic library paths carefully.
+
+## Cloudflare Setup
+
+Share Snapshot storage needs a KV namespace bound as `SHARE_KV`.
+
+Live Share needs a Durable Object binding named `LIVE_ROOMS` using the `LiveRoom` class from `workers/live-room-worker.js`.
+
+Deploy the live room worker with:
+
 ```bash
-docker compose down
+wrangler deploy -c wrangler.live-room.toml
 ```
 
-### Default `docker-compose.yml` Configuration
-```yaml
-services:
-  markdown-viewer:
-    image: ghcr.io/thisis-developer/markdown-viewer:sha-15eafb0
-    container_name: markdown-viewer
-    ports:
-      - "8080:80"
-    restart: unless-stopped
-```
+Then deploy the Pages project with `wrangler.toml` or your Cloudflare Pages configuration. See [Live Share Cloudflare](Live-Share-Cloudflare) and [Configuration](Configuration).
 
-To build a local image instead of pulling the published container, update the `image` field with a `build` directive:
-```yaml
-services:
-  markdown-viewer:
-    build: .
-    container_name: markdown-viewer
-    ports:
-      - "8080:80"
-    restart: unless-stopped
-```
+## Desktop App
 
----
+From `desktop-app/`:
 
-## Option 3: Self-Hosted Static Web Server
-
-Because Markdown Viewer is a fully client-side application, you can serve it from any static web server to serve `index.html` on localhost (`127.0.0.1`) by copying `index.html`, `script.js`, `preview-worker.js`, `styles.css`, `sw.js`, and the `assets/` folder.
-
-### Clone the Repository
 ```bash
-git clone https://github.com/ThisIs-Developer/Markdown-Viewer.git
-cd Markdown-Viewer
+npm install
+npm run setup
+npm run dev
 ```
 
-### Serving with Python (Built-in Web Server)
-Run the following command in the repository root to serve the project on localhost:
+Build release resources and binaries with:
+
 ```bash
-python3 -m http.server 8080
+npm run build
 ```
 
-### Serving with Node.js
-Run the following command in the repository root to serve the project on localhost:
+What setup does:
+
+- Downloads Neutralino binaries.
+- Runs `prepare.js`.
+- Copies the root app into `desktop-app/resources`.
+- Downloads and verifies external libraries where integrity values are available.
+- Rewrites dynamic renderer library paths to local `/libs/...` files.
+- Prepares the desktop app for offline use after the build is complete.
+
+The desktop app uses native open/save dialogs for Markdown and HTML files, asks before closing, and can load a Markdown file passed as a command-line argument.
+
+## Offline Use
+
+Web/PWA:
+
+- First load requires the app shell and any needed CDN libraries.
+- After caching, the app shell and previously fetched CDN libraries can work offline.
+- Features that require live network access still need it: GitHub import, stored Share Snapshot, Live Share, remote diagram rendering, external images, and map tiles.
+
+Desktop:
+
+- The prepared desktop bundle uses local libraries in `resources/libs`.
+- Local editing, rendering, and export features are available without CDN access after preparation.
+- Network features still use the network when invoked.
+
+## Platform Notes
+
+Windows desktop binaries may trigger SmartScreen because they are unsigned. Choose More info, then Run anyway if you trust the build.
+
+Linux binaries may need execute permission:
+
 ```bash
-npx serve . -p 8080
+chmod +x markdown-viewer-linux_x64
+./markdown-viewer-linux_x64
 ```
-Once started, the application is accessible at **http://localhost:8080** or **http://127.0.0.1:8080**.
 
-### Serving with Nginx
-Copy the project assets to Nginx's HTML folder:
+macOS binaries may need quarantine removal:
+
 ```bash
-cp -r . /usr/share/nginx/html/
+xattr -d com.apple.quarantine markdown-viewer-mac_universal
+chmod +x markdown-viewer-mac_universal
+./markdown-viewer-mac_universal
 ```
-
-> [!WARNING]
-> Opening the `index.html` file directly in a browser via the `file://` protocol may fail due to browser security restrictions (CORS) that block Web Workers and Service Workers from running locally. Always serve the files using a local web server.
-
----
-
-## Option 4: Neutralinojs Desktop Application
-
-Markdown Viewer can also run as a native desktop application powered by **Neutralinojs**.
-
-### Downloading Pre-Built Executables
-Download the binary for your platform from the [GitHub Releases Page](https://github.com/ThisIs-Developer/Markdown-Viewer/releases):
-*   **Windows:** `markdown-viewer-win_x64.exe`
-*   **Linux:** `markdown-viewer-linux_x64`
-*   **Linux ARM (Raspberry Pi):** `markdown-viewer-linux_arm64`
-*   **macOS (Apple Silicon/Intel):** `markdown-viewer-mac_universal`
-
-### Building the Desktop Executable from Source
-Follow these steps to build the binaries locally:
-
-1.  Navigate to the desktop application folder:
-    ```bash
-    cd desktop-app
-    ```
-2.  Install dependencies:
-    ```bash
-    npm install
-    ```
-3.  Download Neutralino framework binaries:
-    ```bash
-    node setup-binaries.js
-    ```
-4.  Copy files from the project root into the desktop resource folder:
-    ```bash
-    node prepare.js
-    ```
-5.  Compile the executable:
-    ```bash
-    # Build single-file embedded Windows binary
-    npm run build
-    
-    # Build portable distribution zip files for all platforms
-    npm run build:portable
-    ```
-
----
-
-## Air-Gapped & Offline Isolation Configuration
-
-By default, the application loads large rendering dependencies (like MathJax and Mermaid) from external CDNs. In secure, offline, or air-gapped environments, these remote scripts will fail to load.
-
-### Setting Up a Fully Offline Build:
-1.  Download the required JavaScript dependencies (see [Configuration](Configuration) for URLs) and save them to a local directory (e.g., `js/libs/`).
-2.  Update the `<script>` and `<link>` tags in `index.html` to reference your local asset paths.
-3.  Synchronize the desktop app folder by running `node prepare.js`.
-4.  Rebuild your Docker image or desktop application.

--- a/wiki/Live-Share-Cloudflare.md
+++ b/wiki/Live-Share-Cloudflare.md
@@ -1,30 +1,97 @@
 # Live Share Cloudflare Architecture
 
-Live Share uses a temporary Cloudflare-backed room instead of browser-local storage,
-BroadcastChannel, or peer discovery. The normal Markdown editor remains local-first.
+Live Share is the real-time collaboration feature in Markdown Viewer v3.9.0. It is separate from Share Snapshot. Share Snapshot creates a point-in-time link; Live Share creates a temporary WebSocket room.
 
-## Runtime Flow
+## User Flow
 
-1. A host starts Live Share for the active tab.
-2. The browser creates a Yjs document for that tab and opens a WebSocket to
-   `/live-room/<room-id>?secret=<room-secret>`.
-3. Cloudflare Pages forwards that WebSocket to a `LIVE_ROOMS` Durable Object.
-4. The Durable Object relays Yjs updates, sync requests, participant presence,
-   cursor presence, participant leave events, and host session-end events.
-5. Participants opening the invite link create a separate live tab, join the same
-   room, request the current Yjs state, and render remote participants/cursors.
-6. New invite links do not embed the Markdown document body. The URL contains
-   only the room id, room secret, and tab title so link length does not grow with
-   document size.
+1. The host clicks Live Share.
+2. The host enters or accepts a display name.
+3. The host chooses Can edit or View only.
+4. The app creates a random room id and a random room secret.
+5. The app creates a Yjs document for the active tab.
+6. The host opens a WebSocket to `/live-room/<room-id>?secret=<secret>`.
+7. The invite link is shown only after the room starts.
+8. Participants open the invite link, join a temporary live tab, request the current Yjs state, and render participant avatars/cursors.
+9. The host can end the room for everyone.
 
-## Cloudflare Requirements
+The invite URL contains the room id, secret, and title. It does not embed the full Markdown document body.
 
-- The Pages project must expose a Durable Object binding named `LIVE_ROOMS`.
-- The Durable Object class is `LiveRoom` in `workers/live-room-worker.js`.
-- `wrangler.live-room.toml` deploys the worker and Durable Object migration.
-- The root Pages project does not require a checked-in `wrangler.toml`.
-- Live room document state is not written to KV or a database. Rooms are
-  temporary and exist only while participants are connected.
+## Cloudflare Runtime
 
-`SHARE_KV` is still used only for normal snapshot share links, not for live
-editing transport.
+There are two checked-in Cloudflare entry points:
+
+- `functions/live-room/[[room]].js` is the Pages Function endpoint for `/live-room/<room>`.
+- `workers/live-room-worker.js` contains the `LiveRoom` Durable Object class and a Worker export.
+
+The Pages Function:
+
+- Requires a WebSocket upgrade request.
+- Requires a `LIVE_ROOMS` Durable Object binding.
+- Rejects room names over 160 characters.
+- Rejects secrets over 256 characters.
+- Uses `roomName + ":" + secret` to select the Durable Object id.
+- Returns `Cache-Control: no-store` for non-upgrade status responses.
+
+The Durable Object:
+
+- Accepts the WebSocket pair.
+- Assigns a temporary socket participant id.
+- Relays only known message types: `hello`, `presence`, `sync-request`, `sync-state`, `y-update`, `leave`, and `session-end`.
+- Adds `roomId` and `sentAt` to normalized messages.
+- Broadcasts messages to other sockets in the same room.
+- Broadcasts `leave` when a socket closes or errors.
+
+## Limits
+
+| Limit | Value |
+| :--- | :--- |
+| Max live message size | 1 MB |
+| Max WebSocket participants per room | 64 |
+| Participant stale timeout in client UI | 45 seconds |
+| Client join timeout | 8 seconds |
+| Room name length at Pages Function | 160 characters |
+| Secret length at Pages Function | 256 characters |
+
+If the room is full, the Durable Object returns HTTP 429. If credentials or bindings are missing, the endpoints return a plain error response.
+
+## Data Handling
+
+Live Share relays:
+
+- Yjs document updates.
+- Initial sync state.
+- Display names.
+- Participant presence.
+- Cursor positions.
+- Leave events.
+- Host session-end events.
+
+Live Share does not write document content to Cloudflare KV or a database. State is temporary room/connection state in the Durable Object and clients. The normal local workspace remains local, and joined live tabs are temporary so they are not saved into the participant's tab storage.
+
+## Privacy and Security Notes
+
+- The room secret is part of the invite URL. Anyone with the link can try to join while the room is active.
+- No end-to-end encryption is implemented in the app.
+- View-only mode is enforced by the client and message handling. It is useful for normal collaboration, but it is not a cryptographic permission boundary against modified clients.
+- The host should end the room when collaboration is finished.
+- Cloudflare deployment logs and platform behavior are controlled by the deployer's Cloudflare account configuration.
+
+## Required Configuration
+
+`wrangler.toml` binds `LIVE_ROOMS` for the Pages project and binds `SHARE_KV` for Share Snapshot. `wrangler.live-room.toml` deploys the standalone Durable Object worker:
+
+```toml
+name = "markdown-viewer-live-room"
+main = "workers/live-room-worker.js"
+compatibility_date = "2026-07-02"
+
+[[durable_objects.bindings]]
+name = "LIVE_ROOMS"
+class_name = "LiveRoom"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["LiveRoom"]
+```
+
+Share Snapshot uses `SHARE_KV`; Live Share uses `LIVE_ROOMS`. They should not be described as the same storage path.

--- a/wiki/Localization.md
+++ b/wiki/Localization.md
@@ -1,98 +1,95 @@
-# Localization & Internationalization (i18n)
+# Localization and Internationalization
 
-Markdown Viewer (v3.9.0) features a fully client-side translation engine that translates all user interface menus, modals, and tooltips dynamically.
+Markdown Viewer v3.9.0 has a client-side translation dictionary in `script.js`. It changes visible UI labels, toolbar text, modal titles, stats labels, and common messages without sending text to a translation service.
 
----
+## Supported Locales
 
-## 🌐 Supported Languages
+| Code | Language |
+| :--- | :--- |
+| `en` | English |
+| `zh` | Simplified Chinese |
+| `ja` | Japanese |
+| `ko` | Korean |
+| `pt` | Portuguese (Brazil) |
+| `es` | Spanish |
+| `fr` | French |
+| `de` | German |
+| `ru` | Russian |
+| `it` | Italian |
+| `tr` | Turkish |
+| `pl` | Polish |
+| `tw` | Traditional Chinese |
+| `uk` | Ukrainian |
 
-The application currently supports **14 language locales**:
+## Selection Order
 
-| Locale Code | Language Name | Flag / Display Name |
-| :--- | :--- | :--- |
-| **`en`** | English | 🇺🇸 English |
-| **`zh`** | 简体中文 (Simplified Chinese) | 🇨🇳 简体中文 |
-| **`tw`** | 繁體中文 (Traditional Chinese) | 🇹🇼 繁體中文 |
-| **`ja`** | 日本語 (Japanese) | 🇯🇵 日本語 |
-| **`ko`** | 한국어 (Korean) | 🇰🇷 한국어 |
-| **`pt`** | Português (Brasil) | 🇧🇷 Português (Brasil) |
-| **`es`** | Español (Spanish) | 🇪🇸 Español |
-| **`fr`** | Français (French) | 🇫🇷 Français |
-| **`de`** | Deutsch (German) | 🇩🇪 Deutsch |
-| **`ru`** | Русский (Russian) | 🇷🇺 Русский |
-| **`it`** | Italiano (Italian) | 🇮🇹 Italiano |
-| **`tr`** | Türkçe (Turkish) | 🇹РУ Türkçe |
-| **`pl`** | Polski (Polish) | 🇵🇱 Polski |
-| **`uk`** | Українська (Ukrainian) | 🇺🇦 Українська |
+The app chooses a language in this order:
 
----
+1. URL query parameter, such as `?lang=pt`.
+2. Hash query parameter when present in a shared URL.
+3. Saved `localStorage` key `app-lang`.
+4. Browser language from `navigator.language`.
+5. English fallback.
 
-## ⚙️ Architecture & Selection Precedence
+When a user picks a language from the dropdown, the app saves `app-lang` and updates the URL query parameter.
 
-When a user visits the application, the translation engine resolves the locale using the following precedence cascade:
+## What Gets Translated
 
-```mermaid
-graph TD
-    A["1. URL Query Parameter (?lang=zh)"] -->|Found| B["Apply Language Settings"]
-    A -->|Not Found| C["2. localStorage ('app-lang')"]
-    C -->|Found| B
-    C -->|Not Found| D["3. Browser Language (navigator.language)"]
-    D -->|Match| B
-    D -->|No Match| E["4. Default Locale ('en')"]
-    E --> B
-```
+The dictionary covers:
 
-### 1. URL Query Parameter Mapping
-If the URL contains a `?lang=` query parameter (e.g., `https://markdownviewer.pages.dev/?lang=pt`), it overrides all other settings.
+- Main toolbar labels.
+- Import/export labels.
+- Share Snapshot and Live Share labels.
+- View mode labels.
+- Stats labels.
+- Theme labels.
+- Modal titles for help, about, share, rename, link, reference, image, table, and find/replace.
+- Loading messages for emoji lookup and GitHub file loading.
+- Placeholder text.
 
-### 2. Local Storage Persistence
-When a user manually selects a language from the dropdown menu, their choice is saved to `localStorage` under the key `'app-lang'`. This preference is loaded on subsequent visits.
+Some strings remain English because they come from dynamic renderer output, browser APIs, third-party libraries, generated filenames, external services, or low-level error messages.
 
-### 3. Automatic Browser Detection
-If no parameter or storage key is found, the engine queries `navigator.language` and falls back to matching the user's primary browser settings.
+## Dictionary Shape
 
----
-
-## 📝 Localization Dictionary Schema
-
-All translations are defined statically within `script.js` inside the `I18N_DICTS` object. The localized items use the following dictionary schema:
+Translations are stored in `I18N_DICTS`:
 
 ```javascript
 {
   title: "Markdown Viewer",
-  subtitle: "Live Markdown Editor",
-  new: "New",
-  open: "Open",
+  import: "Import",
   export: "Export",
   exportMd: "Markdown (.md)",
   exportHtml: "HTML",
   exportPdf: "PDF",
   exportPng: "Image (.png)",
   copy: "Copy",
-  copied: "Copied!",
-  share: "Share",
+  shareSnapshot: "Share Snapshot",
+  liveShare: "Live Share",
   reset: "Reset",
   editor: "Editor",
   split: "Split",
   preview: "Preview",
-  minRead: "Min read",
+  minRead: "Min Read",
   words: "Words",
   chars: "Chars",
-  switchRtl: "Switch to RTL",
-  switchLtr: "Switch to LTR",
   darkMode: "Dark Mode",
   lightMode: "Light Mode",
-  helpTitle: "Markdown Viewer Help",
-  aboutTitle: "About Markdown",
-  shareTitle: "Share Document",
-  renameTitle: "Rename File",
-  insertLink: "Insert Link",
-  insertRef: "Insert Quote",
-  insertImg: "Insert Image",
-  insertTable: "Insert Table",
-  findReplace: "Find & Replace",
-  placeholder: "Type your markdown here...",
-  loadingEmojis: "Loading emojis...",
-  loadingFiles: "Fetching file structure..."
+  findReplace: "Find & Replace"
 }
 ```
+
+Add new keys to every locale when introducing new visible UI text. If a key is missing, code should fall back to English or a hard-coded safe label.
+
+## Contributor Checklist
+
+- Update `I18N_DICTS` for all supported locales.
+- Update desktop resources by running the desktop prepare step.
+- Check desktop and mobile menus.
+- Check modal titles and buttons.
+- Check Share Snapshot and Live Share labels.
+- Check `?lang=` URLs.
+- Keep language names readable in both desktop and mobile dropdowns.
+
+## Privacy
+
+Localization is local. The app does not send document text or UI text to machine translation APIs.

--- a/wiki/Markdown-Reference.md
+++ b/wiki/Markdown-Reference.md
@@ -1,151 +1,134 @@
-# Markdown Syntax Reference
+# Markdown Reference
 
-This page provides a comprehensive guide to writing GitHub-Flavored Markdown (GFM), LaTeX math formulas, and Mermaid diagrams in **Markdown Viewer** (v3.9.0).
+Markdown Viewer v3.9.0 supports standard Markdown, GitHub-Flavored Markdown (GFM), selected custom inline extensions, LaTeX math, GitHub alerts, frontmatter, and many fenced-code renderers. This makes it useful for README files, documentation, notes, tables, task lists, code blocks, math, diagrams, and other content people often preview before exporting or sharing.
 
----
+All rendered HTML is sanitized before display. Raw HTML is useful for formatting, but scripts and unsafe event handlers are removed. The preview is GitHub-style and GFM-oriented, not a promise of byte-for-byte identical rendering to GitHub, Pandoc, Obsidian, Typora, or other Markdown tools.
 
-## Table of Contents
+## Core Markdown
 
-- [Headings](#headings)
-- [Paragraphs & Line Breaks](#paragraphs--line-breaks)
-- [Emphasis & Text Formatting](#emphasis--text-formatting)
-- [Blockquotes](#blockquotes)
-- [Lists & Task Lists](#lists--task-lists)
-- [Code Elements](#code-elements)
-- [Horizontal Rules](#horizontal-rules)
-- [Links & Images](#links--images)
-- [Tables](#tables)
-- [Footnotes](#footnotes)
-- [HTML Sanitized Formatting](#html-sanitized-formatting)
-- [LaTeX Mathematical Formulas](#latex-mathematical-formulas)
-- [Mermaid Diagrams](#mermaid-diagrams)
-- [Emoji & Alerts](#emoji--alerts)
-
----
-
-## Headings
-
-You can write headings using hash symbols (`#`) at the beginning of a line:
+### Headings
 
 ```markdown
-# Heading 1 (Document Title)
-## Heading 2 (Main Section)
-### Heading 3 (Sub-Section)
+# Heading 1
+## Heading 2
+### Heading 3
 #### Heading 4
 ##### Heading 5
 ###### Heading 6
+
+Setext Heading 1
+================
+
+Setext Heading 2
+----------------
 ```
 
-Alternative Setext syntax for Heading 1 and Heading 2:
-```markdown
-Heading 1
-=========
+Heading ids are generated from heading text so links like `[Jump](#heading-2)` can scroll inside the preview.
 
-Heading 2
----------
+### Paragraphs and Line Breaks
+
+Separate paragraphs with a blank line. End a line with two spaces or a backslash for a hard line break.
+
+```markdown
+First paragraph.
+
+Second paragraph.
+
+Line one\
+Line two
 ```
 
----
-
-## Paragraphs & Line Breaks
-
-*   **Paragraphs:** Separate paragraphs with a blank line.
-*   **Line Breaks:** Insert two spaces at the end of a line, or end the line with a backslash (`\`), to start a new line within the same paragraph.
+### Emphasis
 
 ```markdown
-This is paragraph one.
-
-This is paragraph two.
-
-Line one (ended with a backslash)\
-Line two inside the same paragraph.
-
-Line one (ended with two spaces)  
-Line two inside the same paragraph.
+*italic*
+_italic_
+**bold**
+__bold__
+***bold italic***
+~~strikethrough~~
 ```
 
----
-
-## Emphasis & Text Formatting
-
-| Style | Syntax | Output |
-| :--- | :--- | :--- |
-| **Italic** | `*text*` or `_text_` | *Italic* |
-| **Bold** | `**text**` or `__text__` | **Bold** |
-| **Bold Italic** | `***text***` | ***Bold Italic*** |
-| **Strikethrough** | `~~text~~` | ~~Strikethrough~~ |
-| **Underline (HTML)** | `<u>text</u>` | <u>Underline</u> |
-| **Highlight (HTML)** | `<mark>text</mark>` | <mark>Highlight</mark> |
-
----
-
-## Blockquotes
-
-Use the `>` symbol to indent blockquotes:
+Custom inline extensions:
 
 ```markdown
-> This is a blockquote.
+==highlight==
+^superscript^
+~subscript~
+```
+
+### Blockquotes
+
+```markdown
+> A quote.
 >
-> You can write multiple paragraphs inside a blockquote.
->
->> This is a nested blockquote level 2.
+> > A nested quote.
 ```
 
----
+GitHub alert blocks are also written as blockquotes. See [Alerts](#alerts).
 
-## Lists & Task Lists
+### Lists and Task Lists
 
-### Unordered Lists
-Use `-`, `*`, or `+` to create bulleted lists:
 ```markdown
-- Item A
-- Item B
-  - Nested Item B1
-  - Nested Item B2
+- Item
+- Item
+  - Nested item
+
+1. First
+2. Second
+   1. Nested
+
+- [x] Done
+- [ ] Not done
 ```
 
-### Ordered Lists
-Use numbers followed by a period:
+The editor continues Markdown lists when you press Enter and exits a list when you press Enter on an empty list item.
+
+### Code
+
+Inline:
+
 ```markdown
-1. First item
-2. Second item
-   1. Nested ordered item
+Use `const value = 1`.
 ```
 
-### GFM Task Checklists
-```markdown
-- [x] Completed task item
-- [ ] Incomplete task item
-- [x] Another completed task
-```
-
----
-
-## Code Elements
-
-### Inline Code
-Wrap inline code code segments in single backticks:
-```markdown
-Use the `const api = "/v1"` configuration variable to target the endpoint.
-```
-
-### Code Blocks with Syntax Highlighting
-Wrap code blocks in triple backticks and specify the programming language (e.g. `javascript`, `python`, `html`, `css`, `bash`, `yaml`) to enable syntax highlighting:
+Fenced code:
 
 ````markdown
 ```javascript
-const greet = (name) => {
-    return `Hello, ${name}!`;
-};
-console.log(greet("Developer"));
+console.log("Hello");
 ```
 ````
 
----
+Highlight.js colors known languages. Unknown languages fall back to plaintext.
 
-## Horizontal Rules
+### Links and Images
 
-Insert three or more hyphens, asterisks, or underscores on a line by themselves to create a divider:
+```markdown
+[GitHub](https://github.com)
+[GitHub with title](https://github.com "GitHub")
+[Reference link][repo]
+
+![Alt text](assets/icon.jpg)
+![Alt text with title](assets/icon.jpg "Logo")
+![Reference image][logo]
+
+[repo]: https://github.com/ThisIs-Developer/Markdown-Viewer
+[logo]: assets/icon.jpg
+```
+
+Links and images can request external resources when opened or rendered.
+
+### Tables
+
+```markdown
+| Name | Count | Price |
+| :--- | :---: | ---: |
+| Editor | 1 | $0 |
+| Exporter | 2 | $0 |
+```
+
+### Horizontal Rules
 
 ```markdown
 ---
@@ -153,188 +136,272 @@ Insert three or more hyphens, asterisks, or underscores on a line by themselves 
 ___
 ```
 
----
+## Extended Markdown
 
-## Links & Images
-
-### Links
-```markdown
-# Inline link
-[GitHub](https://github.com)
-
-# Link with a title tooltip
-[GitHub](https://github.com "GitHub Homepage")
-
-# Reference link
-[GitHub][github-link]
-
-[github-link]: https://github.com
-```
-
-### Images
-```markdown
-# Standard image
-![Alt text](assets/icon.jpg)
-
-# Image with a title tooltip
-![Alt text](assets/icon.jpg "Logo")
-
-# Reference-style image
-![Alt text][logo-image]
-
-[logo-image]: assets/icon.jpg
-```
-
----
-
-## Tables
-
-Use vertical bars `|` to separate columns and hyphens `-` to create the header divider. You can align columns using colons `:`:
+### Footnotes
 
 ```markdown
-| Product Name | Quantity | Price |
-| :--- | :---: | ---: |
-| Markdown Editor | 1 | $0.00 |
-| PDF Exporter | 5 | $0.00 |
-| Dynamic Diagrams | 2 | $0.00 |
+This sentence has a footnote.[^1]
+
+[^1]: Footnotes can contain multiple paragraphs.
+
+    Indented continuation lines are part of the note.
 ```
 
-*   `:---`: Left-aligned (default).
-*   `:---:`: Center-aligned.
-*   `---:`: Right-aligned.
+Footnotes render at the bottom with back-reference links. Multi-paragraph footnotes are supported.
 
----
-
-## Footnotes
-
-Add footnotes using carets `[^]`:
+### Definition Lists
 
 ```markdown
-Here is a sentence with a footnote citation.[^1]
-
-[^1]: This is the text of the footnote displayed at the bottom of the page.
+Term
+: Definition text
+: Another definition for the same term
 ```
 
+### Frontmatter
+
+YAML frontmatter can be placed at the top of a document.
+
+```markdown
+---
+title: Project Notes
+status: Draft
+tags:
+  - markdown
+  - docs
 ---
 
-## HTML Sanitized Formatting
+# Body
+```
 
-You can write HTML tags directly in your Markdown files. The application sanitizes HTML using **DOMPurify** to block unsafe code (like `<script>` elements and inline event handlers):
+HTML export parses frontmatter and renders it as a table before the document body.
+
+### Raw HTML
 
 ```html
 <details>
-  <summary>Click to expand additional configurations</summary>
-  <p>Here is some additional content tucked inside an HTML details tag.</p>
+  <summary>Open me</summary>
+  <p>Hidden content.</p>
 </details>
 
-<div class="alert alert-info">
-  This is a custom alert box using Bootstrap styles.
-</div>
+<kbd>Ctrl</kbd> + <kbd>S</kbd>
+<abbr title="Application Programming Interface">API</abbr>
 ```
 
----
+DOMPurify sanitization removes unsafe tags and attributes. Inline scripts and handlers such as `onclick` are not preserved.
 
-## LaTeX Mathematical Formulas
-
-LaTeX mathematical equations are typeset in real time using MathJax.
-
-### Inline Math
-Wrap formulas in single dollar signs (`$`):
-```markdown
-The quadratic formula is defined as $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$ when solving equations.
-```
-
-### Block Math
-Wrap formulas in double dollar signs (`$$`):
-```markdown
-$$
-\int_{a}^{b} f(x) \,dx = F(b) - F(a)
-$$
-```
-
-### LaTeX Examples
-
-| Description | Formula Syntax |
-| :--- | :--- |
-| **Fractions** | `\frac{numerator}{denominator}` |
-| **Integrals** | `\int_{lower}^{upper} x^2 \,dx` |
-| **Summations** | `\sum_{i=1}^{n} a_i` |
-| **Matrices** | `\begin{matrix} a & b \\ c & d \end{matrix}` |
-| **Greek Letters** | `\alpha, \beta, \gamma, \theta, \lambda` |
-| **Roots** | `\sqrt{x^2 + y^2}` |
-
----
-
-## Mermaid Diagrams
-
-Wrap Mermaid syntax in a fenced code block with the `mermaid` language tag:
-
-### Flowchart
-````markdown
-```mermaid
-flowchart TD
-    A[Start Node] --> B{Is Authentication Valid?}
-    B -- Yes --> C[Access granted]
-    B -- No --> D[Access denied]
-```
-````
-
-### Sequence Diagram
-````markdown
-```mermaid
-sequenceDiagram
-    participant Client
-    participant API Worker
-    participant Storage
-    
-    Client->>API Worker: HTTP POST Request (markdown content)
-    API Worker->>Storage: Save file state
-    Storage-->>API Worker: State saved confirmation
-    API Worker-->>Client: HTTP 200 OK Response
-```
-````
-
-### Gantt Chart
-````markdown
-```mermaid
-gantt
-    title Development Sprint Tasks
-    dateFormat YYYY-MM-DD
-    section Parsing Core
-    Web Worker Integration :a1, 2026-06-01, 10d
-    DOM Patching Engine :after a1, 5d
-    section Desktop wrapper
-    Neutralino Shell Integration :2026-06-15, 8d
-```
-````
-
----
-
-## Emoji & Alerts
-
-### Emoji
-Use emoji shortcodes to insert icons:
-```markdown
-:rocket: :tada: :sparkles: :warning: :memo:
-```
-*   Renders as: 🚀 🎉 ✨ ⚠️ 📝
-
-### GitHub Alerts
-GitHub-style alert callouts are rendered with corresponding styling:
+### Alerts
 
 ```markdown
 > [!NOTE]
-> This is a general note callout box.
+> Useful background information.
 
 > [!TIP]
-> This is a helpful tip callout box.
+> A helpful suggestion.
 
 > [!IMPORTANT]
-> This is a critical important callout box.
+> Something the reader should not miss.
 
 > [!WARNING]
-> This is a warning callout box.
+> A risk or possible problem.
 
 > [!CAUTION]
-> This is a caution callout box.
+> A serious warning.
 ```
+
+### Emoji
+
+```markdown
+:rocket: :tada: :warning: :memo:
+```
+
+Emoji shortcode rendering uses the JoyPixels/emoji toolkit when available. The emoji picker can also query GitHub's emoji API.
+
+## Math
+
+Inline math:
+
+```markdown
+Einstein wrote $E = mc^2$.
+```
+
+Display math:
+
+```markdown
+$$
+\int_a^b f(x)\,dx = F(b) - F(a)
+$$
+```
+
+Fenced math:
+
+````markdown
+```math
+\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+```
+````
+
+MathJax renders math on demand. Escape literal dollar signs as `\$` when they are not math delimiters.
+
+## Diagrams and Rich Fences
+
+### Mermaid
+
+````markdown
+```mermaid
+flowchart TD
+  A[Start] --> B{Ready?}
+  B -- Yes --> C[Ship]
+  B -- No --> D[Fix]
+```
+````
+
+Mermaid renders client-side and supports zoom, pan, copy image, PNG download, and SVG download.
+
+### PlantUML
+
+````markdown
+```plantuml
+@startuml
+Alice -> Bob: Hello
+Bob --> Alice: Hi
+@enduml
+```
+````
+
+PlantUML rendering uses a remote PlantUML server first and Kroki fallback. Diagram source is sent to the remote renderer.
+
+### D2
+
+````markdown
+```d2
+app -> api -> db
+api.shape: hexagon
+db.shape: cylinder
+```
+````
+
+D2 rendering uses Kroki. Some D2 source is normalized for common SQL-table layout cases.
+
+### Graphviz / DOT
+
+````markdown
+```graphviz
+digraph G {
+  A -> B;
+  B -> C;
+}
+```
+````
+
+You can also use the `dot` fence. Rendering uses Kroki.
+
+### Vega-Lite
+
+````markdown
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {"values": [{"a": "A", "b": 28}, {"a": "B", "b": 55}]},
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "a", "type": "nominal"},
+    "y": {"field": "b", "type": "quantitative"}
+  }
+}
+```
+````
+
+Use `vega-lite` or `vegalite`. Rendering uses Kroki.
+
+### WaveDrom
+
+````markdown
+```wavedrom
+{ signal: [
+  { name: "clk", wave: "p....." },
+  { name: "data", wave: "x.345x", data: ["A", "B", "C"] }
+] }
+```
+````
+
+Rendering uses Kroki.
+
+### Markmap
+
+````markdown
+```markmap
+# Plan
+## Build
+### Parse
+### Render
+## Ship
+```
+````
+
+Markmap renders client-side with Markmap and D3. The app normalizes Markmap fences so nested code fences do not break parsing.
+
+### GeoJSON
+
+````markdown
+```geojson
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {"type": "Point", "coordinates": [-73.9857, 40.7484]},
+      "properties": {"name": "Example point"}
+    }
+  ]
+}
+```
+````
+
+GeoJSON renders as an interactive Leaflet map. Map tiles can require network access depending on the tile source.
+
+### TopoJSON
+
+````markdown
+```topojson
+{
+  "type": "Topology",
+  "objects": {},
+  "arcs": []
+}
+```
+````
+
+TopoJSON is converted with the TopoJSON library and rendered on a Leaflet map.
+
+### STL 3D Models
+
+````markdown
+```stl
+solid example
+endsolid example
+```
+````
+
+STL renders with Three.js. The viewer supports orbit controls, a zoom modal, solid mode, surface-angle mode, wireframe mode, copy image, and PNG export. Large models depend on browser memory and WebGL support.
+
+### ABC Music Notation
+
+````markdown
+```abc
+X:1
+T:Example
+M:4/4
+K:C
+C D E F | G A B c |
+```
+````
+
+ABCJS renders sheet music. Playback uses browser audio support and shows a synchronized cursor and note highlighting when audio is supported.
+
+## Export Notes for Markdown Authors
+
+- Browser Print is usually best for long documents.
+- Raster PDF and PNG exports are screenshots of rendered HTML and can be affected by cross-origin images, very large canvases, and late-loading remote diagrams.
+- Remote-rendered diagrams should finish rendering before export.
+- Wide tables, large diagrams, and huge STL models may be scaled or moved during export.

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -1,177 +1,160 @@
-# User Operations & Usage Guide
+# Usage Guide
 
-This guide details how to work with the editing workspace, importing flows, exporting tools, and serverless sharing mechanisms in **Markdown Viewer** (v3.9.0).
+This guide explains how to use Markdown Viewer v3.9.0 as a premium browser-based Markdown editor, viewer, reader, and live preview tool. For deeper implementation notes and privacy details, see [Features](Features).
 
----
+## Workspace Layout
 
-## Table of Contents
+The app has five main areas:
 
-- [User Interface Layout](#user-interface-layout)
-- [Workspace Tab Management](#workspace-tab-management)
-- [Importing Documents](#importing-documents)
-- [Exporting & Compiling Documents](#exporting--compiling-documents)
-- [View Modes and Layout Control](#view-modes-and-layout-control)
-- [Theme Configurations](#theme-configurations)
-- [Proportional Scroll Sync](#proportional-scroll-sync)
-- [Content Analytics & Metrics](#content-analytics--metrics)
-- [Serverless URL Hash Sharing](#serverless-url-hash-sharing)
-- [Keyboard Shortcuts Reference](#keyboard-shortcuts-reference)
+| Area | What It Does |
+| :--- | :--- |
+| Header | Shows app name, stats, view controls, import/export, copy, sharing, language, and theme controls. |
+| Tab bar | Holds up to 20 normal document tabs, plus temporary shared/live tabs. |
+| Formatting toolbar | Inserts Markdown syntax, opens helper modals, starts find/replace, and toggles fullscreen/help/about. |
+| Editor pane | Plain-text Markdown textarea with line numbers, custom undo/redo, list continuation, and find highlights. |
+| Preview pane | Sanitized rendered Markdown with math, diagrams, maps, models, music, alerts, and syntax highlighting. |
 
----
+Use the view buttons to switch between Editor, Split, and Preview. Split view is the main live Markdown preview workflow: type, paste, or open Markdown on one side and read the rendered result on the other. Sync scrolling can keep the source and preview aligned while you write. Drag the divider to change the pane widths. The app prevents either side from becoming too narrow. On small screens, the mobile menu exposes the same main actions without forcing a cramped split layout.
 
-## User Interface Layout
+## Tabs and Autosave
 
-The interface is structured into a header section, formatting toolbar, document tabs, and a resizable workspace.
+- Click New Tab to create a document.
+- Rename a tab from its menu or rename action.
+- Duplicate, delete, or reorder tabs from the tab UI.
+- Closing the last normal tab resets to a clean document.
+- Reset clears the saved workspace.
+- Normal tabs autosave to local browser storage or desktop storage.
+- Temporary Share Snapshot and Live Share tabs are not saved to the recipient's workspace.
 
-```
-+-----------------------------------------------------------------------+
-|  App Header (.app-header)                                             |
-|  [Tab 1] [Tab 2] [Tab 3]                   [View Modes] [Settings]    |
-+-----------------------------------------------------------------------+
-|  Formatting Toolbar (.markdown-format-toolbar)                        |
-|  [Bold] [Italic] [Link] [Image] [Table] [Mermaid] [Math]              |
-+-----------------------------------------------------------------------+
-|                                  |                                    |
-|  Editor Pane (.editor-pane)      |  Preview Pane (.preview-pane)      |
-|                                  |                                    |
-|  [Gutter]  # Welcome...          |  # Welcome...                      |
-|    1       This is markdown      |  This is markdown.                 |
-|    2                             |                                    |
-|                                  |                                    |
-+-----------------------------------------------------------------------+
-|  Status Bar                                                           |
-|  Words: 4   Chars: 21                          Reading Time: 1 min    |
-+-----------------------------------------------------------------------+
-```
+Storage is local unless you explicitly use a network feature such as GitHub import, Share Snapshot storage, or Live Share.
 
-*   **Editor Pane (Left):** Monospace editing workspace with a line gutter showing line numbers.
-*   **Preview Pane (Right):** Sandbox layout area rendering GitHub-Flavored Markdown outputs.
-*   **Splitter Bar (Center):** Resizable divider allowing width adjustments. Drag boundaries clamp either pane from scaling below 20% width.
+## Editing Tools
 
----
+The toolbar can:
 
-## Workspace Tab Management
+- Format text as bold, italic, strikethrough, quote, inline code, fenced code, terminal block, headings, lists, and horizontal rules.
+- Insert links, images, reference links, tables, date/time stamps, emoji shortcodes, symbols/entities, GitHub alerts, and diagram templates.
+- Change selected text to title case, uppercase, or lowercase.
+- Insert left, center, or right aligned HTML blocks.
+- Switch document direction between LTR and RTL.
+- Open Find and Replace, Help, About, and fullscreen.
 
-Markdown Viewer allows you to open and edit multiple documents concurrently.
+The editor also supports list continuation on Enter, two-space indent on Tab, outdent on Shift+Tab, and custom undo/redo. View-only shared tabs block editing actions and keep reading, find, help, and fullscreen available.
 
-*   **Create Tabs:** Click the **`+`** button in the tab header bar.
-*   **Rename Tabs:** Double-click a tab label or open the tab menu to change the name.
-*   **Reorder Tabs:** Drag and drop tab components horizontally to reorganize them.
-*   **Duplicate Tabs:** Choose **Duplicate** from the tab's context dropdown to clone the document.
-*   **Delete Tabs:** Click the **`x`** icon on the tab. Deleting the last tab clears editor content and resets state.
-*   **Auto-Save Cache:** Tabs are auto-saved to `localStorage` every 500ms when typing, and flushed immediately during `beforeunload` or `visibilitychange` lifecycle states.
+## Find and Replace
 
----
+Open Find and Replace with the toolbar, `Ctrl+F`, or `Cmd+F`. Open replacement focus with `Ctrl+H` or `Cmd+H`.
+
+Supported options:
+
+- Case-sensitive search.
+- Whole-word search.
+- Regular expressions.
+- Regex capture replacements such as `$1` and `$<name>`.
+- Preserve-case replacement.
+- Search only within the selected text.
+- Scope matching to the whole document, headings, code, Mermaid, or LaTeX.
+- Replace current match or replace all.
+- Diff preview before bulk replacement.
+- Floating, docked, draggable, and resettable panel positions.
+
+Scope matching uses Marked's lexer and is best-effort for unusual Markdown.
 
 ## Importing Documents
 
-Load files into the workspace using three different paths:
+### Local Files
 
-### 1. Drag & Drop
-Drag a `.md` or `.markdown` text file from your file system and drop it directly onto the editor pane. The contents will overwrite the active tab. A binary safety guard scans the first 8 KB of the file for null bytes (`\x00`) to block corrupted or binary files.
+Use Import > From files, the mobile import button, or drag and drop to open local Markdown files.
 
-### 2. File Picker
-Click **Import** in the toolbar, select **From files**, and choose one or more Markdown files from your system.
+- Supported file types are `.md`, `.markdown`, and `text/markdown`.
+- Extension matching is case-insensitive.
+- Dragging over the app shows a drop overlay.
+- The app scans the first 8 KB for null bytes and rejects likely binary files.
+- Local file content stays on the device unless you later share it.
 
-### 3. GitHub Importer
-1.  Click **Import** and select **From GitHub**.
-2.  Paste a public GitHub URL (e.g., repository main page, subdirectory, or direct blob file link):
-    *   `https://github.com/owner/repository`
-    *   `https://github.com/owner/repository/tree/main/src/docs`
-    *   `https://github.com/owner/repository/blob/main/README.md`
-3.  The importer fetches the file tree from GitHub's API.
-4.  In the file selection modal, choose the files you want to import. You can select all files or clear the selection.
-5.  Click **Import Selected** to load the selected files into separate document tabs.
+### GitHub
 
----
+Use Import > From GitHub and paste one of these URL types:
 
-## Exporting & Compiling Documents
+- `https://github.com/owner/repo`
+- `https://github.com/owner/repo/tree/main/docs`
+- `https://github.com/owner/repo/blob/main/README.md`
+- `https://raw.githubusercontent.com/owner/repo/main/README.md`
 
-Export options are available in the **Export** dropdown in the toolbar:
+Direct Markdown file URLs import immediately. Repository and folder URLs query GitHub's public API, show a tree of Markdown files, and let you import selected files into separate tabs. If more than 30 Markdown files exist, only the first 30 are shown.
 
-### 1. Raw Markdown (`.md`)
-Saves the raw text buffer of the active tab.
+GitHub import sends the repository/path request to GitHub and only works for public content. The app does not ask for GitHub credentials.
 
-### 2. Standalone HTML (`.html`)
-Generates a self-contained HTML file. It bundles the compiled Markdown content, highlights code blocks, renders diagrams, and inlines GitHub-markdown styles so the document displays correctly offline.
+## Exporting
 
-### 3. Compiled PDF (`.pdf`)
-Generates a PDF using `jsPDF` and `html2canvas` via an off-screen sandbox. It converts SVG diagrams to rasters, scales oversized elements, and runs a cascade pagination loop to keep headings with their sections and prevent text lines from being cut in half.
+Export names use the active tab title when possible.
 
-> [!TIP]
-> For the highest PDF rendering quality, use your browser's built-in Print functionality (`Ctrl+P` or `Cmd+P`) and select "Save as PDF".
-
----
-
-## View Modes and Layout Control
-
-Configure the workspace layout to fit your current writing context:
-
-| View Mode | Toolbar Icon | Layout Description |
-| :--- | :---: | :--- |
-| **Split View** | `⬜⬜` | Dual-pane side-by-side editing and previewing (Default desktop view). |
-| **Editor Only** | `⬜` | Single pane showing only the editor for distraction-free writing. |
-| **Preview Only** | `◼` | Single pane showing only the compiled HTML output for reading. |
-
-*   **Mobile Layout Auto-Collapse:** On viewports below 768px wide, split mode is disabled. The application displays either the editor or the preview, toggling via the view mode icons.
-
----
-
-## Theme Configurations
-
-Switch themes using the toggle icon in the toolbar:
-*   **Light Theme:** White background matching standard GitHub styling.
-*   **Dark Theme:** Dark theme (`#0d1117`) matching GitHub Dark.
-
-Theme variables default to system preferences and are written to the document root class attribute.
-
----
-
-## Proportional Scroll Sync
-
-When working in Split View, scrolling the editor or preview will automatically update the opposite pane:
-*   **Scroll Sync Toggle:** Enable or disable synchronization via the scroll lock toggle in the toolbar.
-*   **Ratio-Based Calculations:** Computes relative scroll offsets based on total scrollable heights to keep text and headers aligned.
-*   **Feedback Mitigation:** Employs scroll event locks and frame scheduling via `requestAnimationFrame` to prevent circular updates.
-
----
-
-## Content Analytics & Metrics
-
-Toggle the **📊 Stats** view in the toolbar to display:
-*   **Word Count:** Total count of space-separated strings.
-*   **Character Count:** Total count of character bytes, excluding whitespace.
-*   **Lines:** Total line count of the document.
-*   **Estimated Reading Time:** Calculated at an average speed of 200 words per minute.
-
----
-
-## Serverless URL Hash Sharing
-
-Create serverless, database-free sharing links using the **Share** button in the toolbar:
-1.  Markdown text is compressed using `Pako.js` (zlib DEFLATE).
-2.  Data is converted to a URL-safe Base64 string (replacing `+` with `-`, `/` with `_`, and removing trailing `=` padding).
-3.  The string is appended as a URL hash fragment: `http://domain/#share=<payload>`.
-4.  Copy and share this link. Opening it decodes and decompresses the hash to load the document in the editor.
-5.  A warning is displayed if the generated URL exceeds 32,000 characters.
-
----
-
-## Keyboard Shortcuts Reference
-
-The following shortcut keys are active inside the editor:
-
-| Action | Windows / Linux | macOS |
+| Export | Behavior | Main Limitations |
 | :--- | :--- | :--- |
-| **Export raw Markdown** | `Ctrl + S` | `⌘ + S` |
-| **Copy Rich HTML** | `Ctrl + C` (with no text selected) | `⌘ + C` (with no text selected) |
-| **Toggle Scroll Sync** | `Ctrl + Shift + S` | `⌘ + Shift + S` |
-| **Open a New Tab** | `Ctrl + T` | `⌘ + T` |
-| **Close the Active Tab** | `Ctrl + W` | `⌘ + W` |
-| **Open Find & Replace** | `Ctrl + F` | `⌘ + F` |
-| **Undo Last Edit** | `Ctrl + Z` | `⌘ + Z` |
-| **Redo Last Edit** | `Ctrl + Shift + Z` / `Ctrl + Y` | `⌘ + Shift + Z` / `⌘ + Y` |
-| **Insert Code Block** | `Ctrl + Shift + C` | `⌘ + Shift + C` |
-| **Toggle Fullscreen Editor** | `F11` | `F11` |
-| **Insert 2-space Indent** | `Tab` | `Tab` |
-| **Outdent Line** | `Shift + Tab` | `Shift + Tab` |
+| Markdown | Saves the raw `.md` text. | Browser downloads or desktop native save dialog only. |
+| HTML | Saves standalone rendered HTML with styles and renderer support hooks. | External content referenced by the document may still load remotely when opened. |
+| PDF: Browser Print | Calls `window.print()` and lets the browser save/print. Recommended for most long documents. | Browser print engines vary; complex images/diagrams may differ. |
+| PDF: Legacy Raster | Uses `html2canvas` and `jsPDF` with page-break planning. | Memory-heavy for very long documents; cross-origin images need CORS. |
+| PNG | Captures the rendered document to a PNG. | Browser canvas limits apply; cross-origin images need CORS. |
+
+Raster PDF and PNG exports render Mermaid, ABC, and MathJax in an off-screen capture before saving. Export progress can be cancelled.
+
+## Share Snapshot
+
+Use Share Snapshot when you want to send a point-in-time copy.
+
+1. Choose View only or Editable.
+2. Click Share.
+3. Copy the generated link.
+
+View only opens the document in preview mode and hides editing. Editable opens the copy in split mode so the recipient can edit their own local copy. It is not real-time collaboration.
+
+Small documents are compressed into the URL hash as `#share=...`. Large documents, or documents whose encoded URL would be too long, are stored through `/api/share` and opened with `#id=...`. Stored snapshots use Cloudflare KV for 90 days and can contain up to 500,000 characters.
+
+Anyone with the link can open the snapshot. Shared snapshot tabs are temporary and are not saved into the recipient's workspace.
+
+## Live Share
+
+Use Live Share when you want a temporary real-time room.
+
+1. Click Live Share.
+2. Enter or accept a display name.
+3. Choose Can edit or View only.
+4. Start the session.
+5. Copy the invite link after the room starts.
+
+Live Share sends real-time Yjs updates through a Cloudflare Durable Object. It does not store the document in KV or a database. The invite URL contains a room id, room secret, and title, not the full document body.
+
+Participants get a temporary live tab, presence avatars, and live cursor indicators. The host can end the session for everyone. Rooms are limited to 64 WebSocket participants and 1 MB live messages.
+
+## Rendering Advanced Content
+
+Use fenced code blocks for advanced renderers:
+
+- `mermaid` for Mermaid diagrams.
+- `plantuml`, `d2`, `graphviz`/`dot`, `vega-lite`, `wavedrom`, and `markmap` for diagrams and charts.
+- `geojson` and `topojson` for maps.
+- `stl` for 3D models.
+- `abc` for sheet music and playback.
+- `math` for display math.
+
+Mermaid, Markmap, maps, STL, ABC, and MathJax use client-side libraries. PlantUML, D2, Graphviz, Vega-Lite, WaveDrom, and some diagram previews can send source to remote rendering endpoints such as PlantUML, Kroki, or mermaid.ink.
+
+## Keyboard Shortcuts
+
+| Action | Shortcut |
+| :--- | :--- |
+| Save/export Markdown | `Ctrl+S` / `Cmd+S` |
+| Copy selected text, or whole Markdown when nothing is selected | `Ctrl+C` / `Cmd+C` |
+| Toggle scroll sync in Split view | `Ctrl+Shift+S` / `Cmd+Shift+S` |
+| Find | `Ctrl+F` / `Cmd+F` |
+| Replace | `Ctrl+H` / `Cmd+H` |
+| Undo | `Ctrl+Z` / `Cmd+Z` |
+| Redo | `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` |
+| New tab | Desktop: `Ctrl+T` / `Cmd+T`; web and desktop: `Alt+Shift+T` |
+| Close tab | Desktop: `Ctrl+W` / `Cmd+W`; web and desktop: `Alt+Shift+W` |
+| Indent | `Tab` |
+| Outdent | `Shift+Tab` |
+| Close modals, panels, tab menus, and diagram modals | `Escape` |
+
+Browser shortcuts are intentionally not all intercepted on the web. For example, web tab creation/closing uses `Alt+Shift+T/W` so the app does not hijack browser tab shortcuts.


### PR DESCRIPTION
## Summary

Updates Markdown Viewer documentation and discoverability wording across the README, wiki, app metadata, desktop docs, and localized README notices.

## What changed

- Rewrote wiki pages to reflect current product behavior, limitations, privacy boundaries, storage, sharing, desktop behavior, and deployment workflows.
- Updated README feature wording and ordering, including separate Live Share and Share Snapshot entries, WaveDrom as its own feature point, and a more human Development Journey section.
- Restored all title metadata to the existing secure editor title while refining non-title descriptions around browser-based Markdown editing, `.md` opening, live preview, sync scrolling, GFM, math, diagrams, and exports.
- Removed the phrase “local-first” from documentation and metadata in favor of clearer on-device behavior wording.
- Updated the technology stack table and desktop package description to match current implementation.

## Validation

- `git diff --check`
- `node --check script.js`
- `manifest.json` and `desktop-app/package.json` JSON parse
- `index.html` JSON-LD parse
- Searched the changed docs/metadata for `local-first` / `local first`

Only normal Git CRLF warnings were reported.