### PR TITLE
Fix missing assets in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY sw.js /usr/share/nginx/html/
 COPY manifest.json /usr/share/nginx/html/
 COPY robots.txt /usr/share/nginx/html/
 COPY sitemap.xml /usr/share/nginx/html/
-COPY assets/icon.jpg /usr/share/nginx/html/assets/
+COPY assets/ /usr/share/nginx/html/assets/
 
 # Create a custom nginx configuration with compression and security
 # PERF-020: Added gzip compression for text-based assets


### PR DESCRIPTION
## Summary

The Docker image currently copies only `assets/icon.jpg`, while the application also references additional files from the `assets` directory, such as `assets/lucide-icons.css`.

As a result, requests for missing assets (for example `assets/lucide-icons.css`) return `404`, causing toolbar icons to be missing in Docker deployments.

I noticed this because the live preview renders correctly, while a container created from the published Docker image does not.

## Change

```diff
- COPY assets/icon.jpg /usr/share/nginx/html/assets/
+ COPY assets/ /usr/share/nginx/html/assets/
```

## Testing

- Built the Docker image locally
- Verified `/assets/lucide-icons.css` returns `200 OK`
- Verified toolbar icons render correctly