### PR TITLE
feat(diagrams): group insert diagram categories

### DIFF
--- a/desktop-app/resources/index.html
+++ b/desktop-app/resources/index.html
@@ -327,7 +327,7 @@
             <button type="button" class="markdown-tool-btn" data-md-action="emoji" title="Emoji shortcode" aria-label="Emoji shortcode"><i class="bi bi-emoji-smile"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="symbols" title="Symbols &amp; HTML entities" aria-label="Symbols &amp; HTML entities"><i class="bi bi-c-circle"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="alert" title="Markdown alert" aria-label="Markdown alert"><i class="bi bi-newspaper"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="diagram" title="Insert Diagram" aria-label="Insert Diagram"><i class="bi bi-diagram-3"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="diagram" title="Insert Diagram &amp; More" aria-label="Insert Diagram &amp; More"><i class="bi bi-diagram-3"></i></button>
           </div>
           <div class="markdown-toolbar-group">
             <button type="button" class="markdown-tool-btn" data-md-action="fullscreen" title="Fullscreen" aria-label="Fullscreen"><i class="bi bi-arrows-fullscreen"></i></button>
@@ -947,7 +947,7 @@
         <div id="diagram-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diagram-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide reset-modal-box--xl diagram-modal-box">
             <div class="modal-header">
-              <p id="diagram-modal-title" class="reset-modal-message">Insert Diagram</p>
+              <p id="diagram-modal-title" class="reset-modal-message">Insert Diagram &amp; More</p>
               <button class="modal-close-btn" id="diagram-modal-close" aria-label="Close modal">&times;</button>
             </div>
             

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6786,6 +6786,18 @@ document.addEventListener("DOMContentLoaded", async function () {
         categories: ['STL (3D)']
       }
     ];
+
+    const categoryIcons = {
+      Mermaid: 'bi-water',
+      PlantUML: 'bi-braces',
+      Graphviz: 'bi-bezier2',
+      D2: 'bi-grid-3x3',
+      Markmap: 'bi-diagram-2',
+      'Vega-Lite': 'bi-bar-chart-line',
+      WaveDrom: 'bi-activity',
+      'ABC Notation': 'bi-music-note-beamed',
+      'STL (3D)': 'bi-badge-3d'
+    };
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
     const svgMermaidFlowchartLR = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="30" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Left</text><path d="M 50 60 L 110 60" stroke="#2e7d32" stroke-width="1.2" marker-end="url(#arrow-flr)"/><rect x="110" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="130" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Right</text><defs><marker id="arrow-flr" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2e7d32"/></marker></defs></svg>`;
@@ -7544,7 +7556,7 @@ document.addEventListener("DOMContentLoaded", async function () {
           btn.className = 'diagram-sidebar-btn';
           if (cat === activeCategory) btn.classList.add('is-active');
           btn.innerHTML = `
-            <span class="diagram-sidebar-item-dot" aria-hidden="true"></span>
+            <i class="bi ${categoryIcons[cat] || 'bi-circle'} diagram-sidebar-item-icon" aria-hidden="true"></i>
             <span>${cat}</span>
           `;
           btn.addEventListener('click', () => {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6955,7 +6955,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const tangentSeed = Math.abs(normal[2]) > 0.82 ? [1, 0, 0] : [0, 0, 1];
       const u = normalizeVector(crossVectors(normal, tangentSeed));
       const v = normalizeVector(crossVectors(normal, u));
-      const baseCenter = scaleVector(normal, bodyRadius);
+      const baseCenter = scaleVector(normal, bodyRadius - 1.4);
       const tip = scaleVector(normal, bodyRadius + spikeLength);
       const ring = Array.from({ length: segments }, (_, index) => {
         const angle = (Math.PI * 2 * index) / segments;
@@ -7004,7 +7004,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         [1, 1, -1], [-1, 1, -1], [1, -1, -1], [-1, -1, -1]
       ];
       spikeDirections.forEach(direction => {
-        facets.push(...createConeSpikeFacets(direction, 2.2, 10, 6, 6));
+        facets.push(...createConeSpikeFacets(direction, 2.8, 10, 6, 6));
       });
 
       return wrapStl('spiked_round_ball', facets);

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6912,6 +6912,101 @@ document.addEventListener("DOMContentLoaded", async function () {
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
     const svgStlCube = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 118,44 88,62 28,42" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><polygon points="28,42 88,62 88,100 28,80" fill="#93c5fd" stroke="#2563eb" stroke-width="1.8"/><polygon points="88,62 118,44 118,82 88,100" fill="#60a5fa" stroke="#2563eb" stroke-width="1.8"/><line x1="58" y1="24" x2="58" y2="62" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="28" y2="80" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="118" y2="82" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><text x="80" y="16" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">20 mm cube</text></svg>`;
+    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="28,72 88,92 132,66 72,46" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.8"/><polygon points="72,46 132,66 132,82 72,62" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.5"/><polygon points="48,50 76,60 76,82 48,72" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,48 118,56 118,76 94,68" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><circle cx="62" cy="68" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><circle cx="106" cy="64" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><text x="80" y="20" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">bracket</text></svg>`;
+    const svgStlGear = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,12 89,29 107,21 109,40 128,43 116,58 130,72 111,77 110,96 92,88 80,105 68,88 50,96 49,77 30,72 44,58 32,43 51,40 53,21 71,29" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><circle cx="80" cy="60" r="22" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1.8"/><circle cx="80" cy="60" r="9" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="116" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">gear mesh</text></svg>`;
+    const svgStlTwist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 94,16 112,38 78,48" fill="#dbeafe" stroke="#2563eb" stroke-width="1.7"/><polygon points="46,82 82,102 116,78 78,60" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.7"/><polygon points="58,24 78,48 78,60 46,82" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,16 112,38 116,78 82,102" fill="#93c5fd" stroke="#2563eb" stroke-width="1.5"/><polygon points="78,48 112,38 116,78 78,60" fill="#60a5fa" opacity="0.85" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="114" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">twist</text></svg>`;
+
+    function formatStlNumber(value) {
+      return Number(value.toFixed(4)).toString();
+    }
+
+    function stlFacet(normal, vertices) {
+      const vertexLines = vertices.map(vertex => `      vertex ${vertex.map(formatStlNumber).join(' ')}\n`).join('');
+      return `  facet normal ${normal.map(formatStlNumber).join(' ')}\n    outer loop\n${vertexLines}    endloop\n  endfacet\n`;
+    }
+
+    function wrapStl(name, facets) {
+      return `\`\`\`stl\nsolid ${name}\n${facets.join('')}endsolid ${name}\n\`\`\`\n`;
+    }
+
+    function createBoxFacets(x0, y0, z0, x1, y1, z1) {
+      const p = {
+        a: [x0, y0, z0], b: [x1, y0, z0], c: [x1, y1, z0], d: [x0, y1, z0],
+        e: [x0, y0, z1], f: [x1, y0, z1], g: [x1, y1, z1], h: [x0, y1, z1]
+      };
+      const face = (normal, v1, v2, v3, v4) => [
+        stlFacet(normal, [v1, v2, v3]),
+        stlFacet(normal, [v1, v3, v4])
+      ];
+      return [
+        ...face([0, 0, -1], p.a, p.b, p.c, p.d),
+        ...face([0, 0, 1], p.e, p.h, p.g, p.f),
+        ...face([0, -1, 0], p.a, p.e, p.f, p.b),
+        ...face([1, 0, 0], p.b, p.f, p.g, p.c),
+        ...face([0, 1, 0], p.c, p.g, p.h, p.d),
+        ...face([-1, 0, 0], p.d, p.h, p.e, p.a)
+      ];
+    }
+
+    function createSteppedBracketStl() {
+      return wrapStl('stepped_bracket_with_raised_bosses', [
+        ...createBoxFacets(-24, -12, 0, 24, 12, 4),
+        ...createBoxFacets(-18, -6, 4, 18, 6, 9),
+        ...createBoxFacets(-20, -10, 9, -8, 10, 18),
+        ...createBoxFacets(8, -10, 9, 20, 10, 18),
+        ...createBoxFacets(-5, -4, 9, 5, 4, 15)
+      ]);
+    }
+
+    function createRadialPrismStl(name, points, z0, z1) {
+      const facets = [];
+      const centerBottom = [0, 0, z0];
+      const centerTop = [0, 0, z1];
+      points.forEach((point, index) => {
+        const next = points[(index + 1) % points.length];
+        const bottomA = [point[0], point[1], z0];
+        const bottomB = [next[0], next[1], z0];
+        const topA = [point[0], point[1], z1];
+        const topB = [next[0], next[1], z1];
+        facets.push(stlFacet([0, 0, -1], [centerBottom, bottomB, bottomA]));
+        facets.push(stlFacet([0, 0, 1], [centerTop, topA, topB]));
+        facets.push(stlFacet([0, 0, 0], [bottomA, bottomB, topB]));
+        facets.push(stlFacet([0, 0, 0], [bottomA, topB, topA]));
+      });
+      return wrapStl(name, facets);
+    }
+
+    function createGearStl() {
+      const points = Array.from({ length: 24 }, (_, index) => {
+        const radius = index % 2 === 0 ? 16 : 12;
+        const angle = (Math.PI * 2 * index) / 24;
+        return [Math.cos(angle) * radius, Math.sin(angle) * radius];
+      });
+      return createRadialPrismStl('faceted_gear_wheel_24_tooth', points, 0, 5);
+    }
+
+    function createTwistedColumnStl() {
+      const sides = 8;
+      const bottom = Array.from({ length: sides }, (_, index) => {
+        const angle = (Math.PI * 2 * index) / sides;
+        return [Math.cos(angle) * 9, Math.sin(angle) * 9, 0];
+      });
+      const top = Array.from({ length: sides }, (_, index) => {
+        const angle = (Math.PI * 2 * index) / sides + Math.PI / 5;
+        return [Math.cos(angle) * 7, Math.sin(angle) * 7, 28];
+      });
+      const facets = [];
+      const bottomCenter = [0, 0, 0];
+      const topCenter = [0, 0, 28];
+      bottom.forEach((point, index) => {
+        const next = (index + 1) % sides;
+        facets.push(stlFacet([0, 0, -1], [bottomCenter, bottom[next], point]));
+        facets.push(stlFacet([0, 0, 1], [topCenter, top[index], top[next]]));
+        facets.push(stlFacet([0, 0, 0], [bottom[index], bottom[next], top[next]]));
+        facets.push(stlFacet([0, 0, 0], [bottom[index], top[next], top[index]]));
+      });
+      return wrapStl('twisted_octagonal_column', facets);
+    }
 
     const templates = [
       // Mermaid
@@ -7514,6 +7609,30 @@ document.addEventListener("DOMContentLoaded", async function () {
         label: 'Calibration Cube',
         svg: svgStlCube,
         code: '```stl\nsolid calibration_cube_20mm\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 0\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 20 0\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 20 20 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 0 20 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 20\n      vertex 20 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 0 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 20 20\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 20 20 20\n      vertex 0 20 20\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 0 20 20\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 20 20\n      vertex 0 0 20\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 0 20\n      vertex 0 0 0\n    endloop\n  endfacet\nendsolid calibration_cube_20mm\n```\n'
+      },
+      {
+        id: 'stl-stepped-bracket',
+        category: 'STL (3D)',
+        title: 'Stepped Bracket',
+        label: 'Stepped Bracket',
+        svg: svgStlBracket,
+        code: createSteppedBracketStl()
+      },
+      {
+        id: 'stl-faceted-gear',
+        category: 'STL (3D)',
+        title: 'Faceted Gear Wheel',
+        label: 'Faceted Gear Wheel',
+        svg: svgStlGear,
+        code: createGearStl()
+      },
+      {
+        id: 'stl-twisted-column',
+        category: 'STL (3D)',
+        title: 'Twisted Column',
+        label: 'Twisted Column',
+        svg: svgStlTwist,
+        code: createTwistedColumnStl()
       }
     ];
     

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6596,7 +6596,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       WaveDrom: 'wavedrom',
       Markmap: 'markmap',
       Mermaid: 'mermaid',
-      'ABC Notation': 'abc'
+      'ABC Notation': 'abc',
+      'STL (3D)': 'stl'
     };
     return engines[category] || null;
   }
@@ -6698,7 +6699,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const cleanCode = getCleanCode(template.code);
     const engine = getDiagramEngineForCategory(template.category);
     try {
-      if (template.category === 'ABC Notation') {
+      if (template.category === 'ABC Notation' || template.category === 'STL (3D)') {
         callback(null);
         return;
       }
@@ -6758,15 +6759,27 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (previewCode) previewCode.value = '';
     confirmBtn.disabled = true;
     
-    const categories = [
-      'Mermaid',
-      'PlantUML',
-      'Graphviz',
-      'D2',
-      'Vega-Lite',
-      'ABC Notation',
-      'WaveDrom',
-      'Markmap'
+    const categoryGroups = [
+      {
+        label: 'Diagrams',
+        categories: ['Mermaid', 'PlantUML', 'Graphviz', 'D2']
+      },
+      {
+        label: 'Mind Maps',
+        categories: ['Markmap']
+      },
+      {
+        label: 'Data Visualization',
+        categories: ['Vega-Lite']
+      },
+      {
+        label: 'Technical Notation',
+        categories: ['WaveDrom', 'ABC Notation']
+      },
+      {
+        label: '3D Models',
+        categories: ['STL (3D)']
+      }
     ];
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
@@ -6878,6 +6891,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     // Markmap additional (Aesthetic: colorful mindmaps, checklist notation)
     const svgMarkmapChecklist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#ede7f6" stroke="#5e35b1" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#5e35b1" font-weight="bold">Tasks</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#5e35b1" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#5e35b1" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#5e35b1"/><circle cx="90" cy="90" r="3" fill="#5e35b1"/><text x="96" y="33" font-size="7" font-family="sans-serif">☒ Todo A</text><text x="96" y="93" font-size="7" font-family="sans-serif">☑ Todo B</text></svg>`;
     const svgMarkmapCode = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#eceff1" stroke="#455a64" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#455a64" font-weight="bold">Project</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#455a64" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#455a64" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#455a64"/><circle cx="90" cy="90" r="3" fill="#455a64"/><text x="96" y="33" font-size="7" font-family="monospace">code()</text><text x="96" y="93" font-size="7" font-family="monospace">test()</text></svg>`;
+
+    // STL (3D) local previews
+    const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
+    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><path d="M38 78 L82 32 L126 54 L82 100 Z" fill="#e0f2fe" stroke="#075985" stroke-width="2"/><path d="M82 32 L126 54 L126 76 L82 100 Z" fill="#7dd3fc" opacity="0.85" stroke="#075985" stroke-width="1.4"/><path d="M38 78 L82 100 L82 78 L58 66 Z" fill="#38bdf8" opacity="0.85" stroke="#075985" stroke-width="1.4"/><circle cx="82" cy="66" r="9" fill="#ffffff" stroke="#075985" stroke-width="2"/><text x="80" y="18" text-anchor="middle" font-size="8" font-family="monospace" fill="#075985" font-weight="bold">3D Mesh</text></svg>`;
 
     const templates = [
       // Mermaid
@@ -7462,6 +7479,24 @@ document.addEventListener("DOMContentLoaded", async function () {
         label: 'Inline Code Blocks',
         svg: svgMarkmapCode,
         code: '```markmap\n# Development\n## Languages\n- `JavaScript`\n- `Python`\n## Functions\n- `main()`\n- `helper_func()`\n```\n'
+      },
+
+      // STL (3D)
+      {
+        id: 'stl-tetrahedron',
+        category: 'STL (3D)',
+        title: 'Tetrahedron Mesh',
+        label: 'Tetrahedron Mesh',
+        svg: svgStlTetrahedron,
+        code: '```stl\nsolid tetrahedron\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 1 0 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 1\n      vertex 1 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 1 0\n      vertex 0 0 1\n    endloop\n  endfacet\n  facet normal 1 1 1\n    outer loop\n      vertex 1 0 0\n      vertex 0 0 1\n      vertex 0 1 0\n    endloop\n  endfacet\nendsolid tetrahedron\n```\n'
+      },
+      {
+        id: 'stl-triangle-panel',
+        category: 'STL (3D)',
+        title: 'Triangle Panel',
+        label: 'Triangle Panel',
+        svg: svgStlBracket,
+        code: '```stl\nsolid triangle_panel\n  facet normal 0 0 1\n    outer loop\n      vertex -1 -1 0\n      vertex 1 -1 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex -1 -1 -0.15\n      vertex 0 1 -0.15\n      vertex 1 -1 -0.15\n    endloop\n  endfacet\nendsolid triangle_panel\n```\n'
       }
     ];
     
@@ -7470,18 +7505,26 @@ document.addEventListener("DOMContentLoaded", async function () {
     
     function renderSidebar() {
       sidebar.textContent = '';
-      categories.forEach(cat => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'diagram-sidebar-btn';
-        if (cat === activeCategory) btn.classList.add('is-active');
-        btn.textContent = cat;
-        btn.addEventListener('click', () => {
-          activeCategory = cat;
-          renderSidebar();
-          renderGrid();
+      categoryGroups.forEach(group => {
+        const heading = document.createElement('div');
+        heading.className = 'diagram-sidebar-group-title';
+        heading.setAttribute('role', 'presentation');
+        heading.textContent = group.label;
+        sidebar.appendChild(heading);
+
+        group.categories.forEach(cat => {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'diagram-sidebar-btn';
+          if (cat === activeCategory) btn.classList.add('is-active');
+          btn.textContent = cat;
+          btn.addEventListener('click', () => {
+            activeCategory = cat;
+            renderSidebar();
+            renderGrid();
+          });
+          sidebar.appendChild(btn);
         });
-        sidebar.appendChild(btn);
       });
     }
     
@@ -7514,7 +7557,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const previewDiv = document.createElement('div');
         previewDiv.className = 'diagram-card-preview';
         
-        const catClass = t.category.toLowerCase().replace(/\s+/g, '');
+        const catClass = t.category.toLowerCase().replace(/[^a-z0-9]+/g, '');
 
         previewDiv.innerHTML = `
           <div style="display:flex; align-items:center; justify-content:center; width:100%; height:100%;">
@@ -7552,7 +7595,7 @@ document.addEventListener("DOMContentLoaded", async function () {
           if (previewCode) previewCode.value = t.code.trim();
           confirmBtn.disabled = false;
 
-          const catClass = t.category.toLowerCase().replace(/\s+/g, '');
+          const catClass = t.category.toLowerCase().replace(/[^a-z0-9]+/g, '');
           // Render bottom preview container with API image & fallback
           previewContainer.innerHTML = `
             <div class="diagram-svg-container diagram-svg-${catClass}" style="width:100%; height:100%; display:flex; align-items:center; justify-content:center; overflow:hidden;">

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -7670,20 +7670,20 @@ document.addEventListener("DOMContentLoaded", async function () {
         code: geoJsonPointCode
       },
       {
-        id: 'geojson-feature-collection',
-        category: 'GeoJSON',
-        title: 'Feature Collection Map',
-        label: 'Feature Collection Map',
-        svg: svgGeoJsonMap,
-        code: geoJsonMapCode
-      },
-      {
         id: 'topojson-landmark-point',
         category: 'TopoJSON',
         title: 'Landmark Point',
         label: 'Landmark Point',
         svg: svgTopoJsonMap,
         code: topoJsonPointCode
+      },
+      {
+        id: 'geojson-feature-collection',
+        category: 'GeoJSON',
+        title: 'Feature Collection Map',
+        label: 'Feature Collection Map',
+        svg: svgGeoJsonMap,
+        code: geoJsonMapCode
       },
       {
         id: 'topojson-topology',

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6776,11 +6776,6 @@ document.addEventListener("DOMContentLoaded", async function () {
         categories: ['Vega-Lite']
       },
       {
-        label: 'Maps',
-        icon: 'bi-map',
-        categories: ['GeoJSON', 'TopoJSON']
-      },
-      {
         label: 'Technical Notation',
         icon: 'bi-code-slash',
         categories: ['WaveDrom', 'ABC Notation']
@@ -6789,6 +6784,11 @@ document.addEventListener("DOMContentLoaded", async function () {
         label: '3D Models',
         icon: 'bi-box',
         categories: ['STL (3D)']
+      },
+      {
+        label: 'Maps',
+        icon: 'bi-map',
+        categories: ['GeoJSON', 'TopoJSON']
       }
     ];
 
@@ -6919,6 +6919,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     // Map local previews
     const svgGeoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#eef6ff" stroke="#94a3b8" stroke-width="1.4"/><path d="M22 84 C40 70, 52 76, 68 58 C86 38, 104 52, 124 30" fill="none" stroke="#60a5fa" stroke-width="4" stroke-linecap="round" opacity="0.85"/><path d="M28 32 L65 24 L82 48 L60 76 L30 68 Z" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.6"/><path d="M86 66 L126 56 L138 86 L102 96 Z" fill="#bbf7d0" stroke="#16a34a" stroke-width="1.6"/><circle cx="112" cy="46" r="6" fill="#ef4444" stroke="#fff" stroke-width="2"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">GeoJSON</text></svg>`;
     const svgTopoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1.4"/><path d="M30 30 L68 24 L86 52 L58 84 L26 70 Z" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.6"/><path d="M86 30 L126 38 L134 78 L104 94 L82 66 Z" fill="#dcfce7" stroke="#15803d" stroke-width="1.6"/><path d="M68 24 L86 52 L82 66" fill="none" stroke="#f59e0b" stroke-width="2.6" stroke-dasharray="4 3"/><circle cx="68" cy="24" r="3" fill="#f59e0b"/><circle cx="86" cy="52" r="3" fill="#f59e0b"/><circle cx="82" cy="66" r="3" fill="#f59e0b"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">TopoJSON</text></svg>`;
+    const geoJsonPointCode = '```geojson\n{\n  "type": "FeatureCollection",\n  "features": [\n    {\n      "type": "Feature",\n      "properties": { "name": "Taj Mahal" },\n      "geometry": {\n        "type": "Point",\n        "coordinates": [78.0421, 27.1751]\n      }\n    }\n  ]\n}\n```\n';
+    const topoJsonPointCode = '```topojson\n{\n  "type": "Topology",\n  "objects": {\n    "example": {\n      "type": "GeometryCollection",\n      "geometries": [\n        {\n          "type": "Point",\n          "coordinates": [2.2945, 48.8584],\n          "properties": { "name": "Eiffel Tower" }\n        }\n      ]\n    }\n  },\n  "arcs": [],\n  "transform": {\n    "scale": [1, 1],\n    "translate": [0, 0]\n  }\n}\n```\n';
     const geoJsonMapCode = '```geojson\n{\n  "type": "FeatureCollection",\n  "features": [\n    {\n      "type": "Feature",\n      "properties": { "name": "Demo district" },\n      "geometry": {\n        "type": "Polygon",\n        "coordinates": [[\n          [-122.45, 37.76],\n          [-122.41, 37.76],\n          [-122.40, 37.79],\n          [-122.44, 37.80],\n          [-122.45, 37.76]\n        ]]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Walking route" },\n      "geometry": {\n        "type": "LineString",\n        "coordinates": [\n          [-122.45, 37.77],\n          [-122.43, 37.78],\n          [-122.41, 37.79]\n        ]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Meeting point" },\n      "geometry": {\n        "type": "Point",\n        "coordinates": [-122.42, 37.785]\n      }\n    }\n  ]\n}\n```\n';
     const topoJsonMapCode = '```topojson\n{\n  "type": "Topology",\n  "transform": {\n    "scale": [0.01, 0.01],\n    "translate": [-122.45, 37.76]\n  },\n  "objects": {\n    "districts": {\n      "type": "GeometryCollection",\n      "geometries": [\n        {\n          "type": "Polygon",\n          "properties": { "name": "North zone" },\n          "arcs": [[0]]\n        },\n        {\n          "type": "Polygon",\n          "properties": { "name": "South zone" },\n          "arcs": [[1]]\n        }\n      ]\n    }\n  },\n  "arcs": [\n    [[0, 0], [4, 0], [0, 3], [-4, 0], [0, -3]],\n    [[4, 0], [4, 0], [0, 3], [-4, 0], [0, -3]]\n  ]\n}\n```\n';
 
@@ -7660,12 +7662,28 @@ document.addEventListener("DOMContentLoaded", async function () {
 
       // Maps
       {
+        id: 'geojson-landmark-point',
+        category: 'GeoJSON',
+        title: 'Landmark Point',
+        label: 'Landmark Point',
+        svg: svgGeoJsonMap,
+        code: geoJsonPointCode
+      },
+      {
         id: 'geojson-feature-collection',
         category: 'GeoJSON',
         title: 'Feature Collection Map',
         label: 'Feature Collection Map',
         svg: svgGeoJsonMap,
         code: geoJsonMapCode
+      },
+      {
+        id: 'topojson-landmark-point',
+        category: 'TopoJSON',
+        title: 'Landmark Point',
+        label: 'Landmark Point',
+        svg: svgTopoJsonMap,
+        code: topoJsonPointCode
       },
       {
         id: 'topojson-topology',

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6762,25 +6762,42 @@ document.addEventListener("DOMContentLoaded", async function () {
     const categoryGroups = [
       {
         label: 'Diagrams',
+        icon: 'bi-diagram-3',
         categories: ['Mermaid', 'PlantUML', 'Graphviz', 'D2']
       },
       {
         label: 'Mind Maps',
+        icon: 'bi-diagram-2',
         categories: ['Markmap']
       },
       {
         label: 'Data Visualization',
+        icon: 'bi-bar-chart-line',
         categories: ['Vega-Lite']
       },
       {
         label: 'Technical Notation',
+        icon: 'bi-code-slash',
         categories: ['WaveDrom', 'ABC Notation']
       },
       {
         label: '3D Models',
+        icon: 'bi-box',
         categories: ['STL (3D)']
       }
     ];
+
+    const categoryIcons = {
+      Mermaid: 'bi-water',
+      PlantUML: 'bi-leaf',
+      Graphviz: 'bi-bezier2',
+      D2: 'bi-badge-2d',
+      Markmap: 'bi-diagram-2',
+      'Vega-Lite': 'bi-bar-chart-line',
+      WaveDrom: 'bi-activity',
+      'ABC Notation': 'bi-music-note-beamed',
+      'STL (3D)': 'bi-box'
+    };
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
     const svgMermaidFlowchartLR = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="30" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Left</text><path d="M 50 60 L 110 60" stroke="#2e7d32" stroke-width="1.2" marker-end="url(#arrow-flr)"/><rect x="110" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="130" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Right</text><defs><marker id="arrow-flr" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2e7d32"/></marker></defs></svg>`;
@@ -7506,28 +7523,51 @@ document.addEventListener("DOMContentLoaded", async function () {
     function renderSidebar() {
       sidebar.textContent = '';
       categoryGroups.forEach(group => {
+        const isExpanded = group.categories.includes(activeCategory);
         const groupEl = document.createElement('div');
         groupEl.className = 'diagram-sidebar-group';
+        if (isExpanded) groupEl.classList.add('is-expanded');
 
-        const heading = document.createElement('div');
-        heading.className = 'diagram-sidebar-group-title';
-        heading.setAttribute('role', 'presentation');
-        heading.textContent = group.label;
+        const heading = document.createElement('button');
+        heading.type = 'button';
+        heading.className = 'diagram-sidebar-group-header';
+        heading.setAttribute('aria-expanded', String(isExpanded));
+        heading.innerHTML = `
+          <i class="bi ${group.icon} diagram-sidebar-group-icon" aria-hidden="true"></i>
+          <span>${group.label}</span>
+          <i class="bi ${isExpanded ? 'bi-chevron-up' : 'bi-chevron-right'} diagram-sidebar-chevron" aria-hidden="true"></i>
+        `;
+        heading.addEventListener('click', () => {
+          if (!isExpanded) {
+            activeCategory = group.categories[0];
+            selectedTemplate = null;
+            renderSidebar();
+            renderGrid();
+          }
+        });
         groupEl.appendChild(heading);
+
+        const itemsEl = document.createElement('div');
+        itemsEl.className = 'diagram-sidebar-items';
 
         group.categories.forEach(cat => {
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'diagram-sidebar-btn';
           if (cat === activeCategory) btn.classList.add('is-active');
-          btn.textContent = cat;
+          btn.innerHTML = `
+            <i class="bi ${categoryIcons[cat] || 'bi-circle'} diagram-sidebar-item-icon" aria-hidden="true"></i>
+            <span>${cat}</span>
+          `;
           btn.addEventListener('click', () => {
             activeCategory = cat;
             renderSidebar();
             renderGrid();
           });
-          groupEl.appendChild(btn);
+          itemsEl.appendChild(btn);
         });
+
+        groupEl.appendChild(itemsEl);
 
         sidebar.appendChild(groupEl);
       });

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6767,7 +6767,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       },
       {
         label: 'Mind Maps',
-        icon: 'bi-diagram-2',
+        icon: 'bi-list-ul',
         categories: ['Markmap']
       },
       {
@@ -6786,18 +6786,6 @@ document.addEventListener("DOMContentLoaded", async function () {
         categories: ['STL (3D)']
       }
     ];
-
-    const categoryIcons = {
-      Mermaid: 'bi-water',
-      PlantUML: 'bi-leaf',
-      Graphviz: 'bi-bezier2',
-      D2: 'bi-badge-2d',
-      Markmap: 'bi-diagram-2',
-      'Vega-Lite': 'bi-bar-chart-line',
-      WaveDrom: 'bi-activity',
-      'ABC Notation': 'bi-music-note-beamed',
-      'STL (3D)': 'bi-box'
-    };
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
     const svgMermaidFlowchartLR = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="30" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Left</text><path d="M 50 60 L 110 60" stroke="#2e7d32" stroke-width="1.2" marker-end="url(#arrow-flr)"/><rect x="110" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="130" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Right</text><defs><marker id="arrow-flr" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2e7d32"/></marker></defs></svg>`;
@@ -7556,7 +7544,7 @@ document.addEventListener("DOMContentLoaded", async function () {
           btn.className = 'diagram-sidebar-btn';
           if (cat === activeCategory) btn.classList.add('is-active');
           btn.innerHTML = `
-            <i class="bi ${categoryIcons[cat] || 'bi-circle'} diagram-sidebar-item-icon" aria-hidden="true"></i>
+            <span class="diagram-sidebar-item-dot" aria-hidden="true"></span>
             <span>${cat}</span>
           `;
           btn.addEventListener('click', () => {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -1990,6 +1990,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   function normalizeDiagramSvg(node, engine, source) {
     const svg = node ? node.querySelector('svg') : null;
     if (!svg) return null;
+    if (engine === 'wavedrom') isolateWaveDromSvgStyles(svg);
 
     let intrinsicWidth = 0;
     let intrinsicHeight = 0;
@@ -2031,6 +2032,43 @@ document.addEventListener("DOMContentLoaded", async function () {
     svg.style.maxWidth = '100%';
     svg.style.maxHeight = 'min(70vh, 720px)';
     return svg;
+  }
+
+  function isolateWaveDromSvgStyles(svg) {
+    if (svg.getAttribute('data-wavedrom-style-scoped') === 'true') return;
+    let scopeId = svg.getAttribute('data-wavedrom-style-scope');
+    if (!scopeId) {
+      scopeId = `wavedrom-${Math.random().toString(36).slice(2, 10)}`;
+      svg.setAttribute('data-wavedrom-style-scope', scopeId);
+    }
+
+    const classMap = new Map();
+    const getScopedClass = className => {
+      if (!classMap.has(className)) {
+        classMap.set(className, `wd-${scopeId}-${className}`);
+      }
+      return classMap.get(className);
+    };
+
+    svg.querySelectorAll('[class]').forEach(element => {
+      const classes = (element.getAttribute('class') || '').trim().split(/\s+/).filter(Boolean);
+      if (classes.length) {
+        element.setAttribute('class', classes.map(getScopedClass).join(' '));
+      }
+    });
+
+    svg.querySelectorAll('style').forEach(style => {
+      const css = style.textContent || '';
+      style.textContent = scopeWaveDromStyleClasses(css, getScopedClass);
+      style.setAttribute('data-wavedrom-style-scoped', 'true');
+    });
+    svg.setAttribute('data-wavedrom-style-scoped', 'true');
+  }
+
+  function scopeWaveDromStyleClasses(css, getScopedClass) {
+    return css.replace(/\.([A-Za-z_-][A-Za-z0-9_-]*)/g, (match, className) => {
+      return `.${getScopedClass(className)}`;
+    });
   }
 
   function getDiagramFailureMessage(engine, error) {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6894,7 +6894,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
-    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><path d="M38 78 L82 32 L126 54 L82 100 Z" fill="#e0f2fe" stroke="#075985" stroke-width="2"/><path d="M82 32 L126 54 L126 76 L82 100 Z" fill="#7dd3fc" opacity="0.85" stroke="#075985" stroke-width="1.4"/><path d="M38 78 L82 100 L82 78 L58 66 Z" fill="#38bdf8" opacity="0.85" stroke="#075985" stroke-width="1.4"/><circle cx="82" cy="66" r="9" fill="#ffffff" stroke="#075985" stroke-width="2"/><text x="80" y="18" text-anchor="middle" font-size="8" font-family="monospace" fill="#075985" font-weight="bold">3D Mesh</text></svg>`;
+    const svgStlCube = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 118,44 88,62 28,42" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><polygon points="28,42 88,62 88,100 28,80" fill="#93c5fd" stroke="#2563eb" stroke-width="1.8"/><polygon points="88,62 118,44 118,82 88,100" fill="#60a5fa" stroke="#2563eb" stroke-width="1.8"/><line x1="58" y1="24" x2="58" y2="62" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="28" y2="80" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="118" y2="82" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><text x="80" y="16" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">20 mm cube</text></svg>`;
 
     const templates = [
       // Mermaid
@@ -7491,12 +7491,12 @@ document.addEventListener("DOMContentLoaded", async function () {
         code: '```stl\nsolid tetrahedron\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 1 0 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 1\n      vertex 1 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 1 0\n      vertex 0 0 1\n    endloop\n  endfacet\n  facet normal 1 1 1\n    outer loop\n      vertex 1 0 0\n      vertex 0 0 1\n      vertex 0 1 0\n    endloop\n  endfacet\nendsolid tetrahedron\n```\n'
       },
       {
-        id: 'stl-triangle-panel',
+        id: 'stl-calibration-cube',
         category: 'STL (3D)',
-        title: 'Triangle Panel',
-        label: 'Triangle Panel',
-        svg: svgStlBracket,
-        code: '```stl\nsolid triangle_panel\n  facet normal 0 0 1\n    outer loop\n      vertex -1 -1 0\n      vertex 1 -1 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex -1 -1 -0.15\n      vertex 0 1 -0.15\n      vertex 1 -1 -0.15\n    endloop\n  endfacet\nendsolid triangle_panel\n```\n'
+        title: 'Calibration Cube',
+        label: 'Calibration Cube',
+        svg: svgStlCube,
+        code: '```stl\nsolid calibration_cube_20mm\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 0\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 20 0\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 20 20 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 0 20 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 20\n      vertex 20 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 0 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 20 20\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 20 20 20\n      vertex 0 20 20\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 0 20 20\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 20 20\n      vertex 0 0 20\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 0 20\n      vertex 0 0 0\n    endloop\n  endfacet\nendsolid calibration_cube_20mm\n```\n'
       }
     ];
     
@@ -7506,11 +7506,14 @@ document.addEventListener("DOMContentLoaded", async function () {
     function renderSidebar() {
       sidebar.textContent = '';
       categoryGroups.forEach(group => {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'diagram-sidebar-group';
+
         const heading = document.createElement('div');
         heading.className = 'diagram-sidebar-group-title';
         heading.setAttribute('role', 'presentation');
         heading.textContent = group.label;
-        sidebar.appendChild(heading);
+        groupEl.appendChild(heading);
 
         group.categories.forEach(cat => {
           const btn = document.createElement('button');
@@ -7523,8 +7526,10 @@ document.addEventListener("DOMContentLoaded", async function () {
             renderSidebar();
             renderGrid();
           });
-          sidebar.appendChild(btn);
+          groupEl.appendChild(btn);
         });
+
+        sidebar.appendChild(groupEl);
       });
     }
     

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6912,7 +6912,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
     const svgStlCube = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 118,44 88,62 28,42" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><polygon points="28,42 88,62 88,100 28,80" fill="#93c5fd" stroke="#2563eb" stroke-width="1.8"/><polygon points="88,62 118,44 118,82 88,100" fill="#60a5fa" stroke="#2563eb" stroke-width="1.8"/><line x1="58" y1="24" x2="58" y2="62" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="28" y2="80" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="118" y2="82" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><text x="80" y="16" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">20 mm cube</text></svg>`;
-    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="28,72 88,92 132,66 72,46" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.8"/><polygon points="72,46 132,66 132,82 72,62" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.5"/><polygon points="48,50 76,60 76,82 48,72" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,48 118,56 118,76 94,68" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><circle cx="62" cy="68" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><circle cx="106" cy="64" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><text x="80" y="20" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">bracket</text></svg>`;
+    const svgStlSpikedBall = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,8 88,32 112,22 104,48 130,56 104,68 118,92 90,84 80,108 70,84 42,92 56,68 30,56 56,48 48,22 72,32" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.7" stroke-linejoin="round"/><circle cx="80" cy="60" r="34" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1.8"/><path d="M58 42 C70 28, 96 30, 106 46 C92 40, 72 39, 58 42 Z" fill="#dbeafe" opacity="0.85"/><circle cx="68" cy="53" r="4" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.1"/><circle cx="92" cy="67" r="5" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.1"/><text x="80" y="116" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">spiked ball</text></svg>`;
     const svgStlGear = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,12 89,29 107,21 109,40 128,43 116,58 130,72 111,77 110,96 92,88 80,105 68,88 50,96 49,77 30,72 44,58 32,43 51,40 53,21 71,29" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><circle cx="80" cy="60" r="22" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1.8"/><circle cx="80" cy="60" r="9" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="116" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">gear mesh</text></svg>`;
     const svgStlTwist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 94,16 112,38 78,48" fill="#dbeafe" stroke="#2563eb" stroke-width="1.7"/><polygon points="46,82 82,102 116,78 78,60" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.7"/><polygon points="58,24 78,48 78,60 46,82" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,16 112,38 116,78 82,102" fill="#93c5fd" stroke="#2563eb" stroke-width="1.5"/><polygon points="78,48 112,38 116,78 78,60" fill="#60a5fa" opacity="0.85" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="114" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">twist</text></svg>`;
 
@@ -6929,33 +6929,84 @@ document.addEventListener("DOMContentLoaded", async function () {
       return `\`\`\`stl\nsolid ${name}\n${facets.join('')}endsolid ${name}\n\`\`\`\n`;
     }
 
-    function createBoxFacets(x0, y0, z0, x1, y1, z1) {
-      const p = {
-        a: [x0, y0, z0], b: [x1, y0, z0], c: [x1, y1, z0], d: [x0, y1, z0],
-        e: [x0, y0, z1], f: [x1, y0, z1], g: [x1, y1, z1], h: [x0, y1, z1]
-      };
-      const face = (normal, v1, v2, v3, v4) => [
-        stlFacet(normal, [v1, v2, v3]),
-        stlFacet(normal, [v1, v3, v4])
-      ];
+    function normalizeVector(vector) {
+      const length = Math.hypot(vector[0], vector[1], vector[2]) || 1;
+      return vector.map(value => value / length);
+    }
+
+    function scaleVector(vector, scale) {
+      return vector.map(value => value * scale);
+    }
+
+    function addVectors(a, b) {
+      return a.map((value, index) => value + b[index]);
+    }
+
+    function crossVectors(a, b) {
       return [
-        ...face([0, 0, -1], p.a, p.b, p.c, p.d),
-        ...face([0, 0, 1], p.e, p.h, p.g, p.f),
-        ...face([0, -1, 0], p.a, p.e, p.f, p.b),
-        ...face([1, 0, 0], p.b, p.f, p.g, p.c),
-        ...face([0, 1, 0], p.c, p.g, p.h, p.d),
-        ...face([-1, 0, 0], p.d, p.h, p.e, p.a)
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
       ];
     }
 
-    function createSteppedBracketStl() {
-      return wrapStl('stepped_bracket_with_raised_bosses', [
-        ...createBoxFacets(-24, -12, 0, 24, 12, 4),
-        ...createBoxFacets(-18, -6, 4, 18, 6, 9),
-        ...createBoxFacets(-20, -10, 9, -8, 10, 18),
-        ...createBoxFacets(8, -10, 9, 20, 10, 18),
-        ...createBoxFacets(-5, -4, 9, 5, 4, 15)
-      ]);
+    function createConeSpikeFacets(direction, baseRadius, bodyRadius, spikeLength, segments) {
+      const normal = normalizeVector(direction);
+      const tangentSeed = Math.abs(normal[2]) > 0.82 ? [1, 0, 0] : [0, 0, 1];
+      const u = normalizeVector(crossVectors(normal, tangentSeed));
+      const v = normalizeVector(crossVectors(normal, u));
+      const baseCenter = scaleVector(normal, bodyRadius);
+      const tip = scaleVector(normal, bodyRadius + spikeLength);
+      const ring = Array.from({ length: segments }, (_, index) => {
+        const angle = (Math.PI * 2 * index) / segments;
+        return addVectors(baseCenter, addVectors(scaleVector(u, Math.cos(angle) * baseRadius), scaleVector(v, Math.sin(angle) * baseRadius)));
+      });
+      const facets = [];
+      ring.forEach((point, index) => {
+        const next = ring[(index + 1) % ring.length];
+        facets.push(stlFacet([0, 0, 0], [point, next, tip]));
+      });
+      return facets;
+    }
+
+    function createSpikedBallStl() {
+      const facets = [];
+      const segments = 12;
+      const rings = [-60, -30, 0, 30, 60].map(degrees => {
+        const phi = (degrees * Math.PI) / 180;
+        const radius = Math.cos(phi) * 10;
+        const z = Math.sin(phi) * 10;
+        return Array.from({ length: segments }, (_, index) => {
+          const theta = (Math.PI * 2 * index) / segments;
+          return [Math.cos(theta) * radius, Math.sin(theta) * radius, z];
+        });
+      });
+      const south = [0, 0, -10];
+      const north = [0, 0, 10];
+
+      for (let index = 0; index < segments; index += 1) {
+        const next = (index + 1) % segments;
+        facets.push(stlFacet([0, 0, 0], [south, rings[0][next], rings[0][index]]));
+        facets.push(stlFacet([0, 0, 0], [rings[rings.length - 1][index], rings[rings.length - 1][next], north]));
+      }
+
+      for (let ringIndex = 0; ringIndex < rings.length - 1; ringIndex += 1) {
+        for (let index = 0; index < segments; index += 1) {
+          const next = (index + 1) % segments;
+          facets.push(stlFacet([0, 0, 0], [rings[ringIndex][index], rings[ringIndex][next], rings[ringIndex + 1][next]]));
+          facets.push(stlFacet([0, 0, 0], [rings[ringIndex][index], rings[ringIndex + 1][next], rings[ringIndex + 1][index]]));
+        }
+      }
+
+      const spikeDirections = [
+        [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1],
+        [1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1], [-1, -1, 1], [-1, 1, -1]
+      ];
+      spikeDirections.forEach(direction => {
+        facets.push(...createConeSpikeFacets(direction, 2.2, 10, 6, 6));
+      });
+
+      return wrapStl('spiked_round_ball', facets);
     }
 
     function createRadialPrismStl(name, points, z0, z1) {
@@ -7611,12 +7662,12 @@ document.addEventListener("DOMContentLoaded", async function () {
         code: '```stl\nsolid calibration_cube_20mm\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 0\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 20 0\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 20 20 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 0 20 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 20\n      vertex 20 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 0 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 20 20\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 20 20 20\n      vertex 0 20 20\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 0 20 20\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 20 20\n      vertex 0 0 20\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 0 20\n      vertex 0 0 0\n    endloop\n  endfacet\nendsolid calibration_cube_20mm\n```\n'
       },
       {
-        id: 'stl-stepped-bracket',
+        id: 'stl-spiked-round-ball',
         category: 'STL (3D)',
-        title: 'Stepped Bracket',
-        label: 'Stepped Bracket',
-        svg: svgStlBracket,
-        code: createSteppedBracketStl()
+        title: 'Spiked Round Ball',
+        label: 'Spiked Round Ball',
+        svg: svgStlSpikedBall,
+        code: createSpikedBallStl()
       },
       {
         id: 'stl-faceted-gear',

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -6699,7 +6699,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const cleanCode = getCleanCode(template.code);
     const engine = getDiagramEngineForCategory(template.category);
     try {
-      if (template.category === 'ABC Notation' || template.category === 'STL (3D)') {
+      if (template.category === 'ABC Notation' || template.category === 'GeoJSON' || template.category === 'TopoJSON' || template.category === 'STL (3D)') {
         callback(null);
         return;
       }
@@ -6776,6 +6776,11 @@ document.addEventListener("DOMContentLoaded", async function () {
         categories: ['Vega-Lite']
       },
       {
+        label: 'Maps',
+        icon: 'bi-map',
+        categories: ['GeoJSON', 'TopoJSON']
+      },
+      {
         label: 'Technical Notation',
         icon: 'bi-code-slash',
         categories: ['WaveDrom', 'ABC Notation']
@@ -6794,6 +6799,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       D2: 'bi-grid-3x3',
       Markmap: 'bi-diagram-2',
       'Vega-Lite': 'bi-bar-chart-line',
+      GeoJSON: 'bi-pin-map',
+      TopoJSON: 'bi-layers',
       WaveDrom: 'bi-activity',
       'ABC Notation': 'bi-music-note-beamed',
       'STL (3D)': 'bi-badge-3d'
@@ -6908,6 +6915,12 @@ document.addEventListener("DOMContentLoaded", async function () {
     // Markmap additional (Aesthetic: colorful mindmaps, checklist notation)
     const svgMarkmapChecklist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#ede7f6" stroke="#5e35b1" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#5e35b1" font-weight="bold">Tasks</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#5e35b1" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#5e35b1" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#5e35b1"/><circle cx="90" cy="90" r="3" fill="#5e35b1"/><text x="96" y="33" font-size="7" font-family="sans-serif">☒ Todo A</text><text x="96" y="93" font-size="7" font-family="sans-serif">☑ Todo B</text></svg>`;
     const svgMarkmapCode = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#eceff1" stroke="#455a64" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#455a64" font-weight="bold">Project</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#455a64" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#455a64" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#455a64"/><circle cx="90" cy="90" r="3" fill="#455a64"/><text x="96" y="33" font-size="7" font-family="monospace">code()</text><text x="96" y="93" font-size="7" font-family="monospace">test()</text></svg>`;
+
+    // Map local previews
+    const svgGeoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#eef6ff" stroke="#94a3b8" stroke-width="1.4"/><path d="M22 84 C40 70, 52 76, 68 58 C86 38, 104 52, 124 30" fill="none" stroke="#60a5fa" stroke-width="4" stroke-linecap="round" opacity="0.85"/><path d="M28 32 L65 24 L82 48 L60 76 L30 68 Z" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.6"/><path d="M86 66 L126 56 L138 86 L102 96 Z" fill="#bbf7d0" stroke="#16a34a" stroke-width="1.6"/><circle cx="112" cy="46" r="6" fill="#ef4444" stroke="#fff" stroke-width="2"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">GeoJSON</text></svg>`;
+    const svgTopoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1.4"/><path d="M30 30 L68 24 L86 52 L58 84 L26 70 Z" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.6"/><path d="M86 30 L126 38 L134 78 L104 94 L82 66 Z" fill="#dcfce7" stroke="#15803d" stroke-width="1.6"/><path d="M68 24 L86 52 L82 66" fill="none" stroke="#f59e0b" stroke-width="2.6" stroke-dasharray="4 3"/><circle cx="68" cy="24" r="3" fill="#f59e0b"/><circle cx="86" cy="52" r="3" fill="#f59e0b"/><circle cx="82" cy="66" r="3" fill="#f59e0b"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">TopoJSON</text></svg>`;
+    const geoJsonMapCode = '```geojson\n{\n  "type": "FeatureCollection",\n  "features": [\n    {\n      "type": "Feature",\n      "properties": { "name": "Demo district" },\n      "geometry": {\n        "type": "Polygon",\n        "coordinates": [[\n          [-122.45, 37.76],\n          [-122.41, 37.76],\n          [-122.40, 37.79],\n          [-122.44, 37.80],\n          [-122.45, 37.76]\n        ]]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Walking route" },\n      "geometry": {\n        "type": "LineString",\n        "coordinates": [\n          [-122.45, 37.77],\n          [-122.43, 37.78],\n          [-122.41, 37.79]\n        ]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Meeting point" },\n      "geometry": {\n        "type": "Point",\n        "coordinates": [-122.42, 37.785]\n      }\n    }\n  ]\n}\n```\n';
+    const topoJsonMapCode = '```topojson\n{\n  "type": "Topology",\n  "transform": {\n    "scale": [0.01, 0.01],\n    "translate": [-122.45, 37.76]\n  },\n  "objects": {\n    "districts": {\n      "type": "GeometryCollection",\n      "geometries": [\n        {\n          "type": "Polygon",\n          "properties": { "name": "North zone" },\n          "arcs": [[0]]\n        },\n        {\n          "type": "Polygon",\n          "properties": { "name": "South zone" },\n          "arcs": [[1]]\n        }\n      ]\n    }\n  },\n  "arcs": [\n    [[0, 0], [4, 0], [0, 3], [-4, 0], [0, -3]],\n    [[4, 0], [4, 0], [0, 3], [-4, 0], [0, -3]]\n  ]\n}\n```\n';
 
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
@@ -7643,6 +7656,24 @@ document.addEventListener("DOMContentLoaded", async function () {
         label: 'Inline Code Blocks',
         svg: svgMarkmapCode,
         code: '```markmap\n# Development\n## Languages\n- `JavaScript`\n- `Python`\n## Functions\n- `main()`\n- `helper_func()`\n```\n'
+      },
+
+      // Maps
+      {
+        id: 'geojson-feature-collection',
+        category: 'GeoJSON',
+        title: 'Feature Collection Map',
+        label: 'Feature Collection Map',
+        svg: svgGeoJsonMap,
+        code: geoJsonMapCode
+      },
+      {
+        id: 'topojson-topology',
+        category: 'TopoJSON',
+        title: 'Topology Map',
+        label: 'Topology Map',
+        svg: svgTopoJsonMap,
+        code: topoJsonMapCode
       },
 
       // STL (3D)

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -7000,7 +7000,8 @@ document.addEventListener("DOMContentLoaded", async function () {
 
       const spikeDirections = [
         [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1],
-        [1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1], [-1, -1, 1], [-1, 1, -1]
+        [1, 1, 1], [-1, 1, 1], [1, -1, 1], [-1, -1, 1],
+        [1, 1, -1], [-1, 1, -1], [1, -1, -1], [-1, -1, -1]
       ];
       spikeDirections.forEach(direction => {
         facets.push(...createConeSpikeFacets(direction, 2.2, 10, 6, 6));

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5366,7 +5366,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-modal-sidebar {
-  width: 228px;
+  width: 244px;
   border-right: 1px solid var(--border-color);
   background: var(--header-bg);
   padding: 10px 8px;
@@ -5404,6 +5404,14 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   padding: 0 10px;
   border-radius: 6px;
   font-weight: 400;
+}
+
+.diagram-sidebar-group-header span,
+.diagram-sidebar-btn span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .diagram-sidebar-group-header:hover {

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5376,6 +5376,20 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   flex-shrink: 0;
 }
 
+.diagram-sidebar-group-title {
+  padding: 14px 14px 5px;
+  color: var(--text-muted, #6b7280);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.diagram-sidebar-group-title:first-child {
+  padding-top: 2px;
+}
+
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
@@ -5658,6 +5672,11 @@ html[data-theme="dark"] .diagram-preview-container {
     border-bottom: 1px solid var(--border-color);
     padding: 8px;
   }
+
+  .diagram-sidebar-group-title {
+    display: none;
+  }
+
   .diagram-modal-box {
     height: 95vh;
   }

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5380,7 +5380,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 .diagram-sidebar-group {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
 }
 
 .diagram-sidebar-group-header,
@@ -5402,7 +5402,9 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   gap: 8px;
   min-height: 38px;
   padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
   border-radius: 6px;
+  background-color: color-mix(in srgb, var(--text-color) 3%, transparent);
   font-weight: 400;
 }
 
@@ -5415,7 +5417,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-sidebar-group-header:hover {
-  background-color: var(--button-hover);
+  background-color: color-mix(in srgb, var(--button-hover) 72%, transparent);
 }
 
 .diagram-sidebar-group-icon,
@@ -5441,8 +5443,10 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 .diagram-sidebar-items {
   display: none;
   flex-direction: column;
-  gap: 2px;
-  padding: 1px 0 5px 12px;
+  gap: 3px;
+  margin: 1px 0 6px 17px;
+  padding: 2px 0 4px 10px;
+  border-left: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
 }
 
 .diagram-sidebar-group.is-expanded .diagram-sidebar-items {
@@ -5453,9 +5457,11 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 34px;
-  padding: 0 9px;
+  min-height: 32px;
+  padding: 0 9px 0 8px;
   border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
   font-weight: 400;
 }
 
@@ -5472,7 +5478,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 .diagram-sidebar-item-icon {
   width: 18px;
   color: var(--text-secondary);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   flex: 0 0 auto;
 }
 

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5366,27 +5366,21 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-modal-sidebar {
-  width: 260px;
-  margin: 16px 0 16px 16px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-color);
-  padding: 0;
+  width: 228px;
+  border-right: 1px solid var(--border-color);
+  background: var(--header-bg);
+  padding: 10px 8px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 6px;
   flex-shrink: 0;
 }
 
 .diagram-sidebar-group {
   display: flex;
   flex-direction: column;
-  border-top: 1px solid var(--border-color);
-}
-
-.diagram-sidebar-group:first-child {
-  border-top: none;
+  gap: 2px;
 }
 
 .diagram-sidebar-group-header,
@@ -5396,27 +5390,27 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   background: transparent;
   color: var(--text-color);
   cursor: pointer;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   text-align: left;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .diagram-sidebar-group-header {
   display: grid;
-  grid-template-columns: 24px 1fr 18px;
+  grid-template-columns: 18px 1fr 16px;
   align-items: center;
-  gap: 12px;
-  min-height: 62px;
-  padding: 0 18px;
-  font-weight: 500;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 10px;
+  border-radius: 6px;
+  font-weight: 600;
 }
 
 .diagram-sidebar-group-header:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
+  background-color: var(--button-hover);
 }
 
 .diagram-sidebar-group-icon,
-.diagram-sidebar-item-icon,
 .diagram-sidebar-chevron {
   display: inline-flex;
   align-items: center;
@@ -5425,21 +5419,21 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-sidebar-group-icon {
-  color: var(--text-color);
-  font-size: 1.1rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
 }
 
 .diagram-sidebar-chevron {
   justify-self: end;
-  color: var(--text-muted, #6b7280);
-  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
 }
 
 .diagram-sidebar-items {
   display: none;
   flex-direction: column;
-  gap: 4px;
-  padding: 0 12px 12px;
+  gap: 2px;
+  padding: 1px 0 5px 12px;
 }
 
 .diagram-sidebar-group.is-expanded .diagram-sidebar-items {
@@ -5449,31 +5443,37 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
-  gap: 14px;
-  min-height: 50px;
-  padding: 0 16px 0 20px;
-  border-radius: 7px;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 9px;
+  border-radius: 6px;
   font-weight: 500;
 }
 
 .diagram-sidebar-btn:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
+  background-color: var(--button-hover);
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 13%, transparent);
+  background-color: var(--button-hover);
   color: var(--accent-color, #0076ff);
-  font-weight: 650;
+  font-weight: 600;
+  box-shadow: inset 3px 0 0 var(--accent-color, #0076ff);
 }
 
-.diagram-sidebar-btn.is-active .diagram-sidebar-item-icon {
-  color: var(--accent-color, #0076ff);
+.diagram-sidebar-item-dot {
+  width: 6px;
+  height: 6px;
+  border: 1px solid var(--text-secondary);
+  border-radius: 50%;
+  flex: 0 0 auto;
+  opacity: 0.75;
 }
 
-.diagram-sidebar-item-icon {
-  width: 22px;
-  color: var(--text-muted, #6b7280);
-  font-size: 1.05rem;
+.diagram-sidebar-btn.is-active .diagram-sidebar-item-dot {
+  background: var(--accent-color, #0076ff);
+  border-color: var(--accent-color, #0076ff);
+  opacity: 1;
 }
 
 .diagram-modal-content {
@@ -5728,12 +5728,9 @@ html[data-theme="dark"] .diagram-preview-container {
   .diagram-modal-sidebar {
     width: 100%;
     height: 60px;
-    margin: 0;
     flex-direction: row;
     border-right: none;
     border-bottom: 1px solid var(--border-color);
-    border-left: none;
-    border-radius: 0;
     padding: 8px;
     gap: 6px;
   }

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5366,55 +5366,114 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-modal-sidebar {
-  width: 220px;
-  border-right: 1px solid var(--border-color);
-  padding: 14px 10px;
+  width: 260px;
+  margin: 16px 0 16px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-color);
+  padding: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 0;
   flex-shrink: 0;
 }
 
 .diagram-sidebar-group {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  border-top: 1px solid var(--border-color);
 }
 
-.diagram-sidebar-group-title {
-  padding: 0 10px 4px;
+.diagram-sidebar-group:first-child {
+  border-top: none;
+}
+
+.diagram-sidebar-group-header,
+.diagram-sidebar-btn {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 0.95rem;
+  text-align: left;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.diagram-sidebar-group-header {
+  display: grid;
+  grid-template-columns: 24px 1fr 18px;
+  align-items: center;
+  gap: 12px;
+  min-height: 62px;
+  padding: 0 18px;
+  font-weight: 500;
+}
+
+.diagram-sidebar-group-header:hover {
+  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
+}
+
+.diagram-sidebar-group-icon,
+.diagram-sidebar-item-icon,
+.diagram-sidebar-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.diagram-sidebar-group-icon {
+  color: var(--text-color);
+  font-size: 1.1rem;
+}
+
+.diagram-sidebar-chevron {
+  justify-self: end;
   color: var(--text-muted, #6b7280);
-  font-size: 0.76rem;
-  font-weight: 600;
-  letter-spacing: 0;
-  line-height: 1.2;
+  font-size: 0.85rem;
+}
+
+.diagram-sidebar-items {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 12px 12px;
+}
+
+.diagram-sidebar-group.is-expanded .diagram-sidebar-items {
+  display: flex;
 }
 
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 9px 12px;
-  border: none;
-  background: transparent;
-  color: var(--text-color);
-  text-align: left;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.9rem;
+  gap: 14px;
+  min-height: 50px;
+  padding: 0 16px 0 20px;
+  border-radius: 7px;
   font-weight: 500;
-  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .diagram-sidebar-btn:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.08));
+  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 12%, transparent);
+  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 13%, transparent);
   color: var(--accent-color, #0076ff);
   font-weight: 650;
+}
+
+.diagram-sidebar-btn.is-active .diagram-sidebar-item-icon {
+  color: var(--accent-color, #0076ff);
+}
+
+.diagram-sidebar-item-icon {
+  width: 22px;
+  color: var(--text-muted, #6b7280);
+  font-size: 1.05rem;
 }
 
 .diagram-modal-content {
@@ -5662,25 +5721,40 @@ html[data-theme="dark"] .diagram-preview-container {
   display: none !important;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 640px) {
   .diagram-modal-body {
     flex-direction: column;
   }
   .diagram-modal-sidebar {
     width: 100%;
     height: 60px;
+    margin: 0;
     flex-direction: row;
     border-right: none;
     border-bottom: 1px solid var(--border-color);
+    border-left: none;
+    border-radius: 0;
     padding: 8px;
+    gap: 6px;
   }
 
-  .diagram-sidebar-group-title {
+  .diagram-sidebar-group-header {
     display: none;
   }
 
   .diagram-sidebar-group {
     display: contents;
+  }
+
+  .diagram-sidebar-items {
+    display: contents;
+  }
+
+  .diagram-sidebar-btn {
+    width: auto;
+    min-height: 36px;
+    flex-shrink: 0;
+    padding: 0 12px;
   }
 
   .diagram-modal-box {

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5368,33 +5368,34 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 .diagram-modal-sidebar {
   width: 220px;
   border-right: 1px solid var(--border-color);
-  padding: 16px 8px;
+  padding: 14px 10px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 14px;
   flex-shrink: 0;
 }
 
-.diagram-sidebar-group-title {
-  padding: 14px 14px 5px;
-  color: var(--text-muted, #6b7280);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  line-height: 1.2;
-  text-transform: uppercase;
+.diagram-sidebar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
-.diagram-sidebar-group-title:first-child {
-  padding-top: 2px;
+.diagram-sidebar-group-title {
+  padding: 0 10px 4px;
+  color: var(--text-muted, #6b7280);
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.2;
 }
 
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 9px 12px;
   border: none;
   background: transparent;
   color: var(--text-color);
@@ -5407,12 +5408,13 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-sidebar-btn:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.1));
+  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.08));
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: var(--accent-color, #0076ff);
-  color: #fff;
+  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 12%, transparent);
+  color: var(--accent-color, #0076ff);
+  font-weight: 650;
 }
 
 .diagram-modal-content {
@@ -5675,6 +5677,10 @@ html[data-theme="dark"] .diagram-preview-container {
 
   .diagram-sidebar-group-title {
     display: none;
+  }
+
+  .diagram-sidebar-group {
+    display: contents;
   }
 
   .diagram-modal-box {

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -5403,7 +5403,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   min-height: 38px;
   padding: 0 10px;
   border-radius: 6px;
-  font-weight: 600;
+  font-weight: 400;
 }
 
 .diagram-sidebar-group-header:hover {
@@ -5411,6 +5411,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-sidebar-group-icon,
+.diagram-sidebar-item-icon,
 .diagram-sidebar-chevron {
   display: inline-flex;
   align-items: center;
@@ -5447,7 +5448,7 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
   min-height: 34px;
   padding: 0 9px;
   border-radius: 6px;
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .diagram-sidebar-btn:hover {
@@ -5455,25 +5456,20 @@ html[data-theme="dark"] .d2-diagram > svg:not([data-diagram-native-dark="true"])
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: var(--button-hover);
+  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 14%, transparent);
   color: var(--accent-color, #0076ff);
-  font-weight: 600;
-  box-shadow: inset 3px 0 0 var(--accent-color, #0076ff);
+  font-weight: 400;
 }
 
-.diagram-sidebar-item-dot {
-  width: 6px;
-  height: 6px;
-  border: 1px solid var(--text-secondary);
-  border-radius: 50%;
+.diagram-sidebar-item-icon {
+  width: 18px;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
   flex: 0 0 auto;
-  opacity: 0.75;
 }
 
-.diagram-sidebar-btn.is-active .diagram-sidebar-item-dot {
-  background: var(--accent-color, #0076ff);
-  border-color: var(--accent-color, #0076ff);
-  opacity: 1;
+.diagram-sidebar-btn.is-active .diagram-sidebar-item-icon {
+  color: var(--accent-color, #0076ff);
 }
 
 .diagram-modal-content {

--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
             <button type="button" class="markdown-tool-btn" data-md-action="emoji" title="Emoji shortcode" aria-label="Emoji shortcode"><i class="bi bi-emoji-smile"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="symbols" title="Symbols &amp; HTML entities" aria-label="Symbols &amp; HTML entities"><i class="bi bi-c-circle"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="alert" title="Markdown alert" aria-label="Markdown alert"><i class="bi bi-newspaper"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="diagram" title="Insert Diagram" aria-label="Insert Diagram"><i class="bi bi-diagram-3"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="diagram" title="Insert Diagram &amp; More" aria-label="Insert Diagram &amp; More"><i class="bi bi-diagram-3"></i></button>
           </div>
           <div class="markdown-toolbar-group">
             <button type="button" class="markdown-tool-btn" data-md-action="fullscreen" title="Fullscreen" aria-label="Fullscreen"><i class="bi bi-arrows-fullscreen"></i></button>
@@ -1031,7 +1031,7 @@
         <div id="diagram-modal" class="reset-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diagram-modal-title" aria-hidden="true" style="display:none;">
           <div class="reset-modal-box reset-modal-box--wide reset-modal-box--xl diagram-modal-box">
             <div class="modal-header">
-              <p id="diagram-modal-title" class="reset-modal-message">Insert Diagram</p>
+              <p id="diagram-modal-title" class="reset-modal-message">Insert Diagram &amp; More</p>
               <button class="modal-close-btn" id="diagram-modal-close" aria-label="Close modal">&times;</button>
             </div>
             

--- a/script.js
+++ b/script.js
@@ -7002,25 +7002,42 @@ ${selector} .arrowheadPath {
     const categoryGroups = [
       {
         label: 'Diagrams',
+        icon: 'bi-diagram-3',
         categories: ['Mermaid', 'PlantUML', 'Graphviz', 'D2']
       },
       {
         label: 'Mind Maps',
+        icon: 'bi-diagram-2',
         categories: ['Markmap']
       },
       {
         label: 'Data Visualization',
+        icon: 'bi-bar-chart-line',
         categories: ['Vega-Lite']
       },
       {
         label: 'Technical Notation',
+        icon: 'bi-code-slash',
         categories: ['WaveDrom', 'ABC Notation']
       },
       {
         label: '3D Models',
+        icon: 'bi-box',
         categories: ['STL (3D)']
       }
     ];
+
+    const categoryIcons = {
+      Mermaid: 'bi-water',
+      PlantUML: 'bi-leaf',
+      Graphviz: 'bi-bezier2',
+      D2: 'bi-badge-2d',
+      Markmap: 'bi-diagram-2',
+      'Vega-Lite': 'bi-bar-chart-line',
+      WaveDrom: 'bi-activity',
+      'ABC Notation': 'bi-music-note-beamed',
+      'STL (3D)': 'bi-box'
+    };
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
     const svgMermaidFlowchartLR = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="30" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Left</text><path d="M 50 60 L 110 60" stroke="#2e7d32" stroke-width="1.2" marker-end="url(#arrow-flr)"/><rect x="110" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="130" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Right</text><defs><marker id="arrow-flr" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2e7d32"/></marker></defs></svg>`;
@@ -7746,28 +7763,51 @@ ${selector} .arrowheadPath {
     function renderSidebar() {
       sidebar.textContent = '';
       categoryGroups.forEach(group => {
+        const isExpanded = group.categories.includes(activeCategory);
         const groupEl = document.createElement('div');
         groupEl.className = 'diagram-sidebar-group';
+        if (isExpanded) groupEl.classList.add('is-expanded');
 
-        const heading = document.createElement('div');
-        heading.className = 'diagram-sidebar-group-title';
-        heading.setAttribute('role', 'presentation');
-        heading.textContent = group.label;
+        const heading = document.createElement('button');
+        heading.type = 'button';
+        heading.className = 'diagram-sidebar-group-header';
+        heading.setAttribute('aria-expanded', String(isExpanded));
+        heading.innerHTML = `
+          <i class="bi ${group.icon} diagram-sidebar-group-icon" aria-hidden="true"></i>
+          <span>${group.label}</span>
+          <i class="bi ${isExpanded ? 'bi-chevron-up' : 'bi-chevron-right'} diagram-sidebar-chevron" aria-hidden="true"></i>
+        `;
+        heading.addEventListener('click', () => {
+          if (!isExpanded) {
+            activeCategory = group.categories[0];
+            selectedTemplate = null;
+            renderSidebar();
+            renderGrid();
+          }
+        });
         groupEl.appendChild(heading);
+
+        const itemsEl = document.createElement('div');
+        itemsEl.className = 'diagram-sidebar-items';
 
         group.categories.forEach(cat => {
           const btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'diagram-sidebar-btn';
           if (cat === activeCategory) btn.classList.add('is-active');
-          btn.textContent = cat;
+          btn.innerHTML = `
+            <i class="bi ${categoryIcons[cat] || 'bi-circle'} diagram-sidebar-item-icon" aria-hidden="true"></i>
+            <span>${cat}</span>
+          `;
           btn.addEventListener('click', () => {
             activeCategory = cat;
             renderSidebar();
             renderGrid();
           });
-          groupEl.appendChild(btn);
+          itemsEl.appendChild(btn);
         });
+
+        groupEl.appendChild(itemsEl);
 
         sidebar.appendChild(groupEl);
       });

--- a/script.js
+++ b/script.js
@@ -7007,7 +7007,7 @@ ${selector} .arrowheadPath {
       },
       {
         label: 'Mind Maps',
-        icon: 'bi-diagram-2',
+        icon: 'bi-list-ul',
         categories: ['Markmap']
       },
       {
@@ -7026,18 +7026,6 @@ ${selector} .arrowheadPath {
         categories: ['STL (3D)']
       }
     ];
-
-    const categoryIcons = {
-      Mermaid: 'bi-water',
-      PlantUML: 'bi-leaf',
-      Graphviz: 'bi-bezier2',
-      D2: 'bi-badge-2d',
-      Markmap: 'bi-diagram-2',
-      'Vega-Lite': 'bi-bar-chart-line',
-      WaveDrom: 'bi-activity',
-      'ABC Notation': 'bi-music-note-beamed',
-      'STL (3D)': 'bi-box'
-    };
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
     const svgMermaidFlowchartLR = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="30" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Left</text><path d="M 50 60 L 110 60" stroke="#2e7d32" stroke-width="1.2" marker-end="url(#arrow-flr)"/><rect x="110" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="130" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Right</text><defs><marker id="arrow-flr" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2e7d32"/></marker></defs></svg>`;
@@ -7796,7 +7784,7 @@ ${selector} .arrowheadPath {
           btn.className = 'diagram-sidebar-btn';
           if (cat === activeCategory) btn.classList.add('is-active');
           btn.innerHTML = `
-            <i class="bi ${categoryIcons[cat] || 'bi-circle'} diagram-sidebar-item-icon" aria-hidden="true"></i>
+            <span class="diagram-sidebar-item-dot" aria-hidden="true"></span>
             <span>${cat}</span>
           `;
           btn.addEventListener('click', () => {

--- a/script.js
+++ b/script.js
@@ -7240,7 +7240,8 @@ ${selector} .arrowheadPath {
 
       const spikeDirections = [
         [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1],
-        [1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1], [-1, -1, 1], [-1, 1, -1]
+        [1, 1, 1], [-1, 1, 1], [1, -1, 1], [-1, -1, 1],
+        [1, 1, -1], [-1, 1, -1], [1, -1, -1], [-1, -1, -1]
       ];
       spikeDirections.forEach(direction => {
         facets.push(...createConeSpikeFacets(direction, 2.2, 10, 6, 6));

--- a/script.js
+++ b/script.js
@@ -7016,11 +7016,6 @@ ${selector} .arrowheadPath {
         categories: ['Vega-Lite']
       },
       {
-        label: 'Maps',
-        icon: 'bi-map',
-        categories: ['GeoJSON', 'TopoJSON']
-      },
-      {
         label: 'Technical Notation',
         icon: 'bi-code-slash',
         categories: ['WaveDrom', 'ABC Notation']
@@ -7029,6 +7024,11 @@ ${selector} .arrowheadPath {
         label: '3D Models',
         icon: 'bi-box',
         categories: ['STL (3D)']
+      },
+      {
+        label: 'Maps',
+        icon: 'bi-map',
+        categories: ['GeoJSON', 'TopoJSON']
       }
     ];
 
@@ -7159,6 +7159,8 @@ ${selector} .arrowheadPath {
     // Map local previews
     const svgGeoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#eef6ff" stroke="#94a3b8" stroke-width="1.4"/><path d="M22 84 C40 70, 52 76, 68 58 C86 38, 104 52, 124 30" fill="none" stroke="#60a5fa" stroke-width="4" stroke-linecap="round" opacity="0.85"/><path d="M28 32 L65 24 L82 48 L60 76 L30 68 Z" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.6"/><path d="M86 66 L126 56 L138 86 L102 96 Z" fill="#bbf7d0" stroke="#16a34a" stroke-width="1.6"/><circle cx="112" cy="46" r="6" fill="#ef4444" stroke="#fff" stroke-width="2"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">GeoJSON</text></svg>`;
     const svgTopoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1.4"/><path d="M30 30 L68 24 L86 52 L58 84 L26 70 Z" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.6"/><path d="M86 30 L126 38 L134 78 L104 94 L82 66 Z" fill="#dcfce7" stroke="#15803d" stroke-width="1.6"/><path d="M68 24 L86 52 L82 66" fill="none" stroke="#f59e0b" stroke-width="2.6" stroke-dasharray="4 3"/><circle cx="68" cy="24" r="3" fill="#f59e0b"/><circle cx="86" cy="52" r="3" fill="#f59e0b"/><circle cx="82" cy="66" r="3" fill="#f59e0b"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">TopoJSON</text></svg>`;
+    const geoJsonPointCode = '```geojson\n{\n  "type": "FeatureCollection",\n  "features": [\n    {\n      "type": "Feature",\n      "properties": { "name": "Taj Mahal" },\n      "geometry": {\n        "type": "Point",\n        "coordinates": [78.0421, 27.1751]\n      }\n    }\n  ]\n}\n```\n';
+    const topoJsonPointCode = '```topojson\n{\n  "type": "Topology",\n  "objects": {\n    "example": {\n      "type": "GeometryCollection",\n      "geometries": [\n        {\n          "type": "Point",\n          "coordinates": [2.2945, 48.8584],\n          "properties": { "name": "Eiffel Tower" }\n        }\n      ]\n    }\n  },\n  "arcs": [],\n  "transform": {\n    "scale": [1, 1],\n    "translate": [0, 0]\n  }\n}\n```\n';
     const geoJsonMapCode = '```geojson\n{\n  "type": "FeatureCollection",\n  "features": [\n    {\n      "type": "Feature",\n      "properties": { "name": "Demo district" },\n      "geometry": {\n        "type": "Polygon",\n        "coordinates": [[\n          [-122.45, 37.76],\n          [-122.41, 37.76],\n          [-122.40, 37.79],\n          [-122.44, 37.80],\n          [-122.45, 37.76]\n        ]]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Walking route" },\n      "geometry": {\n        "type": "LineString",\n        "coordinates": [\n          [-122.45, 37.77],\n          [-122.43, 37.78],\n          [-122.41, 37.79]\n        ]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Meeting point" },\n      "geometry": {\n        "type": "Point",\n        "coordinates": [-122.42, 37.785]\n      }\n    }\n  ]\n}\n```\n';
     const topoJsonMapCode = '```topojson\n{\n  "type": "Topology",\n  "transform": {\n    "scale": [0.01, 0.01],\n    "translate": [-122.45, 37.76]\n  },\n  "objects": {\n    "districts": {\n      "type": "GeometryCollection",\n      "geometries": [\n        {\n          "type": "Polygon",\n          "properties": { "name": "North zone" },\n          "arcs": [[0]]\n        },\n        {\n          "type": "Polygon",\n          "properties": { "name": "South zone" },\n          "arcs": [[1]]\n        }\n      ]\n    }\n  },\n  "arcs": [\n    [[0, 0], [4, 0], [0, 3], [-4, 0], [0, -3]],\n    [[4, 0], [4, 0], [0, 3], [-4, 0], [0, -3]]\n  ]\n}\n```\n';
 
@@ -7900,12 +7902,28 @@ ${selector} .arrowheadPath {
 
       // Maps
       {
+        id: 'geojson-landmark-point',
+        category: 'GeoJSON',
+        title: 'Landmark Point',
+        label: 'Landmark Point',
+        svg: svgGeoJsonMap,
+        code: geoJsonPointCode
+      },
+      {
         id: 'geojson-feature-collection',
         category: 'GeoJSON',
         title: 'Feature Collection Map',
         label: 'Feature Collection Map',
         svg: svgGeoJsonMap,
         code: geoJsonMapCode
+      },
+      {
+        id: 'topojson-landmark-point',
+        category: 'TopoJSON',
+        title: 'Landmark Point',
+        label: 'Landmark Point',
+        svg: svgTopoJsonMap,
+        code: topoJsonPointCode
       },
       {
         id: 'topojson-topology',

--- a/script.js
+++ b/script.js
@@ -7152,7 +7152,7 @@ ${selector} .arrowheadPath {
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
     const svgStlCube = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 118,44 88,62 28,42" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><polygon points="28,42 88,62 88,100 28,80" fill="#93c5fd" stroke="#2563eb" stroke-width="1.8"/><polygon points="88,62 118,44 118,82 88,100" fill="#60a5fa" stroke="#2563eb" stroke-width="1.8"/><line x1="58" y1="24" x2="58" y2="62" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="28" y2="80" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="118" y2="82" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><text x="80" y="16" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">20 mm cube</text></svg>`;
-    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="28,72 88,92 132,66 72,46" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.8"/><polygon points="72,46 132,66 132,82 72,62" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.5"/><polygon points="48,50 76,60 76,82 48,72" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,48 118,56 118,76 94,68" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><circle cx="62" cy="68" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><circle cx="106" cy="64" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><text x="80" y="20" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">bracket</text></svg>`;
+    const svgStlSpikedBall = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,8 88,32 112,22 104,48 130,56 104,68 118,92 90,84 80,108 70,84 42,92 56,68 30,56 56,48 48,22 72,32" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.7" stroke-linejoin="round"/><circle cx="80" cy="60" r="34" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1.8"/><path d="M58 42 C70 28, 96 30, 106 46 C92 40, 72 39, 58 42 Z" fill="#dbeafe" opacity="0.85"/><circle cx="68" cy="53" r="4" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.1"/><circle cx="92" cy="67" r="5" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.1"/><text x="80" y="116" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">spiked ball</text></svg>`;
     const svgStlGear = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,12 89,29 107,21 109,40 128,43 116,58 130,72 111,77 110,96 92,88 80,105 68,88 50,96 49,77 30,72 44,58 32,43 51,40 53,21 71,29" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><circle cx="80" cy="60" r="22" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1.8"/><circle cx="80" cy="60" r="9" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="116" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">gear mesh</text></svg>`;
     const svgStlTwist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 94,16 112,38 78,48" fill="#dbeafe" stroke="#2563eb" stroke-width="1.7"/><polygon points="46,82 82,102 116,78 78,60" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.7"/><polygon points="58,24 78,48 78,60 46,82" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,16 112,38 116,78 82,102" fill="#93c5fd" stroke="#2563eb" stroke-width="1.5"/><polygon points="78,48 112,38 116,78 78,60" fill="#60a5fa" opacity="0.85" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="114" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">twist</text></svg>`;
 
@@ -7169,33 +7169,84 @@ ${selector} .arrowheadPath {
       return `\`\`\`stl\nsolid ${name}\n${facets.join('')}endsolid ${name}\n\`\`\`\n`;
     }
 
-    function createBoxFacets(x0, y0, z0, x1, y1, z1) {
-      const p = {
-        a: [x0, y0, z0], b: [x1, y0, z0], c: [x1, y1, z0], d: [x0, y1, z0],
-        e: [x0, y0, z1], f: [x1, y0, z1], g: [x1, y1, z1], h: [x0, y1, z1]
-      };
-      const face = (normal, v1, v2, v3, v4) => [
-        stlFacet(normal, [v1, v2, v3]),
-        stlFacet(normal, [v1, v3, v4])
-      ];
+    function normalizeVector(vector) {
+      const length = Math.hypot(vector[0], vector[1], vector[2]) || 1;
+      return vector.map(value => value / length);
+    }
+
+    function scaleVector(vector, scale) {
+      return vector.map(value => value * scale);
+    }
+
+    function addVectors(a, b) {
+      return a.map((value, index) => value + b[index]);
+    }
+
+    function crossVectors(a, b) {
       return [
-        ...face([0, 0, -1], p.a, p.b, p.c, p.d),
-        ...face([0, 0, 1], p.e, p.h, p.g, p.f),
-        ...face([0, -1, 0], p.a, p.e, p.f, p.b),
-        ...face([1, 0, 0], p.b, p.f, p.g, p.c),
-        ...face([0, 1, 0], p.c, p.g, p.h, p.d),
-        ...face([-1, 0, 0], p.d, p.h, p.e, p.a)
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
       ];
     }
 
-    function createSteppedBracketStl() {
-      return wrapStl('stepped_bracket_with_raised_bosses', [
-        ...createBoxFacets(-24, -12, 0, 24, 12, 4),
-        ...createBoxFacets(-18, -6, 4, 18, 6, 9),
-        ...createBoxFacets(-20, -10, 9, -8, 10, 18),
-        ...createBoxFacets(8, -10, 9, 20, 10, 18),
-        ...createBoxFacets(-5, -4, 9, 5, 4, 15)
-      ]);
+    function createConeSpikeFacets(direction, baseRadius, bodyRadius, spikeLength, segments) {
+      const normal = normalizeVector(direction);
+      const tangentSeed = Math.abs(normal[2]) > 0.82 ? [1, 0, 0] : [0, 0, 1];
+      const u = normalizeVector(crossVectors(normal, tangentSeed));
+      const v = normalizeVector(crossVectors(normal, u));
+      const baseCenter = scaleVector(normal, bodyRadius);
+      const tip = scaleVector(normal, bodyRadius + spikeLength);
+      const ring = Array.from({ length: segments }, (_, index) => {
+        const angle = (Math.PI * 2 * index) / segments;
+        return addVectors(baseCenter, addVectors(scaleVector(u, Math.cos(angle) * baseRadius), scaleVector(v, Math.sin(angle) * baseRadius)));
+      });
+      const facets = [];
+      ring.forEach((point, index) => {
+        const next = ring[(index + 1) % ring.length];
+        facets.push(stlFacet([0, 0, 0], [point, next, tip]));
+      });
+      return facets;
+    }
+
+    function createSpikedBallStl() {
+      const facets = [];
+      const segments = 12;
+      const rings = [-60, -30, 0, 30, 60].map(degrees => {
+        const phi = (degrees * Math.PI) / 180;
+        const radius = Math.cos(phi) * 10;
+        const z = Math.sin(phi) * 10;
+        return Array.from({ length: segments }, (_, index) => {
+          const theta = (Math.PI * 2 * index) / segments;
+          return [Math.cos(theta) * radius, Math.sin(theta) * radius, z];
+        });
+      });
+      const south = [0, 0, -10];
+      const north = [0, 0, 10];
+
+      for (let index = 0; index < segments; index += 1) {
+        const next = (index + 1) % segments;
+        facets.push(stlFacet([0, 0, 0], [south, rings[0][next], rings[0][index]]));
+        facets.push(stlFacet([0, 0, 0], [rings[rings.length - 1][index], rings[rings.length - 1][next], north]));
+      }
+
+      for (let ringIndex = 0; ringIndex < rings.length - 1; ringIndex += 1) {
+        for (let index = 0; index < segments; index += 1) {
+          const next = (index + 1) % segments;
+          facets.push(stlFacet([0, 0, 0], [rings[ringIndex][index], rings[ringIndex][next], rings[ringIndex + 1][next]]));
+          facets.push(stlFacet([0, 0, 0], [rings[ringIndex][index], rings[ringIndex + 1][next], rings[ringIndex + 1][index]]));
+        }
+      }
+
+      const spikeDirections = [
+        [1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1],
+        [1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1], [-1, -1, 1], [-1, 1, -1]
+      ];
+      spikeDirections.forEach(direction => {
+        facets.push(...createConeSpikeFacets(direction, 2.2, 10, 6, 6));
+      });
+
+      return wrapStl('spiked_round_ball', facets);
     }
 
     function createRadialPrismStl(name, points, z0, z1) {
@@ -7851,12 +7902,12 @@ ${selector} .arrowheadPath {
         code: '```stl\nsolid calibration_cube_20mm\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 0\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 20 0\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 20 20 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 0 20 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 20\n      vertex 20 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 0 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 20 20\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 20 20 20\n      vertex 0 20 20\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 0 20 20\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 20 20\n      vertex 0 0 20\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 0 20\n      vertex 0 0 0\n    endloop\n  endfacet\nendsolid calibration_cube_20mm\n```\n'
       },
       {
-        id: 'stl-stepped-bracket',
+        id: 'stl-spiked-round-ball',
         category: 'STL (3D)',
-        title: 'Stepped Bracket',
-        label: 'Stepped Bracket',
-        svg: svgStlBracket,
-        code: createSteppedBracketStl()
+        title: 'Spiked Round Ball',
+        label: 'Spiked Round Ball',
+        svg: svgStlSpikedBall,
+        code: createSpikedBallStl()
       },
       {
         id: 'stl-faceted-gear',

--- a/script.js
+++ b/script.js
@@ -7026,6 +7026,18 @@ ${selector} .arrowheadPath {
         categories: ['STL (3D)']
       }
     ];
+
+    const categoryIcons = {
+      Mermaid: 'bi-water',
+      PlantUML: 'bi-braces',
+      Graphviz: 'bi-bezier2',
+      D2: 'bi-grid-3x3',
+      Markmap: 'bi-diagram-2',
+      'Vega-Lite': 'bi-bar-chart-line',
+      WaveDrom: 'bi-activity',
+      'ABC Notation': 'bi-music-note-beamed',
+      'STL (3D)': 'bi-badge-3d'
+    };
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
     const svgMermaidFlowchartLR = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="30" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Left</text><path d="M 50 60 L 110 60" stroke="#2e7d32" stroke-width="1.2" marker-end="url(#arrow-flr)"/><rect x="110" y="47" width="40" height="26" fill="#e8f5e9" stroke="#2e7d32" stroke-width="1.5" rx="3"/><text x="130" y="63" font-size="8" text-anchor="middle" font-family="sans-serif" fill="#1b5e20" font-weight="bold">Right</text><defs><marker id="arrow-flr" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#2e7d32"/></marker></defs></svg>`;
@@ -7784,7 +7796,7 @@ ${selector} .arrowheadPath {
           btn.className = 'diagram-sidebar-btn';
           if (cat === activeCategory) btn.classList.add('is-active');
           btn.innerHTML = `
-            <span class="diagram-sidebar-item-dot" aria-hidden="true"></span>
+            <i class="bi ${categoryIcons[cat] || 'bi-circle'} diagram-sidebar-item-icon" aria-hidden="true"></i>
             <span>${cat}</span>
           `;
           btn.addEventListener('click', () => {

--- a/script.js
+++ b/script.js
@@ -7152,6 +7152,101 @@ ${selector} .arrowheadPath {
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
     const svgStlCube = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 118,44 88,62 28,42" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><polygon points="28,42 88,62 88,100 28,80" fill="#93c5fd" stroke="#2563eb" stroke-width="1.8"/><polygon points="88,62 118,44 118,82 88,100" fill="#60a5fa" stroke="#2563eb" stroke-width="1.8"/><line x1="58" y1="24" x2="58" y2="62" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="28" y2="80" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="118" y2="82" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><text x="80" y="16" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">20 mm cube</text></svg>`;
+    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="28,72 88,92 132,66 72,46" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.8"/><polygon points="72,46 132,66 132,82 72,62" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.5"/><polygon points="48,50 76,60 76,82 48,72" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,48 118,56 118,76 94,68" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/><circle cx="62" cy="68" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><circle cx="106" cy="64" r="6" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.6"/><text x="80" y="20" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">bracket</text></svg>`;
+    const svgStlGear = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,12 89,29 107,21 109,40 128,43 116,58 130,72 111,77 110,96 92,88 80,105 68,88 50,96 49,77 30,72 44,58 32,43 51,40 53,21 71,29" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><circle cx="80" cy="60" r="22" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1.8"/><circle cx="80" cy="60" r="9" fill="#eff6ff" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="116" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">gear mesh</text></svg>`;
+    const svgStlTwist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 94,16 112,38 78,48" fill="#dbeafe" stroke="#2563eb" stroke-width="1.7"/><polygon points="46,82 82,102 116,78 78,60" fill="#60a5fa" stroke="#1d4ed8" stroke-width="1.7"/><polygon points="58,24 78,48 78,60 46,82" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.5"/><polygon points="94,16 112,38 116,78 82,102" fill="#93c5fd" stroke="#2563eb" stroke-width="1.5"/><polygon points="78,48 112,38 116,78 78,60" fill="#60a5fa" opacity="0.85" stroke="#1d4ed8" stroke-width="1.5"/><text x="80" y="114" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">twist</text></svg>`;
+
+    function formatStlNumber(value) {
+      return Number(value.toFixed(4)).toString();
+    }
+
+    function stlFacet(normal, vertices) {
+      const vertexLines = vertices.map(vertex => `      vertex ${vertex.map(formatStlNumber).join(' ')}\n`).join('');
+      return `  facet normal ${normal.map(formatStlNumber).join(' ')}\n    outer loop\n${vertexLines}    endloop\n  endfacet\n`;
+    }
+
+    function wrapStl(name, facets) {
+      return `\`\`\`stl\nsolid ${name}\n${facets.join('')}endsolid ${name}\n\`\`\`\n`;
+    }
+
+    function createBoxFacets(x0, y0, z0, x1, y1, z1) {
+      const p = {
+        a: [x0, y0, z0], b: [x1, y0, z0], c: [x1, y1, z0], d: [x0, y1, z0],
+        e: [x0, y0, z1], f: [x1, y0, z1], g: [x1, y1, z1], h: [x0, y1, z1]
+      };
+      const face = (normal, v1, v2, v3, v4) => [
+        stlFacet(normal, [v1, v2, v3]),
+        stlFacet(normal, [v1, v3, v4])
+      ];
+      return [
+        ...face([0, 0, -1], p.a, p.b, p.c, p.d),
+        ...face([0, 0, 1], p.e, p.h, p.g, p.f),
+        ...face([0, -1, 0], p.a, p.e, p.f, p.b),
+        ...face([1, 0, 0], p.b, p.f, p.g, p.c),
+        ...face([0, 1, 0], p.c, p.g, p.h, p.d),
+        ...face([-1, 0, 0], p.d, p.h, p.e, p.a)
+      ];
+    }
+
+    function createSteppedBracketStl() {
+      return wrapStl('stepped_bracket_with_raised_bosses', [
+        ...createBoxFacets(-24, -12, 0, 24, 12, 4),
+        ...createBoxFacets(-18, -6, 4, 18, 6, 9),
+        ...createBoxFacets(-20, -10, 9, -8, 10, 18),
+        ...createBoxFacets(8, -10, 9, 20, 10, 18),
+        ...createBoxFacets(-5, -4, 9, 5, 4, 15)
+      ]);
+    }
+
+    function createRadialPrismStl(name, points, z0, z1) {
+      const facets = [];
+      const centerBottom = [0, 0, z0];
+      const centerTop = [0, 0, z1];
+      points.forEach((point, index) => {
+        const next = points[(index + 1) % points.length];
+        const bottomA = [point[0], point[1], z0];
+        const bottomB = [next[0], next[1], z0];
+        const topA = [point[0], point[1], z1];
+        const topB = [next[0], next[1], z1];
+        facets.push(stlFacet([0, 0, -1], [centerBottom, bottomB, bottomA]));
+        facets.push(stlFacet([0, 0, 1], [centerTop, topA, topB]));
+        facets.push(stlFacet([0, 0, 0], [bottomA, bottomB, topB]));
+        facets.push(stlFacet([0, 0, 0], [bottomA, topB, topA]));
+      });
+      return wrapStl(name, facets);
+    }
+
+    function createGearStl() {
+      const points = Array.from({ length: 24 }, (_, index) => {
+        const radius = index % 2 === 0 ? 16 : 12;
+        const angle = (Math.PI * 2 * index) / 24;
+        return [Math.cos(angle) * radius, Math.sin(angle) * radius];
+      });
+      return createRadialPrismStl('faceted_gear_wheel_24_tooth', points, 0, 5);
+    }
+
+    function createTwistedColumnStl() {
+      const sides = 8;
+      const bottom = Array.from({ length: sides }, (_, index) => {
+        const angle = (Math.PI * 2 * index) / sides;
+        return [Math.cos(angle) * 9, Math.sin(angle) * 9, 0];
+      });
+      const top = Array.from({ length: sides }, (_, index) => {
+        const angle = (Math.PI * 2 * index) / sides + Math.PI / 5;
+        return [Math.cos(angle) * 7, Math.sin(angle) * 7, 28];
+      });
+      const facets = [];
+      const bottomCenter = [0, 0, 0];
+      const topCenter = [0, 0, 28];
+      bottom.forEach((point, index) => {
+        const next = (index + 1) % sides;
+        facets.push(stlFacet([0, 0, -1], [bottomCenter, bottom[next], point]));
+        facets.push(stlFacet([0, 0, 1], [topCenter, top[index], top[next]]));
+        facets.push(stlFacet([0, 0, 0], [bottom[index], bottom[next], top[next]]));
+        facets.push(stlFacet([0, 0, 0], [bottom[index], top[next], top[index]]));
+      });
+      return wrapStl('twisted_octagonal_column', facets);
+    }
 
     const templates = [
       // Mermaid
@@ -7754,6 +7849,30 @@ ${selector} .arrowheadPath {
         label: 'Calibration Cube',
         svg: svgStlCube,
         code: '```stl\nsolid calibration_cube_20mm\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 0\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 20 0\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 20 20 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 0 20 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 20\n      vertex 20 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 0 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 20 20\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 20 20 20\n      vertex 0 20 20\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 0 20 20\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 20 20\n      vertex 0 0 20\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 0 20\n      vertex 0 0 0\n    endloop\n  endfacet\nendsolid calibration_cube_20mm\n```\n'
+      },
+      {
+        id: 'stl-stepped-bracket',
+        category: 'STL (3D)',
+        title: 'Stepped Bracket',
+        label: 'Stepped Bracket',
+        svg: svgStlBracket,
+        code: createSteppedBracketStl()
+      },
+      {
+        id: 'stl-faceted-gear',
+        category: 'STL (3D)',
+        title: 'Faceted Gear Wheel',
+        label: 'Faceted Gear Wheel',
+        svg: svgStlGear,
+        code: createGearStl()
+      },
+      {
+        id: 'stl-twisted-column',
+        category: 'STL (3D)',
+        title: 'Twisted Column',
+        label: 'Twisted Column',
+        svg: svgStlTwist,
+        code: createTwistedColumnStl()
       }
     ];
     

--- a/script.js
+++ b/script.js
@@ -6836,7 +6836,8 @@ ${selector} .arrowheadPath {
       WaveDrom: 'wavedrom',
       Markmap: 'markmap',
       Mermaid: 'mermaid',
-      'ABC Notation': 'abc'
+      'ABC Notation': 'abc',
+      'STL (3D)': 'stl'
     };
     return engines[category] || null;
   }
@@ -6938,7 +6939,7 @@ ${selector} .arrowheadPath {
     const cleanCode = getCleanCode(template.code);
     const engine = getDiagramEngineForCategory(template.category);
     try {
-      if (template.category === 'ABC Notation') {
+      if (template.category === 'ABC Notation' || template.category === 'STL (3D)') {
         callback(null);
         return;
       }
@@ -6998,15 +6999,27 @@ ${selector} .arrowheadPath {
     if (previewCode) previewCode.value = '';
     confirmBtn.disabled = true;
     
-    const categories = [
-      'Mermaid',
-      'PlantUML',
-      'Graphviz',
-      'D2',
-      'Vega-Lite',
-      'ABC Notation',
-      'WaveDrom',
-      'Markmap'
+    const categoryGroups = [
+      {
+        label: 'Diagrams',
+        categories: ['Mermaid', 'PlantUML', 'Graphviz', 'D2']
+      },
+      {
+        label: 'Mind Maps',
+        categories: ['Markmap']
+      },
+      {
+        label: 'Data Visualization',
+        categories: ['Vega-Lite']
+      },
+      {
+        label: 'Technical Notation',
+        categories: ['WaveDrom', 'ABC Notation']
+      },
+      {
+        label: '3D Models',
+        categories: ['STL (3D)']
+      }
     ];
     
     const svgFlowchart = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="45" y="15" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="31" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">Start</text><path d="M 80 41 L 80 75" stroke="#333" stroke-width="1.2" marker-end="url(#arrow-f)"/><rect x="45" y="75" width="70" height="26" fill="#f4f5f7" stroke="#673ab7" stroke-width="1.5" rx="3"/><text x="80" y="91" font-size="9" text-anchor="middle" font-family="sans-serif" fill="#333" font-weight="bold">End</text><defs><marker id="arrow-f" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs></svg>`;
@@ -7118,6 +7131,10 @@ ${selector} .arrowheadPath {
     // Markmap additional (Aesthetic: colorful mindmaps, checklist notation)
     const svgMarkmapChecklist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#ede7f6" stroke="#5e35b1" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#5e35b1" font-weight="bold">Tasks</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#5e35b1" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#5e35b1" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#5e35b1"/><circle cx="90" cy="90" r="3" fill="#5e35b1"/><text x="96" y="33" font-size="7" font-family="sans-serif">☒ Todo A</text><text x="96" y="93" font-size="7" font-family="sans-serif">☑ Todo B</text></svg>`;
     const svgMarkmapCode = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#eceff1" stroke="#455a64" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#455a64" font-weight="bold">Project</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#455a64" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#455a64" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#455a64"/><circle cx="90" cy="90" r="3" fill="#455a64"/><text x="96" y="33" font-size="7" font-family="monospace">code()</text><text x="96" y="93" font-size="7" font-family="monospace">test()</text></svg>`;
+
+    // STL (3D) local previews
+    const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
+    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><path d="M38 78 L82 32 L126 54 L82 100 Z" fill="#e0f2fe" stroke="#075985" stroke-width="2"/><path d="M82 32 L126 54 L126 76 L82 100 Z" fill="#7dd3fc" opacity="0.85" stroke="#075985" stroke-width="1.4"/><path d="M38 78 L82 100 L82 78 L58 66 Z" fill="#38bdf8" opacity="0.85" stroke="#075985" stroke-width="1.4"/><circle cx="82" cy="66" r="9" fill="#ffffff" stroke="#075985" stroke-width="2"/><text x="80" y="18" text-anchor="middle" font-size="8" font-family="monospace" fill="#075985" font-weight="bold">3D Mesh</text></svg>`;
 
     const templates = [
       // Mermaid
@@ -7702,6 +7719,24 @@ ${selector} .arrowheadPath {
         label: 'Inline Code Blocks',
         svg: svgMarkmapCode,
         code: '```markmap\n# Development\n## Languages\n- `JavaScript`\n- `Python`\n## Functions\n- `main()`\n- `helper_func()`\n```\n'
+      },
+
+      // STL (3D)
+      {
+        id: 'stl-tetrahedron',
+        category: 'STL (3D)',
+        title: 'Tetrahedron Mesh',
+        label: 'Tetrahedron Mesh',
+        svg: svgStlTetrahedron,
+        code: '```stl\nsolid tetrahedron\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 1 0 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 1\n      vertex 1 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 1 0\n      vertex 0 0 1\n    endloop\n  endfacet\n  facet normal 1 1 1\n    outer loop\n      vertex 1 0 0\n      vertex 0 0 1\n      vertex 0 1 0\n    endloop\n  endfacet\nendsolid tetrahedron\n```\n'
+      },
+      {
+        id: 'stl-triangle-panel',
+        category: 'STL (3D)',
+        title: 'Triangle Panel',
+        label: 'Triangle Panel',
+        svg: svgStlBracket,
+        code: '```stl\nsolid triangle_panel\n  facet normal 0 0 1\n    outer loop\n      vertex -1 -1 0\n      vertex 1 -1 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex -1 -1 -0.15\n      vertex 0 1 -0.15\n      vertex 1 -1 -0.15\n    endloop\n  endfacet\nendsolid triangle_panel\n```\n'
       }
     ];
     
@@ -7710,18 +7745,26 @@ ${selector} .arrowheadPath {
     
     function renderSidebar() {
       sidebar.textContent = '';
-      categories.forEach(cat => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'diagram-sidebar-btn';
-        if (cat === activeCategory) btn.classList.add('is-active');
-        btn.textContent = cat;
-        btn.addEventListener('click', () => {
-          activeCategory = cat;
-          renderSidebar();
-          renderGrid();
+      categoryGroups.forEach(group => {
+        const heading = document.createElement('div');
+        heading.className = 'diagram-sidebar-group-title';
+        heading.setAttribute('role', 'presentation');
+        heading.textContent = group.label;
+        sidebar.appendChild(heading);
+
+        group.categories.forEach(cat => {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'diagram-sidebar-btn';
+          if (cat === activeCategory) btn.classList.add('is-active');
+          btn.textContent = cat;
+          btn.addEventListener('click', () => {
+            activeCategory = cat;
+            renderSidebar();
+            renderGrid();
+          });
+          sidebar.appendChild(btn);
         });
-        sidebar.appendChild(btn);
       });
     }
     
@@ -7754,7 +7797,7 @@ ${selector} .arrowheadPath {
         const previewDiv = document.createElement('div');
         previewDiv.className = 'diagram-card-preview';
         
-        const catClass = t.category.toLowerCase().replace(/\s+/g, '');
+        const catClass = t.category.toLowerCase().replace(/[^a-z0-9]+/g, '');
 
         previewDiv.innerHTML = `
           <div style="display:flex; align-items:center; justify-content:center; width:100%; height:100%;">
@@ -7792,7 +7835,7 @@ ${selector} .arrowheadPath {
           if (previewCode) previewCode.value = t.code.trim();
           confirmBtn.disabled = false;
 
-          const catClass = t.category.toLowerCase().replace(/\s+/g, '');
+          const catClass = t.category.toLowerCase().replace(/[^a-z0-9]+/g, '');
           // Render bottom preview container with API image & fallback
           previewContainer.innerHTML = `
             <div class="diagram-svg-container diagram-svg-${catClass}" style="width:100%; height:100%; display:flex; align-items:center; justify-content:center; overflow:hidden;">

--- a/script.js
+++ b/script.js
@@ -6939,7 +6939,7 @@ ${selector} .arrowheadPath {
     const cleanCode = getCleanCode(template.code);
     const engine = getDiagramEngineForCategory(template.category);
     try {
-      if (template.category === 'ABC Notation' || template.category === 'STL (3D)') {
+      if (template.category === 'ABC Notation' || template.category === 'GeoJSON' || template.category === 'TopoJSON' || template.category === 'STL (3D)') {
         callback(null);
         return;
       }
@@ -7016,6 +7016,11 @@ ${selector} .arrowheadPath {
         categories: ['Vega-Lite']
       },
       {
+        label: 'Maps',
+        icon: 'bi-map',
+        categories: ['GeoJSON', 'TopoJSON']
+      },
+      {
         label: 'Technical Notation',
         icon: 'bi-code-slash',
         categories: ['WaveDrom', 'ABC Notation']
@@ -7034,6 +7039,8 @@ ${selector} .arrowheadPath {
       D2: 'bi-grid-3x3',
       Markmap: 'bi-diagram-2',
       'Vega-Lite': 'bi-bar-chart-line',
+      GeoJSON: 'bi-pin-map',
+      TopoJSON: 'bi-layers',
       WaveDrom: 'bi-activity',
       'ABC Notation': 'bi-music-note-beamed',
       'STL (3D)': 'bi-badge-3d'
@@ -7148,6 +7155,12 @@ ${selector} .arrowheadPath {
     // Markmap additional (Aesthetic: colorful mindmaps, checklist notation)
     const svgMarkmapChecklist = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#ede7f6" stroke="#5e35b1" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#5e35b1" font-weight="bold">Tasks</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#5e35b1" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#5e35b1" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#5e35b1"/><circle cx="90" cy="90" r="3" fill="#5e35b1"/><text x="96" y="33" font-size="7" font-family="sans-serif">☒ Todo A</text><text x="96" y="93" font-size="7" font-family="sans-serif">☑ Todo B</text></svg>`;
     const svgMarkmapCode = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="10" y="50" width="35" height="18" rx="2" fill="#eceff1" stroke="#455a64" stroke-width="1.5"/><text x="27" y="61" font-size="7" text-anchor="middle" font-family="sans-serif" fill="#455a64" font-weight="bold">Project</text><path d="M 45 59 C 65 59, 70 30, 90 30" fill="none" stroke="#455a64" stroke-width="1.5"/><path d="M 45 59 C 65 59, 70 90, 90 90" fill="none" stroke="#455a64" stroke-width="1.5"/><circle cx="90" cy="30" r="3" fill="#455a64"/><circle cx="90" cy="90" r="3" fill="#455a64"/><text x="96" y="33" font-size="7" font-family="monospace">code()</text><text x="96" y="93" font-size="7" font-family="monospace">test()</text></svg>`;
+
+    // Map local previews
+    const svgGeoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#eef6ff" stroke="#94a3b8" stroke-width="1.4"/><path d="M22 84 C40 70, 52 76, 68 58 C86 38, 104 52, 124 30" fill="none" stroke="#60a5fa" stroke-width="4" stroke-linecap="round" opacity="0.85"/><path d="M28 32 L65 24 L82 48 L60 76 L30 68 Z" fill="#bfdbfe" stroke="#2563eb" stroke-width="1.6"/><path d="M86 66 L126 56 L138 86 L102 96 Z" fill="#bbf7d0" stroke="#16a34a" stroke-width="1.6"/><circle cx="112" cy="46" r="6" fill="#ef4444" stroke="#fff" stroke-width="2"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">GeoJSON</text></svg>`;
+    const svgTopoJsonMap = `<svg viewBox="0 0 160 120" width="100%" height="100%"><rect x="12" y="12" width="136" height="96" rx="6" fill="#f8fafc" stroke="#94a3b8" stroke-width="1.4"/><path d="M30 30 L68 24 L86 52 L58 84 L26 70 Z" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.6"/><path d="M86 30 L126 38 L134 78 L104 94 L82 66 Z" fill="#dcfce7" stroke="#15803d" stroke-width="1.6"/><path d="M68 24 L86 52 L82 66" fill="none" stroke="#f59e0b" stroke-width="2.6" stroke-dasharray="4 3"/><circle cx="68" cy="24" r="3" fill="#f59e0b"/><circle cx="86" cy="52" r="3" fill="#f59e0b"/><circle cx="82" cy="66" r="3" fill="#f59e0b"/><text x="80" y="112" text-anchor="middle" font-size="8" font-family="monospace" fill="#334155" font-weight="bold">TopoJSON</text></svg>`;
+    const geoJsonMapCode = '```geojson\n{\n  "type": "FeatureCollection",\n  "features": [\n    {\n      "type": "Feature",\n      "properties": { "name": "Demo district" },\n      "geometry": {\n        "type": "Polygon",\n        "coordinates": [[\n          [-122.45, 37.76],\n          [-122.41, 37.76],\n          [-122.40, 37.79],\n          [-122.44, 37.80],\n          [-122.45, 37.76]\n        ]]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Walking route" },\n      "geometry": {\n        "type": "LineString",\n        "coordinates": [\n          [-122.45, 37.77],\n          [-122.43, 37.78],\n          [-122.41, 37.79]\n        ]\n      }\n    },\n    {\n      "type": "Feature",\n      "properties": { "name": "Meeting point" },\n      "geometry": {\n        "type": "Point",\n        "coordinates": [-122.42, 37.785]\n      }\n    }\n  ]\n}\n```\n';
+    const topoJsonMapCode = '```topojson\n{\n  "type": "Topology",\n  "transform": {\n    "scale": [0.01, 0.01],\n    "translate": [-122.45, 37.76]\n  },\n  "objects": {\n    "districts": {\n      "type": "GeometryCollection",\n      "geometries": [\n        {\n          "type": "Polygon",\n          "properties": { "name": "North zone" },\n          "arcs": [[0]]\n        },\n        {\n          "type": "Polygon",\n          "properties": { "name": "South zone" },\n          "arcs": [[1]]\n        }\n      ]\n    }\n  },\n  "arcs": [\n    [[0, 0], [4, 0], [0, 3], [-4, 0], [0, -3]],\n    [[4, 0], [4, 0], [0, 3], [-4, 0], [0, -3]]\n  ]\n}\n```\n';
 
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
@@ -7883,6 +7896,24 @@ ${selector} .arrowheadPath {
         label: 'Inline Code Blocks',
         svg: svgMarkmapCode,
         code: '```markmap\n# Development\n## Languages\n- `JavaScript`\n- `Python`\n## Functions\n- `main()`\n- `helper_func()`\n```\n'
+      },
+
+      // Maps
+      {
+        id: 'geojson-feature-collection',
+        category: 'GeoJSON',
+        title: 'Feature Collection Map',
+        label: 'Feature Collection Map',
+        svg: svgGeoJsonMap,
+        code: geoJsonMapCode
+      },
+      {
+        id: 'topojson-topology',
+        category: 'TopoJSON',
+        title: 'Topology Map',
+        label: 'Topology Map',
+        svg: svgTopoJsonMap,
+        code: topoJsonMapCode
       },
 
       // STL (3D)

--- a/script.js
+++ b/script.js
@@ -1990,6 +1990,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   function normalizeDiagramSvg(node, engine, source) {
     const svg = node ? node.querySelector('svg') : null;
     if (!svg) return null;
+    if (engine === 'wavedrom') isolateWaveDromSvgStyles(svg);
 
     let intrinsicWidth = 0;
     let intrinsicHeight = 0;
@@ -2031,6 +2032,43 @@ document.addEventListener("DOMContentLoaded", async function () {
     svg.style.maxWidth = '100%';
     svg.style.maxHeight = 'min(70vh, 720px)';
     return svg;
+  }
+
+  function isolateWaveDromSvgStyles(svg) {
+    if (svg.getAttribute('data-wavedrom-style-scoped') === 'true') return;
+    let scopeId = svg.getAttribute('data-wavedrom-style-scope');
+    if (!scopeId) {
+      scopeId = `wavedrom-${Math.random().toString(36).slice(2, 10)}`;
+      svg.setAttribute('data-wavedrom-style-scope', scopeId);
+    }
+
+    const classMap = new Map();
+    const getScopedClass = className => {
+      if (!classMap.has(className)) {
+        classMap.set(className, `wd-${scopeId}-${className}`);
+      }
+      return classMap.get(className);
+    };
+
+    svg.querySelectorAll('[class]').forEach(element => {
+      const classes = (element.getAttribute('class') || '').trim().split(/\s+/).filter(Boolean);
+      if (classes.length) {
+        element.setAttribute('class', classes.map(getScopedClass).join(' '));
+      }
+    });
+
+    svg.querySelectorAll('style').forEach(style => {
+      const css = style.textContent || '';
+      style.textContent = scopeWaveDromStyleClasses(css, getScopedClass);
+      style.setAttribute('data-wavedrom-style-scoped', 'true');
+    });
+    svg.setAttribute('data-wavedrom-style-scoped', 'true');
+  }
+
+  function scopeWaveDromStyleClasses(css, getScopedClass) {
+    return css.replace(/\.([A-Za-z_-][A-Za-z0-9_-]*)/g, (match, className) => {
+      return `.${getScopedClass(className)}`;
+    });
   }
 
   function getDiagramFailureMessage(engine, error) {

--- a/script.js
+++ b/script.js
@@ -7910,20 +7910,20 @@ ${selector} .arrowheadPath {
         code: geoJsonPointCode
       },
       {
-        id: 'geojson-feature-collection',
-        category: 'GeoJSON',
-        title: 'Feature Collection Map',
-        label: 'Feature Collection Map',
-        svg: svgGeoJsonMap,
-        code: geoJsonMapCode
-      },
-      {
         id: 'topojson-landmark-point',
         category: 'TopoJSON',
         title: 'Landmark Point',
         label: 'Landmark Point',
         svg: svgTopoJsonMap,
         code: topoJsonPointCode
+      },
+      {
+        id: 'geojson-feature-collection',
+        category: 'GeoJSON',
+        title: 'Feature Collection Map',
+        label: 'Feature Collection Map',
+        svg: svgGeoJsonMap,
+        code: geoJsonMapCode
       },
       {
         id: 'topojson-topology',

--- a/script.js
+++ b/script.js
@@ -7134,7 +7134,7 @@ ${selector} .arrowheadPath {
 
     // STL (3D) local previews
     const svgStlTetrahedron = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="80,18 34,90 126,90" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/><polygon points="80,18 34,90 80,70" fill="#93c5fd" opacity="0.85"/><polygon points="80,18 126,90 80,70" fill="#60a5fa" opacity="0.85"/><polygon points="34,90 126,90 80,70" fill="#1d4ed8" opacity="0.75"/><line x1="80" y1="18" x2="80" y2="70" stroke="#1e40af" stroke-width="1.5"/><text x="80" y="108" text-anchor="middle" font-size="9" font-family="monospace" fill="#1e3a8a" font-weight="bold">STL</text></svg>`;
-    const svgStlBracket = `<svg viewBox="0 0 160 120" width="100%" height="100%"><path d="M38 78 L82 32 L126 54 L82 100 Z" fill="#e0f2fe" stroke="#075985" stroke-width="2"/><path d="M82 32 L126 54 L126 76 L82 100 Z" fill="#7dd3fc" opacity="0.85" stroke="#075985" stroke-width="1.4"/><path d="M38 78 L82 100 L82 78 L58 66 Z" fill="#38bdf8" opacity="0.85" stroke="#075985" stroke-width="1.4"/><circle cx="82" cy="66" r="9" fill="#ffffff" stroke="#075985" stroke-width="2"/><text x="80" y="18" text-anchor="middle" font-size="8" font-family="monospace" fill="#075985" font-weight="bold">3D Mesh</text></svg>`;
+    const svgStlCube = `<svg viewBox="0 0 160 120" width="100%" height="100%"><polygon points="58,24 118,44 88,62 28,42" fill="#dbeafe" stroke="#2563eb" stroke-width="1.8"/><polygon points="28,42 88,62 88,100 28,80" fill="#93c5fd" stroke="#2563eb" stroke-width="1.8"/><polygon points="88,62 118,44 118,82 88,100" fill="#60a5fa" stroke="#2563eb" stroke-width="1.8"/><line x1="58" y1="24" x2="58" y2="62" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="28" y2="80" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><line x1="58" y1="62" x2="118" y2="82" stroke="#1d4ed8" stroke-width="1.4" stroke-dasharray="3 3"/><text x="80" y="16" text-anchor="middle" font-size="8" font-family="monospace" fill="#1e3a8a" font-weight="bold">20 mm cube</text></svg>`;
 
     const templates = [
       // Mermaid
@@ -7731,12 +7731,12 @@ ${selector} .arrowheadPath {
         code: '```stl\nsolid tetrahedron\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 1 0 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 1\n      vertex 1 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 1 0\n      vertex 0 0 1\n    endloop\n  endfacet\n  facet normal 1 1 1\n    outer loop\n      vertex 1 0 0\n      vertex 0 0 1\n      vertex 0 1 0\n    endloop\n  endfacet\nendsolid tetrahedron\n```\n'
       },
       {
-        id: 'stl-triangle-panel',
+        id: 'stl-calibration-cube',
         category: 'STL (3D)',
-        title: 'Triangle Panel',
-        label: 'Triangle Panel',
-        svg: svgStlBracket,
-        code: '```stl\nsolid triangle_panel\n  facet normal 0 0 1\n    outer loop\n      vertex -1 -1 0\n      vertex 1 -1 0\n      vertex 0 1 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex -1 -1 -0.15\n      vertex 0 1 -0.15\n      vertex 1 -1 -0.15\n    endloop\n  endfacet\nendsolid triangle_panel\n```\n'
+        title: 'Calibration Cube',
+        label: 'Calibration Cube',
+        svg: svgStlCube,
+        code: '```stl\nsolid calibration_cube_20mm\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 0\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 0 -1\n    outer loop\n      vertex 0 0 0\n      vertex 20 20 0\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 20 20 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 20\n      vertex 0 20 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 0 0 20\n      vertex 20 0 20\n    endloop\n  endfacet\n  facet normal 0 -1 0\n    outer loop\n      vertex 0 0 0\n      vertex 20 0 20\n      vertex 20 0 0\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 0 20\n      vertex 20 20 20\n    endloop\n  endfacet\n  facet normal 1 0 0\n    outer loop\n      vertex 20 0 0\n      vertex 20 20 20\n      vertex 20 20 0\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 20 20 20\n      vertex 0 20 20\n    endloop\n  endfacet\n  facet normal 0 1 0\n    outer loop\n      vertex 20 20 0\n      vertex 0 20 20\n      vertex 0 20 0\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 20 20\n      vertex 0 0 20\n    endloop\n  endfacet\n  facet normal -1 0 0\n    outer loop\n      vertex 0 20 0\n      vertex 0 0 20\n      vertex 0 0 0\n    endloop\n  endfacet\nendsolid calibration_cube_20mm\n```\n'
       }
     ];
     
@@ -7746,11 +7746,14 @@ ${selector} .arrowheadPath {
     function renderSidebar() {
       sidebar.textContent = '';
       categoryGroups.forEach(group => {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'diagram-sidebar-group';
+
         const heading = document.createElement('div');
         heading.className = 'diagram-sidebar-group-title';
         heading.setAttribute('role', 'presentation');
         heading.textContent = group.label;
-        sidebar.appendChild(heading);
+        groupEl.appendChild(heading);
 
         group.categories.forEach(cat => {
           const btn = document.createElement('button');
@@ -7763,8 +7766,10 @@ ${selector} .arrowheadPath {
             renderSidebar();
             renderGrid();
           });
-          sidebar.appendChild(btn);
+          groupEl.appendChild(btn);
         });
+
+        sidebar.appendChild(groupEl);
       });
     }
     

--- a/script.js
+++ b/script.js
@@ -7195,7 +7195,7 @@ ${selector} .arrowheadPath {
       const tangentSeed = Math.abs(normal[2]) > 0.82 ? [1, 0, 0] : [0, 0, 1];
       const u = normalizeVector(crossVectors(normal, tangentSeed));
       const v = normalizeVector(crossVectors(normal, u));
-      const baseCenter = scaleVector(normal, bodyRadius);
+      const baseCenter = scaleVector(normal, bodyRadius - 1.4);
       const tip = scaleVector(normal, bodyRadius + spikeLength);
       const ring = Array.from({ length: segments }, (_, index) => {
         const angle = (Math.PI * 2 * index) / segments;
@@ -7244,7 +7244,7 @@ ${selector} .arrowheadPath {
         [1, 1, -1], [-1, 1, -1], [1, -1, -1], [-1, -1, -1]
       ];
       spikeDirections.forEach(direction => {
-        facets.push(...createConeSpikeFacets(direction, 2.2, 10, 6, 6));
+        facets.push(...createConeSpikeFacets(direction, 2.8, 10, 6, 6));
       });
 
       return wrapStl('spiked_round_ball', facets);

--- a/styles.css
+++ b/styles.css
@@ -5454,27 +5454,21 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-modal-sidebar {
-  width: 260px;
-  margin: 16px 0 16px 16px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-color);
-  padding: 0;
+  width: 228px;
+  border-right: 1px solid var(--border-color);
+  background: var(--header-bg);
+  padding: 10px 8px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 6px;
   flex-shrink: 0;
 }
 
 .diagram-sidebar-group {
   display: flex;
   flex-direction: column;
-  border-top: 1px solid var(--border-color);
-}
-
-.diagram-sidebar-group:first-child {
-  border-top: none;
+  gap: 2px;
 }
 
 .diagram-sidebar-group-header,
@@ -5484,27 +5478,27 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   background: transparent;
   color: var(--text-color);
   cursor: pointer;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   text-align: left;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .diagram-sidebar-group-header {
   display: grid;
-  grid-template-columns: 24px 1fr 18px;
+  grid-template-columns: 18px 1fr 16px;
   align-items: center;
-  gap: 12px;
-  min-height: 62px;
-  padding: 0 18px;
-  font-weight: 500;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 10px;
+  border-radius: 6px;
+  font-weight: 600;
 }
 
 .diagram-sidebar-group-header:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
+  background-color: var(--button-hover);
 }
 
 .diagram-sidebar-group-icon,
-.diagram-sidebar-item-icon,
 .diagram-sidebar-chevron {
   display: inline-flex;
   align-items: center;
@@ -5513,21 +5507,21 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-sidebar-group-icon {
-  color: var(--text-color);
-  font-size: 1.1rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
 }
 
 .diagram-sidebar-chevron {
   justify-self: end;
-  color: var(--text-muted, #6b7280);
-  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
 }
 
 .diagram-sidebar-items {
   display: none;
   flex-direction: column;
-  gap: 4px;
-  padding: 0 12px 12px;
+  gap: 2px;
+  padding: 1px 0 5px 12px;
 }
 
 .diagram-sidebar-group.is-expanded .diagram-sidebar-items {
@@ -5537,31 +5531,37 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
-  gap: 14px;
-  min-height: 50px;
-  padding: 0 16px 0 20px;
-  border-radius: 7px;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 9px;
+  border-radius: 6px;
   font-weight: 500;
 }
 
 .diagram-sidebar-btn:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
+  background-color: var(--button-hover);
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 13%, transparent);
+  background-color: var(--button-hover);
   color: var(--accent-color, #0076ff);
-  font-weight: 650;
+  font-weight: 600;
+  box-shadow: inset 3px 0 0 var(--accent-color, #0076ff);
 }
 
-.diagram-sidebar-btn.is-active .diagram-sidebar-item-icon {
-  color: var(--accent-color, #0076ff);
+.diagram-sidebar-item-dot {
+  width: 6px;
+  height: 6px;
+  border: 1px solid var(--text-secondary);
+  border-radius: 50%;
+  flex: 0 0 auto;
+  opacity: 0.75;
 }
 
-.diagram-sidebar-item-icon {
-  width: 22px;
-  color: var(--text-muted, #6b7280);
-  font-size: 1.05rem;
+.diagram-sidebar-btn.is-active .diagram-sidebar-item-dot {
+  background: var(--accent-color, #0076ff);
+  border-color: var(--accent-color, #0076ff);
+  opacity: 1;
 }
 
 .diagram-modal-content {
@@ -5817,12 +5817,9 @@ html[data-theme="dark"] .diagram-preview-container {
   .diagram-modal-sidebar {
     width: 100%;
     height: 60px;
-    margin: 0;
     flex-direction: row;
     border-right: none;
     border-bottom: 1px solid var(--border-color);
-    border-left: none;
-    border-radius: 0;
     padding: 8px;
     gap: 6px;
   }

--- a/styles.css
+++ b/styles.css
@@ -5454,7 +5454,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-modal-sidebar {
-  width: 228px;
+  width: 244px;
   border-right: 1px solid var(--border-color);
   background: var(--header-bg);
   padding: 10px 8px;
@@ -5492,6 +5492,14 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   padding: 0 10px;
   border-radius: 6px;
   font-weight: 400;
+}
+
+.diagram-sidebar-group-header span,
+.diagram-sidebar-btn span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .diagram-sidebar-group-header:hover {

--- a/styles.css
+++ b/styles.css
@@ -5468,7 +5468,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 .diagram-sidebar-group {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
 }
 
 .diagram-sidebar-group-header,
@@ -5490,7 +5490,9 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   gap: 8px;
   min-height: 38px;
   padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
   border-radius: 6px;
+  background-color: color-mix(in srgb, var(--text-color) 3%, transparent);
   font-weight: 400;
 }
 
@@ -5503,7 +5505,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-sidebar-group-header:hover {
-  background-color: var(--button-hover);
+  background-color: color-mix(in srgb, var(--button-hover) 72%, transparent);
 }
 
 .diagram-sidebar-group-icon,
@@ -5529,8 +5531,10 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 .diagram-sidebar-items {
   display: none;
   flex-direction: column;
-  gap: 2px;
-  padding: 1px 0 5px 12px;
+  gap: 3px;
+  margin: 1px 0 6px 17px;
+  padding: 2px 0 4px 10px;
+  border-left: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
 }
 
 .diagram-sidebar-group.is-expanded .diagram-sidebar-items {
@@ -5541,9 +5545,11 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 34px;
-  padding: 0 9px;
+  min-height: 32px;
+  padding: 0 9px 0 8px;
   border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
   font-weight: 400;
 }
 
@@ -5560,7 +5566,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 .diagram-sidebar-item-icon {
   width: 18px;
   color: var(--text-secondary);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   flex: 0 0 auto;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -5464,6 +5464,20 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   flex-shrink: 0;
 }
 
+.diagram-sidebar-group-title {
+  padding: 14px 14px 5px;
+  color: var(--text-muted, #6b7280);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.diagram-sidebar-group-title:first-child {
+  padding-top: 2px;
+}
+
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
@@ -5746,6 +5760,10 @@ html[data-theme="dark"] .diagram-preview-container {
     border-right: none;
     border-bottom: 1px solid var(--border-color);
     padding: 8px;
+  }
+
+  .diagram-sidebar-group-title {
+    display: none;
   }
 
   .diagram-modal-box {

--- a/styles.css
+++ b/styles.css
@@ -5456,33 +5456,34 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 .diagram-modal-sidebar {
   width: 220px;
   border-right: 1px solid var(--border-color);
-  padding: 16px 8px;
+  padding: 14px 10px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 14px;
   flex-shrink: 0;
 }
 
-.diagram-sidebar-group-title {
-  padding: 14px 14px 5px;
-  color: var(--text-muted, #6b7280);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  line-height: 1.2;
-  text-transform: uppercase;
+.diagram-sidebar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
-.diagram-sidebar-group-title:first-child {
-  padding-top: 2px;
+.diagram-sidebar-group-title {
+  padding: 0 10px 4px;
+  color: var(--text-muted, #6b7280);
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.2;
 }
 
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 9px 12px;
   border: none;
   background: transparent;
   color: var(--text-color);
@@ -5495,12 +5496,13 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-sidebar-btn:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.1));
+  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.08));
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: var(--accent-color, #0076ff);
-  color: #fff;
+  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 12%, transparent);
+  color: var(--accent-color, #0076ff);
+  font-weight: 650;
 }
 
 .diagram-modal-content {
@@ -5764,6 +5766,10 @@ html[data-theme="dark"] .diagram-preview-container {
 
   .diagram-sidebar-group-title {
     display: none;
+  }
+
+  .diagram-sidebar-group {
+    display: contents;
   }
 
   .diagram-modal-box {

--- a/styles.css
+++ b/styles.css
@@ -5454,55 +5454,114 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-modal-sidebar {
-  width: 220px;
-  border-right: 1px solid var(--border-color);
-  padding: 14px 10px;
+  width: 260px;
+  margin: 16px 0 16px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-color);
+  padding: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 0;
   flex-shrink: 0;
 }
 
 .diagram-sidebar-group {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  border-top: 1px solid var(--border-color);
 }
 
-.diagram-sidebar-group-title {
-  padding: 0 10px 4px;
+.diagram-sidebar-group:first-child {
+  border-top: none;
+}
+
+.diagram-sidebar-group-header,
+.diagram-sidebar-btn {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 0.95rem;
+  text-align: left;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.diagram-sidebar-group-header {
+  display: grid;
+  grid-template-columns: 24px 1fr 18px;
+  align-items: center;
+  gap: 12px;
+  min-height: 62px;
+  padding: 0 18px;
+  font-weight: 500;
+}
+
+.diagram-sidebar-group-header:hover {
+  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
+}
+
+.diagram-sidebar-group-icon,
+.diagram-sidebar-item-icon,
+.diagram-sidebar-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.diagram-sidebar-group-icon {
+  color: var(--text-color);
+  font-size: 1.1rem;
+}
+
+.diagram-sidebar-chevron {
+  justify-self: end;
   color: var(--text-muted, #6b7280);
-  font-size: 0.76rem;
-  font-weight: 600;
-  letter-spacing: 0;
-  line-height: 1.2;
+  font-size: 0.85rem;
+}
+
+.diagram-sidebar-items {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 12px 12px;
+}
+
+.diagram-sidebar-group.is-expanded .diagram-sidebar-items {
+  display: flex;
 }
 
 .diagram-sidebar-btn {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 9px 12px;
-  border: none;
-  background: transparent;
-  color: var(--text-color);
-  text-align: left;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.9rem;
+  gap: 14px;
+  min-height: 50px;
+  padding: 0 16px 0 20px;
+  border-radius: 7px;
   font-weight: 500;
-  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .diagram-sidebar-btn:hover {
-  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.08));
+  background-color: var(--button-hover-bg, rgba(120, 120, 120, 0.06));
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 12%, transparent);
+  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 13%, transparent);
   color: var(--accent-color, #0076ff);
   font-weight: 650;
+}
+
+.diagram-sidebar-btn.is-active .diagram-sidebar-item-icon {
+  color: var(--accent-color, #0076ff);
+}
+
+.diagram-sidebar-item-icon {
+  width: 22px;
+  color: var(--text-muted, #6b7280);
+  font-size: 1.05rem;
 }
 
 .diagram-modal-content {
@@ -5750,7 +5809,7 @@ html[data-theme="dark"] .diagram-preview-container {
   display: none !important;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 640px) {
   .diagram-modal-body {
     flex-direction: column;
   }
@@ -5758,18 +5817,33 @@ html[data-theme="dark"] .diagram-preview-container {
   .diagram-modal-sidebar {
     width: 100%;
     height: 60px;
+    margin: 0;
     flex-direction: row;
     border-right: none;
     border-bottom: 1px solid var(--border-color);
+    border-left: none;
+    border-radius: 0;
     padding: 8px;
+    gap: 6px;
   }
 
-  .diagram-sidebar-group-title {
+  .diagram-sidebar-group-header {
     display: none;
   }
 
   .diagram-sidebar-group {
     display: contents;
+  }
+
+  .diagram-sidebar-items {
+    display: contents;
+  }
+
+  .diagram-sidebar-btn {
+    width: auto;
+    min-height: 36px;
+    flex-shrink: 0;
+    padding: 0 12px;
   }
 
   .diagram-modal-box {

--- a/styles.css
+++ b/styles.css
@@ -5491,7 +5491,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   min-height: 38px;
   padding: 0 10px;
   border-radius: 6px;
-  font-weight: 600;
+  font-weight: 400;
 }
 
 .diagram-sidebar-group-header:hover {
@@ -5499,6 +5499,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-sidebar-group-icon,
+.diagram-sidebar-item-icon,
 .diagram-sidebar-chevron {
   display: inline-flex;
   align-items: center;
@@ -5535,7 +5536,7 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
   min-height: 34px;
   padding: 0 9px;
   border-radius: 6px;
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .diagram-sidebar-btn:hover {
@@ -5543,25 +5544,20 @@ html[data-theme="dark"] .d2-diagram>svg:not([data-diagram-native-dark="true"]) {
 }
 
 .diagram-sidebar-btn.is-active {
-  background-color: var(--button-hover);
+  background-color: color-mix(in srgb, var(--accent-color, #0076ff) 14%, transparent);
   color: var(--accent-color, #0076ff);
-  font-weight: 600;
-  box-shadow: inset 3px 0 0 var(--accent-color, #0076ff);
+  font-weight: 400;
 }
 
-.diagram-sidebar-item-dot {
-  width: 6px;
-  height: 6px;
-  border: 1px solid var(--text-secondary);
-  border-radius: 50%;
+.diagram-sidebar-item-icon {
+  width: 18px;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
   flex: 0 0 auto;
-  opacity: 0.75;
 }
 
-.diagram-sidebar-btn.is-active .diagram-sidebar-item-dot {
-  background: var(--accent-color, #0076ff);
-  border-color: var(--accent-color, #0076ff);
-  opacity: 1;
+.diagram-sidebar-btn.is-active .diagram-sidebar-item-icon {
+  color: var(--accent-color, #0076ff);
 }
 
 .diagram-modal-content {


### PR DESCRIPTION
## Summary
- Group the Insert Diagram sidebar into Diagrams, Mind Maps, Data Visualization, Technical Notation, and 3D Models sections.
- Reorder existing diagram categories to match the requested grouping.
- Add STL (3D) templates and local previews so the new 3D Models category has usable entries.

## Validation
- `node --check script.js`
- `node --check desktop-app\resources\js\script.js`
- `git diff --check`
- Verified the Insert Diagram modal order in the in-app browser at `http://127.0.0.1:4173/index.html`.
