### PR TITLE
chore(release): prepare v3.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable code changes to **Markdown Viewer** are documented here.
 Non-code commits (documentation, planning, README-only updates) are excluded.
 
+## v3.9.3
+
+- **Description:** Redesigned the Markdown Viewer workspace around a professional document Explorer, streamlined toolbar, responsive navigation, consistent icon system, and complete interface localization.
+- **Explorer & Documents:** Added workspace, folder, file, favorite, recent-document, secret-workspace, drag-and-drop, multi-selection, context-menu, bulk-delete, and GitHub repository import workflows. Closing tabs remains separate from deleting documents, and repository imports are grouped into repository-named folders with background progress.
+- **Tabs, Editing & Split View:** Added complete tab-closing commands, synchronized two-document split view, compact long-title handling, shared Edit or Preview modes, save-state feedback, and reliable empty-document behavior.
+- **Toolbar, Icons & Overlays:** Reorganized document and formatting actions, standardized dropdowns, introduced a lightweight local Lucide icon subset with consistent 1.5px strokes, refined the empty state, and unified application dialogs and modal accessibility.
+- **Responsive UI:** Replaced the mobile floating menu with a compact workspace drawer, aligned mobile toolbar and tab sizing with desktop, and improved responsive status, settings, and action layouts.
+- **Localization:** Added complete interface catalogs for 14 languages, covering static and dynamic menus, dialogs, Explorer states, progress messages, validation feedback, titles, and accessibility labels while preserving user-authored Markdown and filenames.
+- **Desktop:** Synchronized the Neutralino desktop application with the redesigned web interface and retained seven standalone Linux, macOS, and Windows release targets.
+- **Date:** 2026-07-20
+- **Commits:** `a7572d682db557563f24ff5f5873267639c19cc6` through `4c04ef7706bb356cecedd388c1c455c9a36f113e`
+- **URL:** https://github.com/ThisIs-Developer/Markdown-Viewer/releases/tag/v3.9.3
+
+---
+
 ## v3.9.2
 
 - **Description:** Added a complete comments-and-suggestions review workflow with responsive controls, lifecycle tracking, and Live Share synchronization.

--- a/desktop-app/neutralino.config.json
+++ b/desktop-app/neutralino.config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/neutralinojs/neutralinojs/main/schemas/neutralino.config.schema.json",
   "applicationId": "com.markdownviewer.desktop",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "defaultMode": "window",
   "port": 0,
   "documentRoot": "/resources/",

--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-viewer-desktop",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-viewer-desktop",
-      "version": "3.9.2"
+      "version": "3.9.3"
     }
   }
 }

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-viewer-desktop",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "private": true,
   "description": "A lightweight Neutralinojs desktop build for Markdown Viewer with live preview, diagrams, math, and PDF/HTML/PNG exports.",
   "scripts": {

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -278,7 +278,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   let currentViewMode = 'split'; // 'editor', 'split', or 'preview'
   const shareSnapshotViewOnlyTabIds = new Set();
   const SHARE_SNAPSHOT_TAB_KIND = 'share-snapshot';
-  const APP_VERSION = '3.9.2';
+  const APP_VERSION = '3.9.3';
   const REVIEW_TARGET_SELECTOR = 'h1, h2, h3, h4, h5, h6, p, pre, .frontmatter-table, .diagram-viewer, .geojson-container, .topojson-container, .stl-container';
   const REVIEW_TEXT_LIMIT = 2000;
   let reviewModeActive = false;

--- a/script.js
+++ b/script.js
@@ -278,7 +278,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   let currentViewMode = 'split'; // 'editor', 'split', or 'preview'
   const shareSnapshotViewOnlyTabIds = new Set();
   const SHARE_SNAPSHOT_TAB_KIND = 'share-snapshot';
-  const APP_VERSION = '3.9.2';
+  const APP_VERSION = '3.9.3';
   const REVIEW_TARGET_SELECTOR = 'h1, h2, h3, h4, h5, h6, p, pre, .frontmatter-table, .diagram-viewer, .geojson-container, .topojson-container, .stl-container';
   const REVIEW_TEXT_LIMIT = 2000;
   let reviewModeActive = false;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'markdown-viewer-cache-v3.9.2-i18n2';
+const CACHE_NAME = 'markdown-viewer-cache-v3.9.3-i18n2';
 
 // PERF-011: Split precache into critical (local files) and lazy (CDN libraries)
 // Critical assets are precached during SW install for instant offline startup


### PR DESCRIPTION
## Summary

Prepares Markdown Viewer **v3.9.3** after the completed Explorer, toolbar, responsive UI, and localization redesign was merged in #222.

## Changes

- updates the browser application version to `3.9.3`
- updates Neutralino and desktop package metadata to `3.9.3`
- synchronizes the bundled desktop application script
- advances the service-worker cache key for clean client upgrades
- adds the complete `v3.9.3` changelog entry

## Release validation

- generated all seven standalone Neutralino desktop binaries locally
- verified release-version consistency across tracked version sources
- `git diff --check` passed
- the local-only static smoke script remains incompatible with the intentionally restored root file layout because it references ignored `assets/js/app.js` paths; it is not tracked or part of the release source

## Release impact

Once merged, tag `v3.9.3` will trigger the desktop release workflow, publish Linux, macOS, and Windows binaries, and generate `SHA256SUMS.txt`.
