### PR TITLE
feat(sync): add Find Section navigation between editor and preview

### DIFF
--- a/desktop-app/resources/js/preview-worker.js
+++ b/desktop-app/resources/js/preview-worker.js
@@ -566,7 +566,7 @@ function splitMarkdownBlocks(markdown) {
     }
 
     if (!inFence && !inMathBlock && trimmed === "") {
-      flush(lineNumber);
+      flush(lineNumber - 1);
       startLine = lineNumber + 1;
       continue;
     }

--- a/index.html
+++ b/index.html
@@ -542,6 +542,9 @@
             <div class="find-replace-meta-row">
               <span id="find-replace-count" class="find-match-count" role="status" aria-live="polite">0 of 0 matches</span>
               <div class="find-nav-group">
+                <button type="button" class="find-section-btn" id="find-section" title="Click content in the editor or preview to locate the matching section." aria-label="Find Section: click content in the editor or preview to locate the matching section" aria-pressed="false">
+                  Find Section
+                </button>
                 <button type="button" class="find-nav-arrow-btn" id="find-prev" title="Previous match (Shift+Enter)" aria-label="Previous match" disabled>
                   <i class="bi bi-chevron-up"></i>
                 </button>

--- a/preview-worker.js
+++ b/preview-worker.js
@@ -566,7 +566,7 @@ function splitMarkdownBlocks(markdown) {
     }
 
     if (!inFence && !inMathBlock && trimmed === "") {
-      flush(lineNumber);
+      flush(lineNumber - 1);
       startLine = lineNumber + 1;
       continue;
     }

--- a/script.js
+++ b/script.js
@@ -271,6 +271,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   let lastFindQuery = '';
   let isSectionPickMode = false;
   let sectionLocateMessageTimer = null;
+  let sectionPickEditorMouseDown = null;
 
   // Custom Editor History State Manager variables
   const tabHistories = {};
@@ -9357,7 +9358,7 @@ ${selector} .arrowheadPath {
       }
 
       if (!inFence && !inMathBlock && trimmed === '') {
-        flush(lineNumber);
+        flush(lineNumber - 1);
         startLine = lineNumber + 1;
         continue;
       }
@@ -9436,7 +9437,11 @@ ${selector} .arrowheadPath {
     return null;
   }
 
-  function getPickedEditorSourceRange(event) {
+  function getPickedEditorSourceRange(event, preferSelection) {
+    if (!preferSelection) {
+      return getEditorSourceRangeFromMouseEvent(event) || getMarkdownSourceBlockAroundLine(getLineNumberForIndex(markdownEditor.selectionStart || 0));
+    }
+
     const selectionStart = markdownEditor.selectionStart || 0;
     const selectionEnd = markdownEditor.selectionEnd || selectionStart;
     const selectedText = selectionEnd > selectionStart ? markdownEditor.value.slice(selectionStart, selectionEnd) : '';
@@ -9617,8 +9622,8 @@ ${selector} .arrowheadPath {
     }, 2300);
   }
 
-  function locateSectionFromEditorPick(event) {
-    const sourceRange = getPickedEditorSourceRange(event);
+  function locateSectionFromEditorPick(event, preferSelection) {
+    const sourceRange = getPickedEditorSourceRange(event, preferSelection);
     if (!sourceRange) {
       showSectionLocateMessage('Matching section not found.');
       return false;
@@ -10944,17 +10949,39 @@ ${selector} .arrowheadPath {
   markdownEditor.addEventListener('keydown', updateLastCursor);
   markdownEditor.addEventListener('keyup', updateLastCursor);
   markdownEditor.addEventListener('mousedown', updateLastCursor);
+  markdownEditor.addEventListener('mousedown', function(event) {
+    if (!isSectionPickMode) {
+      sectionPickEditorMouseDown = null;
+      return;
+    }
+    sectionPickEditorMouseDown = {
+      clientX: event.clientX,
+      clientY: event.clientY,
+      selectionStart: markdownEditor.selectionStart || 0,
+      selectionEnd: markdownEditor.selectionEnd || 0,
+    };
+  });
   markdownEditor.addEventListener('mouseup', updateLastCursor);
   markdownEditor.addEventListener('mouseup', function(event) {
     if (!isSectionPickMode) return;
     event.preventDefault();
     event.stopPropagation();
+    const start = sectionPickEditorMouseDown;
+    sectionPickEditorMouseDown = null;
+    const moved = start
+      ? Math.abs(event.clientX - start.clientX) > 4 || Math.abs(event.clientY - start.clientY) > 4
+      : false;
+    const selectionStart = markdownEditor.selectionStart || 0;
+    const selectionEnd = markdownEditor.selectionEnd || selectionStart;
+    const hasSelection = selectionEnd > selectionStart && (markdownEditor.value || '').slice(selectionStart, selectionEnd).trim().length > 0;
+    const selectionChanged = Boolean(start && (selectionStart !== start.selectionStart || selectionEnd !== start.selectionEnd));
+    const preferSelection = hasSelection && (moved || selectionChanged);
     const pickEvent = {
       clientX: event.clientX,
       clientY: event.clientY,
     };
     setTimeout(function() {
-      locateSectionFromEditorPick(pickEvent);
+      locateSectionFromEditorPick(pickEvent, preferSelection);
     }, 0);
   });
   markdownEditor.addEventListener('focus', updateLastCursor);

--- a/script.js
+++ b/script.js
@@ -269,6 +269,8 @@ document.addEventListener("DOMContentLoaded", async function () {
   let findMatches = [];
   let activeFindIndex = -1;
   let lastFindQuery = '';
+  let isSectionPickMode = false;
+  let sectionLocateMessageTimer = null;
 
   // Custom Editor History State Manager variables
   const tabHistories = {};
@@ -459,6 +461,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const findReplaceModal = document.getElementById("find-replace-modal");
   const findReplaceInput = document.getElementById("find-replace-input");
   const findReplaceWith = document.getElementById("find-replace-with");
+  const findSectionButton = document.getElementById("find-section");
   const findReplaceCount = document.getElementById("find-replace-count");
   const findReplacePrev = document.getElementById("find-prev");
   const findReplaceNext = document.getElementById("find-next");
@@ -855,8 +858,13 @@ document.addEventListener("DOMContentLoaded", async function () {
         previewSegmentHtmlCache.set(cacheKey, sanitizedBlock);
       }
       const blockId = block.id || `preview-block-${index}`;
+      const sourceStart = Number(block.startLine) || 0;
+      const sourceEnd = Number(block.endLine) || sourceStart;
+      const sourceAttrs = sourceStart > 0
+        ? ` data-source-line="${sourceStart}" data-source-start="${sourceStart}" data-source-end="${Math.max(sourceStart, sourceEnd)}"`
+        : '';
       htmlParts.push(
-        `<section class="preview-render-block" style="content-visibility: auto; contain-intrinsic-size: auto 220px;" data-preview-block-id="${escapeHtmlAttribute(blockId)}" data-preview-block-hash="${escapeHtmlAttribute(cacheKey)}">${sanitizedBlock}</section>`
+        `<section class="preview-render-block" style="content-visibility: auto; contain-intrinsic-size: auto 220px;" data-preview-block-id="${escapeHtmlAttribute(blockId)}" data-preview-block-hash="${escapeHtmlAttribute(cacheKey)}"${sourceAttrs}>${sanitizedBlock}</section>`
       );
     });
 
@@ -2896,6 +2904,9 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function switchTab(tabId) {
     if (tabId === activeTabId) return;
+    if (isSectionPickMode) {
+      setSectionPickMode(false);
+    }
     saveCurrentTabState();
     
     // Clear typing timeout and reset tracking for the new tab
@@ -2942,6 +2953,9 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function closeTab(tabId) {
+    if (isSectionPickMode) {
+      setSectionPickMode(false);
+    }
     if (liveCollaboration && liveCollaboration.tabId === tabId) {
       if (liveCollaboration.isHost) {
         endLiveSessionForEveryone();
@@ -4845,6 +4859,7 @@ ${selector} .arrowheadPath {
 
     previewSegmentHtmlCache.clear();
     const patchResult = commitPreviewHtml(sanitizedHtml, referenceData, rawVal, context);
+    applySourceRangesToRenderedPreview(rawVal);
     postProcessPreview(rawVal, context, patchResult);
   }
 
@@ -5686,6 +5701,9 @@ ${selector} .arrowheadPath {
       announceToScreenReader(getEditorReadOnlyMessage());
     }
     if (mode === currentViewMode) return;
+    if (isSectionPickMode) {
+      setSectionPickMode(false);
+    }
 
     const previousMode = currentViewMode;
     currentViewMode = mode;
@@ -9265,6 +9283,371 @@ ${selector} .arrowheadPath {
     syncEditorScrollOverlays();
   }
 
+  function setSectionPickMode(active, message) {
+    isSectionPickMode = Boolean(active);
+    if (findSectionButton) {
+      findSectionButton.classList.toggle('active', isSectionPickMode);
+      findSectionButton.setAttribute('aria-pressed', isSectionPickMode ? 'true' : 'false');
+    }
+    document.body.classList.toggle('section-pick-active', isSectionPickMode);
+    if (isSectionPickMode) {
+      announceToScreenReader('Find Section active. Click content in the editor or preview.');
+    } else if (message !== false) {
+      announceToScreenReader(message || 'Find Section canceled.');
+    }
+  }
+
+  function showSectionLocateMessage(message) {
+    announceToScreenReader(message);
+    const oldToast = document.querySelector('.section-locate-toast');
+    if (oldToast) oldToast.remove();
+    const toast = document.createElement('div');
+    toast.className = 'section-locate-toast';
+    toast.setAttribute('role', 'status');
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    if (sectionLocateMessageTimer) clearTimeout(sectionLocateMessageTimer);
+    sectionLocateMessageTimer = setTimeout(function() {
+      sectionLocateMessageTimer = null;
+      toast.remove();
+    }, 2400);
+  }
+
+  function getLineNumberForIndex(index) {
+    return countLinesBeforeIndex(markdownEditor.value || '', index) + 1;
+  }
+
+  function splitMarkdownSourceBlocksForLocate(markdown) {
+    const lines = String(markdown || '').replace(/\r\n/g, '\n').split('\n');
+    const blocks = [];
+    let buffer = [];
+    let startLine = 1;
+    let inFence = false;
+    let fenceChar = '';
+    let fenceLength = 0;
+    let inMathBlock = false;
+
+    function flush(endLine) {
+      const source = buffer.join('\n').trimEnd();
+      if (source.trim()) {
+        blocks.push({ source, startLine, endLine });
+      }
+      buffer = [];
+    }
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      const lineNumber = index + 1;
+      const trimmed = line.trim();
+      const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+
+      if (fenceMatch) {
+        const marker = fenceMatch[1];
+        if (!inFence) {
+          inFence = true;
+          fenceChar = marker[0];
+          fenceLength = marker.length;
+        } else if (marker[0] === fenceChar && marker.length >= fenceLength) {
+          inFence = false;
+        }
+      }
+
+      if (!inFence && trimmed === '$$') {
+        inMathBlock = !inMathBlock;
+      }
+
+      if (!inFence && !inMathBlock && trimmed === '') {
+        flush(lineNumber);
+        startLine = lineNumber + 1;
+        continue;
+      }
+
+      if (buffer.length === 0) startLine = lineNumber;
+      buffer.push(line);
+    }
+
+    flush(lines.length);
+    return blocks;
+  }
+
+  function countRenderedTopLevelElementsForSource(source) {
+    try {
+      const template = document.createElement('template');
+      template.innerHTML = marked.parse(source || '');
+      const count = Array.from(template.content.childNodes).filter(function(node) {
+        return node.nodeType === Node.ELEMENT_NODE || (node.nodeType === Node.TEXT_NODE && node.textContent.trim());
+      }).length;
+      return Math.max(1, count);
+    } catch (error) {
+      return 1;
+    }
+  }
+
+  function applySourceRangesToRenderedPreview(markdown) {
+    if (!markdownPreview) return;
+    const topLevelElements = Array.from(markdownPreview.children).filter(function(element) {
+      return element.nodeType === Node.ELEMENT_NODE && element.id !== 'markdown-preview-skeleton';
+    });
+    if (!topLevelElements.length) return;
+
+    const blocks = splitMarkdownSourceBlocksForLocate(markdown);
+    let elementIndex = 0;
+    blocks.forEach(function(block) {
+      const renderedCount = countRenderedTopLevelElementsForSource(block.source);
+      for (let count = 0; count < renderedCount && elementIndex < topLevelElements.length; count += 1) {
+        const element = topLevelElements[elementIndex];
+        element.setAttribute('data-source-line', String(block.startLine));
+        element.setAttribute('data-source-start', String(block.startLine));
+        element.setAttribute('data-source-end', String(block.endLine));
+        elementIndex += 1;
+      }
+    });
+  }
+
+  function getMarkdownSourceBlockAroundLine(lineNumber) {
+    const lines = (markdownEditor.value || '').replace(/\r\n/g, '\n').split('\n');
+    const targetLine = Math.max(1, Math.min(lines.length, lineNumber));
+    if (!lines[targetLine - 1] || !lines[targetLine - 1].trim()) return null;
+    return splitMarkdownSourceBlocksForLocate(markdownEditor.value || '').find(function(block) {
+      return targetLine >= block.startLine && targetLine <= block.endLine;
+    }) || null;
+  }
+
+  function getEditorSourceRangeFromMouseEvent(event) {
+    if (!event || !markdownEditor) return null;
+    if (!isGeometryInitialized || cachedEditorWidth !== markdownEditor.clientWidth) {
+      refreshEditorWidth();
+    }
+    const rect = markdownEditor.getBoundingClientRect();
+    const styles = window.getComputedStyle(markdownEditor);
+    const paddingTop = parseFloat(styles.paddingTop) || 10;
+    const targetY = event.clientY - rect.top - paddingTop + markdownEditor.scrollTop;
+    if (!Number.isFinite(targetY) || targetY < 0) return null;
+
+    const lines = (markdownEditor.value || '').split('\n');
+    let offset = 0;
+    for (let index = 0; index < lines.length; index += 1) {
+      const lineHeight = getWrappedLineCountMonospace(lines[index] || '', cachedMaxCharsPerLine) * cachedLineHeight;
+      if (targetY <= offset + lineHeight) {
+        return getMarkdownSourceBlockAroundLine(index + 1);
+      }
+      offset += lineHeight;
+    }
+    return null;
+  }
+
+  function getPickedEditorSourceRange(event) {
+    const selectionStart = markdownEditor.selectionStart || 0;
+    const selectionEnd = markdownEditor.selectionEnd || selectionStart;
+    const selectedText = selectionEnd > selectionStart ? markdownEditor.value.slice(selectionStart, selectionEnd) : '';
+    if (!selectedText.trim()) {
+      return getEditorSourceRangeFromMouseEvent(event) || getMarkdownSourceBlockAroundLine(getLineNumberForIndex(selectionStart));
+    }
+    const startLine = getLineNumberForIndex(selectionStart);
+    const effectiveEnd = selectionEnd > selectionStart && markdownEditor.value[selectionEnd - 1] === '\n'
+      ? selectionEnd - 1
+      : selectionEnd;
+    const endLine = getLineNumberForIndex(Math.max(selectionStart, effectiveEnd));
+    const lines = (markdownEditor.value || '').split('\n');
+    let targetLine = startLine;
+    for (let line = startLine; line <= endLine; line += 1) {
+      if ((lines[line - 1] || '').trim()) {
+        targetLine = line;
+        break;
+      }
+    }
+    return getMarkdownSourceBlockAroundLine(targetLine);
+  }
+
+  function getMappedPreviewBlocks() {
+    if (!markdownPreview) return [];
+    return Array.from(markdownPreview.querySelectorAll('[data-source-start], [data-source-line]'))
+      .map(function(element) {
+        const start = parseInt(element.getAttribute('data-source-start') || element.getAttribute('data-source-line'), 10);
+        const end = parseInt(element.getAttribute('data-source-end') || element.getAttribute('data-source-line'), 10);
+        return {
+          element,
+          startLine: Number.isFinite(start) ? start : null,
+          endLine: Number.isFinite(end) ? end : start,
+        };
+      })
+      .filter(function(item) {
+        return item.startLine !== null;
+      });
+  }
+
+  function findPreviewBlockForSourceRange(sourceRange) {
+    if (!sourceRange || !markdownPreview) return null;
+    const mappedBlocks = getMappedPreviewBlocks();
+    let nearest = null;
+    let nearestDistance = Infinity;
+    for (const block of mappedBlocks) {
+      const overlaps = block.startLine <= sourceRange.endLine && block.endLine >= sourceRange.startLine;
+      if (overlaps) return block.element;
+      const distance = Math.min(
+        Math.abs(block.startLine - sourceRange.startLine),
+        Math.abs(block.endLine - sourceRange.endLine)
+      );
+      if (distance < nearestDistance) {
+        nearest = block.element;
+        nearestDistance = distance;
+      }
+    }
+    if (nearest) return nearest;
+    return findPreviewElementBySourceRatio(sourceRange.startLine);
+  }
+
+  function findPreviewElementBySourceRatio(lineNumber) {
+    if (!markdownPreview || !previewPane) return null;
+    const children = Array.from(markdownPreview.children).filter(function(child) {
+      return child.nodeType === Node.ELEMENT_NODE && child.offsetHeight > 0;
+    });
+    if (!children.length) return null;
+    const totalLines = countLinesFast(markdownEditor.value || '');
+    const ratio = totalLines > 1 ? (Math.max(1, lineNumber) - 1) / (totalLines - 1) : 0;
+    const targetTop = ratio * Math.max(0, markdownPreview.scrollHeight - previewPane.clientHeight);
+    return children.reduce(function(best, child) {
+      const distance = Math.abs(child.offsetTop - targetTop);
+      if (!best || distance < best.distance) {
+        return { element: child, distance };
+      }
+      return best;
+    }, null)?.element || null;
+  }
+
+  function getPreviewSourceRangeFromTarget(target) {
+    if (!target || !markdownPreview) return null;
+    const mapped = target.closest('[data-source-start], [data-source-line]');
+    if (mapped && markdownPreview.contains(mapped)) {
+      const start = parseInt(mapped.getAttribute('data-source-start') || mapped.getAttribute('data-source-line'), 10);
+      const end = parseInt(mapped.getAttribute('data-source-end') || mapped.getAttribute('data-source-line'), 10);
+      if (Number.isFinite(start)) {
+        return {
+          element: mapped,
+          sourceRange: {
+            startLine: start,
+            endLine: Number.isFinite(end) ? end : start,
+          },
+        };
+      }
+    }
+
+    const previewBlock = target.closest('.preview-render-block') || target.closest('.markdown-body > *');
+    if (previewBlock && previewPane) {
+      const ratio = previewPane.scrollHeight > previewPane.clientHeight
+        ? Math.max(0, Math.min(1, previewBlock.offsetTop / Math.max(1, previewPane.scrollHeight - previewPane.clientHeight)))
+        : 0;
+      const approximateLine = Math.max(1, Math.round(ratio * Math.max(1, countLinesFast(markdownEditor.value || ''))));
+      const sourceRange = getMarkdownSourceBlockAroundLine(approximateLine) || { startLine: approximateLine, endLine: approximateLine };
+      return { element: previewBlock, sourceRange };
+    }
+
+    return null;
+  }
+
+  function scrollPreviewSectionIntoView(element) {
+    if (!element || !previewPane) return;
+    isProgrammaticScrolling = true;
+    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (window.programmaticScrollTimeout) clearTimeout(window.programmaticScrollTimeout);
+    window.programmaticScrollTimeout = setTimeout(function() {
+      isProgrammaticScrolling = false;
+    }, 900);
+  }
+
+  function highlightPreviewSection(element) {
+    if (!element) return;
+    element.classList.remove('section-locate-preview-highlight');
+    void element.offsetWidth;
+    element.classList.add('section-locate-preview-highlight');
+    setTimeout(function() {
+      element.classList.remove('section-locate-preview-highlight');
+    }, 2300);
+  }
+
+  function getEditorLineBlockMetrics(sourceRange) {
+    if (!sourceRange) return null;
+    if (!isGeometryInitialized || cachedEditorWidth !== markdownEditor.clientWidth) {
+      refreshEditorWidth();
+    }
+    const lines = (markdownEditor.value || '').split('\n');
+    const startLine = Math.max(1, Math.min(lines.length, sourceRange.startLine));
+    const endLine = Math.max(startLine, Math.min(lines.length, sourceRange.endLine));
+    const styles = window.getComputedStyle(markdownEditor);
+    const paddingTop = parseFloat(styles.paddingTop) || 10;
+    let top = paddingTop;
+    for (let index = 0; index < startLine - 1; index += 1) {
+      top += getWrappedLineCountMonospace(lines[index] || '', cachedMaxCharsPerLine) * cachedLineHeight;
+    }
+    let height = 0;
+    for (let index = startLine - 1; index < endLine; index += 1) {
+      height += getWrappedLineCountMonospace(lines[index] || '', cachedMaxCharsPerLine) * cachedLineHeight;
+    }
+    return { top, height: Math.max(cachedLineHeight, height) };
+  }
+
+  function scrollEditorSectionIntoView(sourceRange) {
+    const metrics = getEditorLineBlockMetrics(sourceRange);
+    if (!metrics) return;
+    isProgrammaticScrolling = true;
+    markdownEditor.scrollTo({
+      top: clampEditorScrollTop(metrics.top - (markdownEditor.clientHeight / 2) + (metrics.height / 2)),
+      behavior: 'smooth',
+    });
+    setTimeout(function() {
+      syncEditorScrollOverlays();
+      isProgrammaticScrolling = false;
+    }, 700);
+  }
+
+  function highlightEditorSourceRange(sourceRange) {
+    if (!sourceRange || !editorPaneElement) return;
+    const metrics = getEditorLineBlockMetrics(sourceRange);
+    if (!metrics) return;
+    const styles = window.getComputedStyle(markdownEditor);
+    const paddingLeft = parseFloat(styles.paddingLeft) || cachedPaddingLeft || 10;
+    const highlight = document.createElement('div');
+    highlight.className = 'section-locate-editor-highlight';
+    highlight.style.top = `${markdownEditor.offsetTop + metrics.top - markdownEditor.scrollTop}px`;
+    highlight.style.left = `${markdownEditor.offsetLeft + paddingLeft}px`;
+    highlight.style.height = `${metrics.height}px`;
+    editorPaneElement.appendChild(highlight);
+    setTimeout(function() {
+      highlight.remove();
+    }, 2300);
+  }
+
+  function locateSectionFromEditorPick(event) {
+    const sourceRange = getPickedEditorSourceRange(event);
+    if (!sourceRange) {
+      showSectionLocateMessage('Matching section not found.');
+      return false;
+    }
+    const previewBlock = findPreviewBlockForSourceRange(sourceRange);
+    if (!previewBlock) {
+      showSectionLocateMessage('Matching section not found.');
+      return false;
+    }
+    scrollPreviewSectionIntoView(previewBlock);
+    highlightPreviewSection(previewBlock);
+    setSectionPickMode(false, 'Matching section located.');
+    return true;
+  }
+
+  function locateSectionFromPreviewPick(target) {
+    const match = getPreviewSourceRangeFromTarget(target);
+    if (!match || !match.sourceRange) {
+      showSectionLocateMessage('Matching section not found.');
+      return false;
+    }
+    scrollEditorSectionIntoView(match.sourceRange);
+    setTimeout(function() {
+      highlightEditorSourceRange(match.sourceRange);
+    }, 450);
+    setSectionPickMode(false, 'Matching section located.');
+    return true;
+  }
+
   // Class encapsulating Search & Replace Engine
   class FindReplaceEngine {
     constructor(editor) {
@@ -9816,6 +10199,9 @@ ${selector} .arrowheadPath {
   }
 
   function closeFindReplaceModal() {
+    if (isSectionPickMode) {
+      setSectionPickMode(false);
+    }
     isFindModalOpen = false;
     const panel = document.getElementById('find-replace-modal');
     const contentCont = document.querySelector('.content-container');
@@ -10099,6 +10485,12 @@ ${selector} .arrowheadPath {
     const allBtn = document.getElementById('find-replace-all');
     if (currentBtn) currentBtn.addEventListener('click', replaceCurrentMatch);
     if (allBtn) allBtn.addEventListener('click', replaceAllMatches);
+
+    if (findSectionButton) {
+      findSectionButton.addEventListener('click', function() {
+        setSectionPickMode(!isSectionPickMode);
+      });
+    }
 
     // Close buttons
     const closeBtn = document.getElementById('find-replace-close');
@@ -10553,6 +10945,18 @@ ${selector} .arrowheadPath {
   markdownEditor.addEventListener('keyup', updateLastCursor);
   markdownEditor.addEventListener('mousedown', updateLastCursor);
   markdownEditor.addEventListener('mouseup', updateLastCursor);
+  markdownEditor.addEventListener('mouseup', function(event) {
+    if (!isSectionPickMode) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const pickEvent = {
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
+    setTimeout(function() {
+      locateSectionFromEditorPick(pickEvent);
+    }, 0);
+  });
   markdownEditor.addEventListener('focus', updateLastCursor);
   markdownEditor.addEventListener('beforeinput', function(e) {
     if (!canMutateEditor()) {
@@ -15094,6 +15498,12 @@ ${selector} .arrowheadPath {
       return;
     }
     
+    if (e.key === 'Escape' && isSectionPickMode) {
+      e.preventDefault();
+      setSectionPickMode(false);
+      return;
+    }
+
     // Global Escape dismissal for find-replace panel
     if (e.key === 'Escape' && isFindModalOpen) {
       e.preventDefault();
@@ -17462,6 +17872,13 @@ ${selector} .arrowheadPath {
 
   // Intercept all link clicks in the preview pane to open them securely and prevent page navigation
   if (markdownPreview) {
+    markdownPreview.addEventListener('click', function(e) {
+      if (!isSectionPickMode) return;
+      e.preventDefault();
+      e.stopPropagation();
+      locateSectionFromPreviewPick(e.target);
+    }, true);
+
     markdownPreview.addEventListener('click', function(e) {
       const link = e.target.closest('a');
       if (link) {

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,8 @@
   --fr-btn-active: #0969da;
   --fr-btn-active-bg: #ddf4ff;
   --fr-match-highlight: #ffdf5d;
+  --section-locate-highlight: rgba(255, 223, 93, 0.48);
+  --section-locate-outline: rgba(9, 105, 218, 0.9);
   --fr-match-active: #ff9b30;
   --fr-match-text-color: #24292e;
   --fr-match-active-text-color: #24292e;
@@ -71,6 +73,8 @@
   --fr-btn-active: #2f81f7;
   --fr-btn-active-bg: rgba(56, 139, 253, 0.15);
   --fr-match-highlight: rgba(187, 128, 9, 0.4);
+  --section-locate-highlight: rgba(187, 128, 9, 0.45);
+  --section-locate-outline: rgba(88, 166, 255, 0.95);
   --fr-match-active: #ad6200;
   --fr-match-text-color: #c9d1d9;
   --fr-match-active-text-color: #ffffff;
@@ -731,6 +735,45 @@ body {
   color: var(--fr-match-active-text-color, inherit) !important;
   outline: 1px solid var(--accent-color, #0366d6) !important;
   outline-offset: -1px;
+}
+
+.section-locate-editor-highlight {
+  position: absolute;
+  right: 12px;
+  border-radius: 4px;
+  background-color: var(--section-locate-highlight);
+  outline: 2px solid var(--section-locate-outline);
+  outline-offset: -1px;
+  pointer-events: none;
+  z-index: 2;
+  animation: section-locate-fade 2.2s ease-out forwards;
+}
+
+.section-locate-preview-highlight {
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px var(--section-locate-outline), 0 0 0 9999px rgba(255, 223, 93, 0.08) inset;
+  background-color: var(--section-locate-highlight);
+  animation: section-locate-fade 2.2s ease-out forwards;
+}
+
+.section-pick-active #markdown-editor,
+.section-pick-active .preview-pane [data-source-start],
+.section-pick-active .preview-pane [data-source-line],
+.section-pick-active .preview-pane .preview-render-block,
+.section-pick-active .preview-pane .markdown-body > * {
+  cursor: crosshair;
+}
+
+@keyframes section-locate-fade {
+  0% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 /* Dropdown improvements */
@@ -4278,6 +4321,65 @@ html[lang="ko"] .markdown-body h3 {
 .find-nav-arrow-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.find-section-btn {
+  background: none;
+  border: 1px solid var(--fr-border);
+  color: var(--text-color);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: 4px;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.find-section-btn:hover {
+  background-color: var(--button-hover);
+}
+
+.find-section-btn.active {
+  color: var(--fr-btn-active);
+  border-color: var(--accent-color);
+  background-color: var(--fr-btn-active-bg);
+}
+
+.section-locate-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 1100;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--fr-border);
+  background-color: var(--fr-bg);
+  color: var(--text-color);
+  box-shadow: var(--fr-shadow);
+  font-size: 13px;
+  pointer-events: none;
+  animation: section-locate-toast-fade 2.4s ease-out forwards;
+}
+
+@keyframes section-locate-toast-fade {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 6px);
+  }
+  12% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  78% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 .find-drawer-toggle-row {


### PR DESCRIPTION
## What feature was added

Adds a new **Find Section** button to the existing Find & Replace panel. When active, users can click or select content in the raw Markdown editor or click rendered content in the preview to locate the matching section in the opposite pane.

## Why it is needed

Ratio-based scroll sync can drift when a small Markdown source block renders into a large preview block, such as an image, table, code block, Mermaid/PlantUML/Graphviz/D2/Vega-Lite/WaveDrom/Markmap/ABC diagram, or STL preview. Find Section gives users a manual one-shot way to jump to the matching source or rendered block.

## How Find Section works

- The Find Section button toggles a temporary section-pick mode and exposes `aria-pressed` state.
- The next editor or preview pick attempts to locate the matching opposite pane block.
- A successful locate scrolls the opposite pane, applies a temporary highlight, announces success, and exits pick mode.
- Escape, closing Find & Replace, switching tabs, switching view mode, or clicking Find Section again cancels pick mode.
- Empty/unknown picks show a non-blocking “Matching section not found.” message.

## Editor-to-preview mapping

- Segmented preview blocks now preserve worker-provided `startLine`/`endLine` as `data-source-line`, `data-source-start`, and `data-source-end`.
- Full-render preview paths also stamp source ranges onto rendered top-level preview blocks, so external images and other content that bypass segmented rendering still have source metadata.
- Editor picks derive the closest source block from selected text, or from the click position in the textarea when no selection is active.
- The preview locator finds the exact overlapping mapped block, then falls back to nearest mapped block or proportional preview location.

## Preview-to-editor mapping

- Preview clicks walk up to the nearest mapped rendered block.
- The source range is read from `data-source-start`/`data-source-end`.
- The editor scroll position is calculated using the existing wrapped-line geometry helpers.
- A temporary editor overlay highlight is drawn without changing Markdown content or the user selection.

## Files changed

- `index.html` - adds the Find Section button to the Find & Replace UI.
- `script.js` - adds pick mode state, source-range stamping, editor/preview locate helpers, event handlers, and cancellation behavior.
- `styles.css` - adds button active styling, pick cursor styling, temporary highlights, and non-blocking locate message styling using existing tokens.

## Manual tests performed

- `node --check script.js`
- `git diff --check` (clean; only existing line-ending warnings from Git on Windows)
- Loaded the app locally at `http://127.0.0.1:8765/` with the provided manual test Markdown.
- Verified Find Section button appears and toggles active state / `aria-pressed`.
- Verified full-render source metadata for image (`data-source-start=7`), table (`13`), code (`21`), and Mermaid (`30`).
- Verified editor-to-preview locate exits active mode, scrolls preview, and highlights the mapped Mermaid preview block.
- Verified preview-to-editor locate from Mermaid scrolls editor and flashes a multi-line editor highlight.
- Verified preview-to-editor locate from the table scrolls editor and highlights source.
- Verified Escape cancels Find Section while keeping the Find & Replace panel open.
- Verified existing Find & Replace still reports/highlights matches (`Final` returned two matches in editor and preview).
- Verified no browser console warnings/errors after the interaction tests.

## Known limitations

- Exact mapping depends on block-level source ranges. If a renderer or unusual Markdown structure produces more/fewer top-level elements than expected in full-render mode, Find Section falls back to nearest/proportional matching instead of throwing.
- Existing scroll sync remains the separate ratio-based feature; Find Section does not replace or alter that behavior.

## Compatibility confirmations

- Existing Find & Replace remains functional.
- Existing sync scroll code paths were not replaced or removed, and the sync toggle remains active in split view.
- No Markdown content is modified by Find Section.
- Temporary highlights are CSS classes/overlay elements only and are removed automatically.
- Export, Share Snapshot, and Live Share logic were not changed.
- `main` was not updated directly; all work was done on `fix/find-section-navigation`.