### PR TITLE
feat(editor): add productivity keyboard shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                     </button>
 
                     <div class="dropdown settings-dropdown">
-                        <button class="header-icon-command" type="button" id="workspaceSettingsDropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" title="Workspace settings" aria-label="Open workspace settings">
+                        <button class="header-icon-command" type="button" id="workspaceSettingsDropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" title="Workspace settings (Ctrl/Cmd+,)" aria-label="Open workspace settings" aria-keyshortcuts="Control+, Meta+,">
                             <i class="lucide lucide-settings" aria-hidden="true"></i>
                         </button>
                         <div class="dropdown-menu dropdown-menu-end settings-menu" aria-labelledby="workspaceSettingsDropdown">
@@ -421,7 +421,7 @@
             <label class="visually-hidden" for="document-sidebar-search">Search files</label>
             <div class="document-sidebar-search-wrap">
               <i class="lucide lucide-search" aria-hidden="true"></i>
-              <input id="document-sidebar-search" type="search" autocomplete="off" placeholder="Search files" />
+              <input id="document-sidebar-search" type="search" autocomplete="off" placeholder="Search files" title="Quick open (Ctrl/Cmd+P)" aria-keyshortcuts="Control+P Meta+P" />
               <button id="document-sidebar-search-clear" type="button" aria-label="Clear document search" title="Clear search" hidden>
                 <i class="lucide lucide-x" aria-hidden="true"></i>
               </button>
@@ -457,7 +457,7 @@
           <div class="document-editor-area" id="document-editor-area">
             <!-- Tab Bar -->
             <div class="tab-bar" id="tab-bar">
-              <button id="document-sidebar-open" class="tool-button document-sidebar-open" type="button" title="Close Explorer" aria-label="Close Explorer" aria-controls="document-sidebar" aria-expanded="true">
+              <button id="document-sidebar-open" class="tool-button document-sidebar-open" type="button" title="Close Explorer (Ctrl/Cmd+Shift+L)" aria-label="Close Explorer" aria-keyshortcuts="Control+Shift+L Meta+Shift+L" aria-controls="document-sidebar" aria-expanded="true">
                 <i class="lucide lucide-panel-left-close" aria-hidden="true"></i>
               </button>
               <span class="document-sidebar-tab-divider" aria-hidden="true"></span>
@@ -470,8 +470,8 @@
         <!-- Markdown Formatting Toolbar -->
         <div class="markdown-format-toolbar" id="markdown-format-toolbar" role="toolbar" aria-label="Markdown formatting toolbar for plain-text editing">
           <div class="markdown-toolbar-group" role="group" aria-label="History">
-            <button type="button" class="markdown-tool-btn" data-md-action="undo" title="Undo" aria-label="Undo"><i class="lucide lucide-undo-2"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="redo" title="Redo" aria-label="Redo"><i class="lucide lucide-redo-2"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="undo" title="Undo (Ctrl/Cmd+Z)" aria-label="Undo" aria-keyshortcuts="Control+Z Meta+Z"><i class="lucide lucide-undo-2"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="redo" title="Redo (Ctrl/Cmd+Shift+Z or Ctrl/Cmd+Y)" aria-label="Redo" aria-keyshortcuts="Control+Shift+Z Meta+Shift+Z Control+Y Meta+Y"><i class="lucide lucide-redo-2"></i></button>
           </div>
           <div class="markdown-toolbar-group" role="group" aria-label="Common formatting">
             <div class="markdown-tool-dropdown">
@@ -479,17 +479,17 @@
                 <span class="markdown-tool-select-label">H</span><i class="lucide lucide-chevron-down" aria-hidden="true"></i>
               </button>
               <div class="markdown-tool-menu markdown-tool-menu--heading" data-toolbar-menu="heading" role="menu" aria-label="Heading levels">
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="1"><span class="markdown-tool-menu-symbol">H1</span><span>Heading 1</span></button>
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="2"><span class="markdown-tool-menu-symbol">H2</span><span>Heading 2</span></button>
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="3"><span class="markdown-tool-menu-symbol">H3</span><span>Heading 3</span></button>
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="4"><span class="markdown-tool-menu-symbol">H4</span><span>Heading 4</span></button>
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="5"><span class="markdown-tool-menu-symbol">H5</span><span>Heading 5</span></button>
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="6"><span class="markdown-tool-menu-symbol">H6</span><span>Heading 6</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="1" title="Desktop: Ctrl/Cmd+1" aria-keyshortcuts="Control+1 Meta+1"><span class="markdown-tool-menu-symbol">H1</span><span>Heading 1</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="2" title="Desktop: Ctrl/Cmd+2" aria-keyshortcuts="Control+2 Meta+2"><span class="markdown-tool-menu-symbol">H2</span><span>Heading 2</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="3" title="Desktop: Ctrl/Cmd+3" aria-keyshortcuts="Control+3 Meta+3"><span class="markdown-tool-menu-symbol">H3</span><span>Heading 3</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="4" title="Desktop: Ctrl/Cmd+4" aria-keyshortcuts="Control+4 Meta+4"><span class="markdown-tool-menu-symbol">H4</span><span>Heading 4</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="5" title="Desktop: Ctrl/Cmd+5" aria-keyshortcuts="Control+5 Meta+5"><span class="markdown-tool-menu-symbol">H5</span><span>Heading 5</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="6" title="Desktop: Ctrl/Cmd+6" aria-keyshortcuts="Control+6 Meta+6"><span class="markdown-tool-menu-symbol">H6</span><span>Heading 6</span></button>
               </div>
             </div>
             <button type="button" class="markdown-tool-btn" data-md-action="bold" title="Bold (Ctrl/Cmd+B)" aria-label="Bold" aria-keyshortcuts="Control+B Meta+B"><i class="lucide lucide-bold"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="italic" title="Italic (Ctrl/Cmd+I)" aria-label="Italic" aria-keyshortcuts="Control+I Meta+I"><i class="lucide lucide-italic"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="strike" title="Strikethrough" aria-label="Strikethrough"><i class="lucide lucide-strikethrough"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="strike" title="Strikethrough (Alt+Shift+5)" aria-label="Strikethrough" aria-keyshortcuts="Alt+Shift+5"><i class="lucide lucide-strikethrough"></i></button>
           </div>
           <div class="markdown-toolbar-group" role="group" aria-label="Text layout">
             <div class="markdown-tool-dropdown">
@@ -512,12 +512,12 @@
             </div>
           </div>
           <div class="markdown-toolbar-group" role="group" aria-label="Content structure">
-            <button type="button" class="markdown-tool-btn" data-md-action="quote" title="Blockquote" aria-label="Blockquote"><i class="lucide lucide-quote" aria-hidden="true"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="unordered-list" title="Bulleted list" aria-label="Bulleted list"><i class="lucide lucide-list"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="ordered-list" title="Numbered list" aria-label="Numbered list"><i class="lucide lucide-list-ordered"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="inline-code" title="Inline code" aria-label="Inline code"><i class="lucide lucide-code-2" aria-hidden="true"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="quote" title="Blockquote (Ctrl+Shift+Q / Cmd+Option+Q)" aria-label="Blockquote" aria-keyshortcuts="Control+Shift+Q Meta+Alt+Q"><i class="lucide lucide-quote" aria-hidden="true"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="unordered-list" title="Bulleted list (Ctrl+Shift+] / Cmd+Option+U)" aria-label="Bulleted list" aria-keyshortcuts="Control+Shift+] Meta+Alt+U"><i class="lucide lucide-list"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="ordered-list" title="Numbered list (Ctrl+Shift+[ / Cmd+Option+O)" aria-label="Numbered list" aria-keyshortcuts="Control+Shift+[ Meta+Alt+O"><i class="lucide lucide-list-ordered"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="inline-code" title="Inline code (Ctrl/Cmd+Shift+`)" aria-label="Inline code" aria-keyshortcuts="Control+Shift+` Meta+Shift+`"><i class="lucide lucide-code-2" aria-hidden="true"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="table" title="Table" aria-label="Table"><i class="lucide lucide-table-2" aria-hidden="true"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="link" title="Link" aria-label="Link"><i class="lucide lucide-link-2"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="link" title="Link (Ctrl/Cmd+K)" aria-label="Link" aria-keyshortcuts="Control+K Meta+K"><i class="lucide lucide-link-2"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="image" title="Image, GIF, or video" aria-label="Insert image, GIF, or video"><i class="lucide lucide-image" aria-hidden="true"></i></button>
           </div>
           <div class="markdown-toolbar-group" role="group" aria-label="Advanced insertion">
@@ -526,7 +526,7 @@
               <button type="button" class="markdown-tool-btn markdown-tool-select markdown-tool-select--insert" data-toolbar-menu-toggle="insert" aria-haspopup="menu" aria-expanded="false" title="More tools" aria-label="More tools"><i class="lucide lucide-ellipsis" aria-hidden="true"></i></button>
               <div class="markdown-tool-menu markdown-tool-menu--wide" data-toolbar-menu="insert" role="menu" aria-label="More tools">
                 <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="reference"><i class="lucide lucide-bookmark" aria-hidden="true"></i><span>Reference</span></button>
-                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="code-block"><i class="lucide lucide-square-code" aria-hidden="true"></i><span>Code block</span></button>
+                <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="code-block" title="Ctrl+Shift+K / Cmd+Option+C" aria-keyshortcuts="Control+Shift+K Meta+Alt+C"><i class="lucide lucide-square-code" aria-hidden="true"></i><span>Code block</span></button>
                 <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="terminal-block"><i class="lucide lucide-square-terminal" aria-hidden="true"></i><span>Terminal block</span></button>
                 <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="horizontal-rule"><i class="lucide lucide-minus" aria-hidden="true"></i><span>Horizontal rule</span></button>
                 <div class="markdown-tool-menu-separator" role="separator"></div>
@@ -538,14 +538,14 @@
             </div>
           </div>
           <div class="markdown-toolbar-group workspace-format-actions" role="group" aria-label="Workspace actions">
-            <button type="button" class="markdown-tool-btn" data-md-action="find" title="Find and replace" aria-label="Find and replace"><i class="lucide lucide-search" aria-hidden="true"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="fullscreen" title="Fullscreen" aria-label="Enter fullscreen"><i class="lucide lucide-maximize" aria-hidden="true"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="find" title="Find and replace (Ctrl/Cmd+F)" aria-label="Find and replace" aria-keyshortcuts="Control+F Meta+F"><i class="lucide lucide-search" aria-hidden="true"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="fullscreen" title="Fullscreen (F11 / Cmd+Option+F)" aria-label="Enter fullscreen" aria-keyshortcuts="F11 Meta+Alt+F"><i class="lucide lucide-maximize" aria-hidden="true"></i></button>
           </div>
           <div class="markdown-toolbar-group markdown-toolbar-group--document markdown-toolbar-group--utilities" role="group" aria-label="Document utilities and view mode">
-            <button id="toggle-sync" class="tool-button document-command-btn sync-enabled sync-active" type="button" title="Disable synchronized scrolling" aria-label="Disable synchronized scrolling" aria-pressed="true">
+            <button id="toggle-sync" class="tool-button document-command-btn sync-enabled sync-active" type="button" title="Disable synchronized scrolling (Ctrl/Cmd+Shift+S)" aria-label="Disable synchronized scrolling" aria-keyshortcuts="Control+Shift+S Meta+Shift+S" aria-pressed="true">
               <i class="lucide lucide-refresh-cw" aria-hidden="true"></i><span class="btn-text">Sync Off</span>
             </button>
-            <button id="copy-markdown-button" class="tool-button document-command-btn" type="button" title="Copy Markdown" aria-label="Copy Markdown">
+            <button id="copy-markdown-button" class="tool-button document-command-btn" type="button" title="Copy Markdown (Ctrl/Cmd+Shift+C)" aria-label="Copy Markdown" aria-keyshortcuts="Control+Shift+C Meta+Shift+C">
               <i class="lucide lucide-copy" aria-hidden="true"></i><span class="btn-text">Copy Markdown</span>
             </button>
             <button id="review-toggle" class="tool-button document-command-btn" type="button" title="Open comments and suggestions" aria-label="Open comments and suggestions" aria-controls="review-panel" aria-expanded="false" aria-pressed="false">
@@ -553,9 +553,9 @@
             </button>
             <span class="document-command-divider" aria-hidden="true"></span>
             <div class="view-toolbar markdown-view-toolbar" role="group" aria-label="View mode">
-              <button class="tool-button view-toggle-btn" data-view-mode="editor" aria-pressed="false" title="Edit" aria-label="Edit Markdown"><i class="lucide lucide-square-pen" aria-hidden="true"></i></button>
+              <button class="tool-button view-toggle-btn" data-view-mode="editor" aria-pressed="false" title="Edit (Ctrl/Cmd+E toggles Edit/Preview)" aria-label="Edit Markdown" aria-keyshortcuts="Control+E Meta+E"><i class="lucide lucide-square-pen" aria-hidden="true"></i></button>
               <button class="tool-button view-toggle-btn is-active" data-view-mode="split" aria-pressed="true" title="Split" aria-label="Split editor and preview"><i class="lucide lucide-columns-2" aria-hidden="true"></i></button>
-              <button class="tool-button view-toggle-btn" data-view-mode="preview" aria-pressed="false" title="Preview" aria-label="Preview Markdown"><i class="lucide lucide-eye" aria-hidden="true"></i></button>
+              <button class="tool-button view-toggle-btn" data-view-mode="preview" aria-pressed="false" title="Preview (Ctrl/Cmd+E toggles Edit/Preview)" aria-label="Preview Markdown" aria-keyshortcuts="Control+E Meta+E"><i class="lucide lucide-eye" aria-hidden="true"></i></button>
             </div>
           </div>
         </div>
@@ -906,12 +906,16 @@
               <div class="modal-section">
                 <h3 class="modal-section-title">Keyboard shortcuts</h3>
                 <ul class="modal-list">
-                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Z</kbd> &mdash; Undo</li>
-                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> &mdash; Redo</li>
-                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>B</kbd> &mdash; Toggle bold</li>
-                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>I</kbd> &mdash; Toggle italic</li>
-                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>F</kbd> &mdash; Open Find &amp; Replace</li>
-                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>C</kbd>/<kbd>V</kbd> &mdash; Copy/Paste</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Z</kbd> &mdash; Undo; add <kbd>Shift</kbd> (or use <kbd>Y</kbd>) to redo.</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>B</kbd>, <kbd>I</kbd>, or <kbd>K</kbd> &mdash; Toggle bold, toggle italic, or insert a link.</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>`</kbd> &mdash; Toggle inline code; <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>5</kbd> toggles strikethrough.</li>
+                  <li><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd>/<kbd>Q</kbd> &mdash; Code block/blockquote on Windows and Linux; macOS uses <kbd>Cmd</kbd> + <kbd>Option</kbd> + <kbd>C</kbd>/<kbd>Q</kbd>.</li>
+                  <li><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd>/<kbd>]</kbd> &mdash; Numbered/bulleted list on Windows and Linux; macOS uses <kbd>Cmd</kbd> + <kbd>Option</kbd> + <kbd>O</kbd>/<kbd>U</kbd>.</li>
+                  <li><kbd>Tab</kbd>/<kbd>Shift</kbd> + <kbd>Tab</kbd> &mdash; Indent/outdent; desktop <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>0</kbd>&ndash;<kbd>6</kbd> applies paragraph or heading levels.</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>F</kbd>/<kbd>H</kbd> &mdash; Find/replace; <kbd>F3</kbd>/<kbd>Shift</kbd> + <kbd>F3</kbd> moves through matches.</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>P</kbd>, <kbd>O</kbd>, <kbd>E</kbd>, or <kbd>,</kbd> &mdash; Quick open, import, toggle Edit/Preview, or open Settings.</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>/<kbd>L</kbd> &mdash; Copy Markdown or toggle Explorer.</li>
+                  <li><kbd>F11</kbd> (or <kbd>Cmd</kbd> + <kbd>Option</kbd> + <kbd>F</kbd>) &mdash; Fullscreen. Desktop also supports new, close, and next/previous document shortcuts.</li>
                 </ul>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -487,8 +487,8 @@
                 <button type="button" class="markdown-tool-menu-item" role="menuitem" data-md-action="heading" data-md-level="6"><span class="markdown-tool-menu-symbol">H6</span><span>Heading 6</span></button>
               </div>
             </div>
-            <button type="button" class="markdown-tool-btn" data-md-action="bold" title="Bold" aria-label="Bold"><i class="lucide lucide-bold"></i></button>
-            <button type="button" class="markdown-tool-btn" data-md-action="italic" title="Italic" aria-label="Italic"><i class="lucide lucide-italic"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="bold" title="Bold (Ctrl/Cmd+B)" aria-label="Bold" aria-keyshortcuts="Control+B Meta+B"><i class="lucide lucide-bold"></i></button>
+            <button type="button" class="markdown-tool-btn" data-md-action="italic" title="Italic (Ctrl/Cmd+I)" aria-label="Italic" aria-keyshortcuts="Control+I Meta+I"><i class="lucide lucide-italic"></i></button>
             <button type="button" class="markdown-tool-btn" data-md-action="strike" title="Strikethrough" aria-label="Strikethrough"><i class="lucide lucide-strikethrough"></i></button>
           </div>
           <div class="markdown-toolbar-group" role="group" aria-label="Text layout">
@@ -908,6 +908,8 @@
                 <ul class="modal-list">
                   <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Z</kbd> &mdash; Undo</li>
                   <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> &mdash; Redo</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>B</kbd> &mdash; Toggle bold</li>
+                  <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>I</kbd> &mdash; Toggle italic</li>
                   <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>F</kbd> &mdash; Open Find &amp; Replace</li>
                   <li><kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>C</kbd>/<kbd>V</kbd> &mdash; Copy/Paste</li>
                 </ul>

--- a/script.js
+++ b/script.js
@@ -13912,6 +13912,109 @@ ${selector} .arrowheadPath {
     replaceEditorRange(start, end, replacement, selectionStart, selectionEnd);
   }
 
+  function countRepeatedMarkerBefore(value, index, markerCharacter) {
+    let count = 0;
+    for (let cursor = index - 1; cursor >= 0 && value[cursor] === markerCharacter; cursor -= 1) {
+      count += 1;
+    }
+    return count;
+  }
+
+  function countRepeatedMarkerAfter(value, index, markerCharacter) {
+    let count = 0;
+    for (let cursor = index; cursor < value.length && value[cursor] === markerCharacter; cursor += 1) {
+      count += 1;
+    }
+    return count;
+  }
+
+  function markerRunIncludesFormat(runLength, markerLength) {
+    return markerLength === 1 ? runLength % 2 === 1 : runLength >= markerLength;
+  }
+
+  function selectionIncludesMarkdownMarkers(selected, prefix, suffix) {
+    if (!selected || selected.length < prefix.length + suffix.length) return false;
+    const repeatedMarker = prefix === suffix && prefix.split('').every(function(character) {
+      return character === prefix[0];
+    });
+    if (!repeatedMarker) return selected.startsWith(prefix) && selected.endsWith(suffix);
+
+    const leadingRun = countRepeatedMarkerAfter(selected, 0, prefix[0]);
+    const trailingRun = countRepeatedMarkerBefore(selected, selected.length, prefix[0]);
+    return markerRunIncludesFormat(leadingRun, prefix.length)
+      && markerRunIncludesFormat(trailingRun, suffix.length);
+  }
+
+  function selectionIsSurroundedByMarkdownMarkers(value, start, end, prefix, suffix) {
+    const repeatedMarker = prefix === suffix && prefix.split('').every(function(character) {
+      return character === prefix[0];
+    });
+    if (!repeatedMarker) {
+      return value.slice(Math.max(0, start - prefix.length), start) === prefix
+        && value.slice(end, end + suffix.length) === suffix;
+    }
+
+    const leadingRun = countRepeatedMarkerBefore(value, start, prefix[0]);
+    const trailingRun = countRepeatedMarkerAfter(value, end, suffix[0]);
+    return markerRunIncludesFormat(leadingRun, prefix.length)
+      && markerRunIncludesFormat(trailingRun, suffix.length);
+  }
+
+  function replaceMarkdownEditorRange(editor, start, end, replacement, selectionStart, selectionEnd) {
+    if (editor === markdownEditor) {
+      replaceEditorRange(start, end, replacement, selectionStart, selectionEnd);
+      return;
+    }
+    editor.focus();
+    editor.setRangeText(replacement, start, end, 'end');
+    editor.setSelectionRange(selectionStart, selectionEnd);
+    editor.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function toggleMarkdownSelection(editor, prefix, suffix, placeholder) {
+    const value = editor.value;
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    const selected = value.slice(start, end);
+
+    if (selectionIncludesMarkdownMarkers(selected, prefix, suffix)) {
+      const replacement = selected.slice(prefix.length, selected.length - suffix.length);
+      replaceMarkdownEditorRange(editor, start, end, replacement, start, start + replacement.length);
+      return;
+    }
+
+    if (selectionIsSurroundedByMarkdownMarkers(value, start, end, prefix, suffix)) {
+      const replacementStart = start - prefix.length;
+      const replacementEnd = end + suffix.length;
+      replaceMarkdownEditorRange(editor, replacementStart, replacementEnd, selected, replacementStart, replacementStart + selected.length);
+      return;
+    }
+
+    const content = selected || placeholder;
+    const replacement = prefix + content + suffix;
+    const selectionStart = start + prefix.length;
+    replaceMarkdownEditorRange(editor, start, end, replacement, selectionStart, selectionStart + content.length);
+  }
+
+  function handleMarkdownFormatShortcut(event) {
+    if (event.defaultPrevented || event.isComposing || event.altKey || event.shiftKey || !(event.ctrlKey || event.metaKey)) return;
+    const key = event.key.toLowerCase();
+    if (key !== 'b' && key !== 'i') return;
+
+    event.preventDefault();
+    const editor = event.currentTarget;
+    const isEditable = editor === markdownEditor
+      ? canMutateEditor()
+      : editor === documentSplitEditor && Boolean(secondarySplitTabId) && !editor.readOnly;
+    if (!isEditable) {
+      announceToScreenReader(getEditorReadOnlyMessage());
+      return;
+    }
+
+    if (key === 'b') toggleMarkdownSelection(editor, '**', '**', 'bold text');
+    else toggleMarkdownSelection(editor, '*', '*', 'italic text');
+  }
+
   function getCurrentLineRange() {
     const value = markdownEditor.value;
     const start = markdownEditor.selectionStart;
@@ -18333,9 +18436,9 @@ ${selector} .arrowheadPath {
       return;
     }
 
-    if (action === 'bold') wrapEditorSelection('**', '**', 'bold text');
+    if (action === 'bold') toggleMarkdownSelection(markdownEditor, '**', '**', 'bold text');
     else if (action === 'strike') wrapEditorSelection('~~', '~~', 'struck text');
-    else if (action === 'italic') wrapEditorSelection('*', '*', 'italic text');
+    else if (action === 'italic') toggleMarkdownSelection(markdownEditor, '*', '*', 'italic text');
     else if (action === 'quote') transformEditorLines(function(line) { return line ? '> ' + line.replace(/^>\s?/, '') : '>'; });
     else if (action === 'align-left') insertAlignmentBlock('left');
     else if (action === 'align-center') insertAlignmentBlock('center');
@@ -19174,6 +19277,9 @@ ${selector} .arrowheadPath {
     headerAboutButton.addEventListener('click', openAboutModal);
   }
   
+  markdownEditor.addEventListener('keydown', handleMarkdownFormatShortcut);
+  if (documentSplitEditor) documentSplitEditor.addEventListener('keydown', handleMarkdownFormatShortcut);
+
   // Editor key handlers for list continuation and indentation
   markdownEditor.addEventListener("keydown", function(e) {
     if (!canMutateEditor()) return;

--- a/script.js
+++ b/script.js
@@ -5965,7 +5965,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       openButton.setAttribute('aria-expanded', sidebarOpen ? 'true' : 'false');
       const icon = openButton.querySelector('i');
       if (icon) icon.className = sidebarOpen ? 'lucide lucide-panel-left-close' : 'lucide lucide-panel-left-open';
-      openButton.title = sidebarOpen ? 'Close Explorer' : 'Open Explorer';
+      openButton.title = (sidebarOpen ? 'Close Explorer' : 'Open Explorer') + ' (Ctrl/Cmd+Shift+L)';
       openButton.setAttribute('aria-label', sidebarOpen ? 'Close Explorer' : 'Open Explorer');
     }
     if (backdrop) backdrop.hidden = !mobileOpen;
@@ -13376,7 +13376,7 @@ ${selector} .arrowheadPath {
       : 'Enable synchronized scrolling';
     toggleSyncButton.setAttribute('aria-pressed', String(syncScrollingEnabled));
     toggleSyncButton.setAttribute('aria-label', syncActionLabel);
-    toggleSyncButton.setAttribute('title', syncActionLabel);
+    toggleSyncButton.setAttribute('title', syncActionLabel + ' (Ctrl/Cmd+Shift+S)');
     if (mobileToggleSyncButton) {
       mobileToggleSyncButton.classList.toggle('is-active', syncScrollingEnabled);
       mobileToggleSyncButton.setAttribute('aria-pressed', String(syncScrollingEnabled));
@@ -13902,16 +13902,6 @@ ${selector} .arrowheadPath {
     }
   }
 
-  function wrapEditorSelection(prefix, suffix, placeholder) {
-    const start = markdownEditor.selectionStart;
-    const end = markdownEditor.selectionEnd;
-    const selected = markdownEditor.value.slice(start, end) || placeholder;
-    const replacement = prefix + selected + suffix;
-    const selectionStart = start + prefix.length;
-    const selectionEnd = selectionStart + selected.length;
-    replaceEditorRange(start, end, replacement, selectionStart, selectionEnd);
-  }
-
   function countRepeatedMarkerBefore(value, index, markerCharacter) {
     let count = 0;
     for (let cursor = index - 1; cursor >= 0 && value[cursor] === markerCharacter; cursor -= 1) {
@@ -13996,54 +13986,184 @@ ${selector} .arrowheadPath {
     replaceMarkdownEditorRange(editor, start, end, replacement, selectionStart, selectionStart + content.length);
   }
 
-  function handleMarkdownFormatShortcut(event) {
-    if (event.defaultPrevented || event.isComposing || event.altKey || event.shiftKey || !(event.ctrlKey || event.metaKey)) return;
-    const key = event.key.toLowerCase();
-    if (key !== 'b' && key !== 'i') return;
+  function isMacShortcutPlatform() {
+    const platform = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '';
+    return /mac|iphone|ipad|ipod/i.test(platform);
+  }
 
+  function isMarkdownEditorEditable(editor) {
+    if (editor === markdownEditor) return canMutateEditor();
+    return editor === documentSplitEditor && Boolean(secondarySplitTabId) && !editor.readOnly;
+  }
+
+  function getMarkdownEditorShortcutAction(event) {
+    if (event.defaultPrevented || event.isComposing) return null;
+    const key = event.key.toLowerCase();
+    const primary = event.ctrlKey || event.metaKey;
+    const isMac = isMacShortcutPlatform();
+    const desktop = typeof Neutralino !== 'undefined';
+
+    if (primary && !event.altKey && !event.shiftKey) {
+      if (key === 'b') return 'bold';
+      if (key === 'i') return 'italic';
+      if (key === 'k') return 'link';
+      if (event.code === 'Backslash' || key === '\\') return 'clear-formatting-selection';
+      if (desktop && /^Digit[0-6]$/.test(event.code)) {
+        const level = Number(event.code.slice(-1));
+        return level === 0 ? 'paragraph' : 'heading-' + level;
+      }
+    }
+
+    if (!isMac && event.ctrlKey && !event.metaKey && event.shiftKey && !event.altKey) {
+      if (event.code === 'Backquote') return 'inline-code';
+      if (key === 'k') return 'code-block';
+      if (key === 'q') return 'quote';
+      if (event.code === 'BracketLeft') return 'ordered-list';
+      if (event.code === 'BracketRight') return 'unordered-list';
+    }
+
+    if (isMac && event.metaKey && !event.ctrlKey && !event.shiftKey && event.altKey) {
+      if (key === 'c') return 'code-block';
+      if (key === 'q') return 'quote';
+      if (key === 'o') return 'ordered-list';
+      if (key === 'u') return 'unordered-list';
+    }
+
+    if (isMac && event.metaKey && !event.ctrlKey && event.shiftKey && !event.altKey && event.code === 'Backquote') {
+      return 'inline-code';
+    }
+    if (event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey && event.code === 'Digit5') {
+      return 'strike';
+    }
+    if (isMac && event.ctrlKey && !event.metaKey && event.shiftKey && !event.altKey && event.code === 'Backquote') {
+      return 'strike';
+    }
+    return null;
+  }
+
+  function clearMarkdownFormattingSelection(editor) {
+    let start = editor.selectionStart;
+    let end = editor.selectionEnd;
+    const hadSelection = start !== end;
+    if (!hadSelection) {
+      const line = getCurrentLineRange(editor);
+      start = line.start;
+      end = line.end;
+    }
+    const replacement = stripMarkdownFormatting(editor.value.slice(start, end));
+    const nextStart = hadSelection ? start : start + replacement.length;
+    const nextEnd = hadSelection ? start + replacement.length : nextStart;
+    replaceMarkdownEditorRange(editor, start, end, replacement, nextStart, nextEnd);
+  }
+
+  function insertMarkdownCodeBlock(editor) {
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    const selected = editor.value.slice(start, end) || 'code';
+    insertMarkdownBlock('```\n' + selected + '\n```\n', start, end, editor);
+  }
+
+  function runMarkdownEditorShortcut(action, editor) {
+    if (action === 'bold') toggleMarkdownSelection(editor, '**', '**', 'bold text');
+    else if (action === 'italic') toggleMarkdownSelection(editor, '*', '*', 'italic text');
+    else if (action === 'strike') toggleMarkdownSelection(editor, '~~', '~~', 'struck text');
+    else if (action === 'inline-code') toggleMarkdownSelection(editor, '`', '`', 'code');
+    else if (action === 'link') insertMarkdownLink(editor);
+    else if (action === 'clear-formatting-selection') clearMarkdownFormattingSelection(editor);
+    else if (action === 'quote') transformEditorLines(function(line) { return line ? '> ' + line.replace(/^>\s?/, '') : '>'; }, editor);
+    else if (action === 'ordered-list') applyMarkdownList('ordered', editor);
+    else if (action === 'unordered-list') applyMarkdownList('unordered', editor);
+    else if (action === 'code-block') insertMarkdownCodeBlock(editor);
+    else if (action === 'paragraph') transformEditorLines(function(line) { return line.replace(/^#{1,6}\s+/, ''); }, editor);
+    else if (action.indexOf('heading-') === 0) {
+      const level = Math.max(1, Math.min(6, Number(action.slice('heading-'.length)) || 1));
+      const marker = '#'.repeat(level) + ' ';
+      transformEditorLines(function(line) { return marker + line.replace(/^#{1,6}\s+/, ''); }, editor);
+    }
+  }
+
+  function handleMarkdownFormatShortcut(event) {
+    const action = getMarkdownEditorShortcutAction(event);
+    if (!action) return;
     event.preventDefault();
     const editor = event.currentTarget;
-    const isEditable = editor === markdownEditor
-      ? canMutateEditor()
-      : editor === documentSplitEditor && Boolean(secondarySplitTabId) && !editor.readOnly;
-    if (!isEditable) {
+    if (!isMarkdownEditorEditable(editor)) {
       announceToScreenReader(getEditorReadOnlyMessage());
       return;
     }
-
-    if (key === 'b') toggleMarkdownSelection(editor, '**', '**', 'bold text');
-    else toggleMarkdownSelection(editor, '*', '*', 'italic text');
+    runMarkdownEditorShortcut(action, editor);
   }
 
-  function getCurrentLineRange() {
-    const value = markdownEditor.value;
-    const start = markdownEditor.selectionStart;
+  function adjustMarkdownEditorIndent(editor, outdent) {
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    if (!outdent && start === end) {
+      replaceMarkdownEditorRange(editor, start, end, '  ', start + 2, start + 2);
+      return;
+    }
+
+    const range = getSelectedLineRange(editor);
+    const replacement = range.text.split('\n').map(function(line) {
+      if (!outdent) return '  ' + line;
+      return line.replace(/^(?: {1,2}|\t)/, '');
+    }).join('\n');
+
+    if (start !== end) {
+      replaceMarkdownEditorRange(editor, range.start, range.end, replacement, range.start, range.start + replacement.length);
+      return;
+    }
+
+    const removedLength = range.text.length - replacement.length;
+    const caret = Math.max(range.start, start - Math.max(0, removedLength));
+    replaceMarkdownEditorRange(editor, range.start, range.end, replacement, caret, caret);
+  }
+
+  function handleMarkdownEditorStructureKeydown(event) {
+    const editor = event.currentTarget;
+    if (editor === markdownEditor && handleListEnter(event)) return;
+    if (event.key !== 'Tab') return;
+    if (!isMarkdownEditorEditable(editor)) {
+      event.preventDefault();
+      announceToScreenReader(getEditorReadOnlyMessage());
+      return;
+    }
+    event.preventDefault();
+    adjustMarkdownEditorIndent(editor, event.shiftKey);
+  }
+
+  function getCurrentLineRange(editorOverride) {
+    const editor = editorOverride || markdownEditor;
+    const value = editor.value;
+    const start = editor.selectionStart;
     const lineStart = value.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
     let lineEnd = value.indexOf('\n', start);
     if (lineEnd === -1) lineEnd = value.length;
     return { start: lineStart, end: lineEnd, text: value.slice(lineStart, lineEnd) };
   }
 
-  function getSelectedLineRange() {
-    const value = markdownEditor.value;
-    const start = markdownEditor.selectionStart;
-    const end = markdownEditor.selectionEnd;
+  function getSelectedLineRange(editorOverride) {
+    const editor = editorOverride || markdownEditor;
+    const value = editor.value;
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
     const lineStart = value.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
     let lineEnd = value.indexOf('\n', end);
     if (lineEnd === -1) lineEnd = value.length;
     return { start: lineStart, end: lineEnd, text: value.slice(lineStart, lineEnd) };
   }
 
-  function transformEditorLines(transformer) {
-    const range = getSelectedLineRange();
+  function transformEditorLines(transformer, editorOverride) {
+    const editor = editorOverride || markdownEditor;
+    const range = getSelectedLineRange(editor);
     const replacement = range.text.split('\n').map(transformer).join('\n');
-    replaceEditorRange(range.start, range.end, replacement, range.start, range.start + replacement.length);
+    replaceMarkdownEditorRange(editor, range.start, range.end, replacement, range.start, range.start + replacement.length);
   }
 
-  function getListLineRange() {
-    const value = markdownEditor.value;
-    const start = markdownEditor.selectionStart;
-    const end = markdownEditor.selectionEnd;
+  function getListLineRange(editorOverride) {
+    const editor = editorOverride || markdownEditor;
+    const value = editor.value;
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
     const effectiveEnd = end > start && value[end - 1] === '\n' ? end - 1 : end;
     const lineStart = value.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
     let lineEnd = value.indexOf('\n', effectiveEnd);
@@ -14075,26 +14195,28 @@ ${selector} .arrowheadPath {
     return { indent: match ? match[1] : '', body: match ? match[2] : line };
   }
 
-  function getPreviousLineInfo(lineStart) {
+  function getPreviousLineInfo(lineStart, editorOverride) {
     if (lineStart <= 0) return null;
-    const value = markdownEditor.value;
+    const editor = editorOverride || markdownEditor;
+    const value = editor.value;
     const previousEnd = lineStart - 1;
     const previousStart = previousEnd > 0 ? value.lastIndexOf('\n', previousEnd - 1) + 1 : 0;
     return { start: previousStart, text: value.slice(previousStart, previousEnd) };
   }
 
-  function getOrderedListStartNumber(lineStart) {
-    const previousLine = getPreviousLineInfo(lineStart);
+  function getOrderedListStartNumber(lineStart, editorOverride) {
+    const previousLine = getPreviousLineInfo(lineStart, editorOverride);
     if (!previousLine || !previousLine.text.trim()) return 1;
     const parsed = parseMarkdownListItem(previousLine.text);
     return parsed && parsed.type === 'ordered' ? parsed.number + 1 : 1;
   }
 
-  function applyMarkdownList(type) {
-    const range = getListLineRange();
-    const hadSelection = markdownEditor.selectionStart !== markdownEditor.selectionEnd;
+  function applyMarkdownList(type, editorOverride) {
+    const editor = editorOverride || markdownEditor;
+    const range = getListLineRange(editor);
+    const hadSelection = editor.selectionStart !== editor.selectionEnd;
     const lines = range.text.split('\n');
-    let nextNumber = type === 'ordered' ? getOrderedListStartNumber(range.start) : 1;
+    let nextNumber = type === 'ordered' ? getOrderedListStartNumber(range.start, editor) : 1;
     let firstPrefixLength = null;
 
     const replacement = lines.map(function(line) {
@@ -14111,7 +14233,7 @@ ${selector} .arrowheadPath {
       ? range.start + (firstPrefixLength || 0)
       : range.start + replacement.length;
 
-    replaceEditorRange(range.start, range.end, replacement, caret, caret);
+    replaceMarkdownEditorRange(editor, range.start, range.end, replacement, caret, caret);
   }
 
   function renumberOrderedListAfterPosition(position, nextNumber) {
@@ -14665,15 +14787,16 @@ ${selector} .arrowheadPath {
     replaceEditorRange(start, end, replacement, contentStart, hasSelection ? contentEnd : contentStart);
   }
 
-  function insertMarkdownBlock(block, startOverride, endOverride) {
-    const value = markdownEditor.value;
-    const start = typeof startOverride === 'number' ? startOverride : markdownEditor.selectionStart;
-    const end = typeof endOverride === 'number' ? endOverride : markdownEditor.selectionEnd;
+  function insertMarkdownBlock(block, startOverride, endOverride, editorOverride) {
+    const editor = editorOverride || markdownEditor;
+    const value = editor.value;
+    const start = typeof startOverride === 'number' ? startOverride : editor.selectionStart;
+    const end = typeof endOverride === 'number' ? endOverride : editor.selectionEnd;
     const needsLeadingBreak = start > 0 && value[start - 1] !== '\n';
     const needsTrailingBreak = end < value.length && value[end] !== '\n';
     const replacement = (needsLeadingBreak ? '\n' : '') + block + (needsTrailingBreak ? '\n' : '');
     const caret = start + replacement.length;
-    replaceEditorRange(start, end, replacement, caret, caret);
+    replaceMarkdownEditorRange(editor, start, end, replacement, caret, caret);
   }
 
   function clampNumber(value, min, max, fallback) {
@@ -16581,16 +16704,17 @@ ${selector} .arrowheadPath {
     openAppModal(modal, { focusTarget: searchInput, returnFocus: opener, onClose: closeModal });
   }
 
-  function insertMarkdownLink() {
+  function insertMarkdownLink(editorOverride) {
+    const editor = editorOverride || markdownEditor;
     const modal = document.getElementById('link-modal');
     const urlInput = document.getElementById('link-modal-url');
     const textInput = document.getElementById('link-modal-text');
     const confirmBtn = document.getElementById('link-modal-apply');
     const cancelBtn = document.getElementById('link-modal-cancel');
     if (!modal || !urlInput || !textInput || !confirmBtn || !cancelBtn) return;
-    const start = markdownEditor.selectionStart;
-    const end = markdownEditor.selectionEnd;
-    const selected = markdownEditor.value.slice(start, end);
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    const selected = editor.value.slice(start, end);
     urlInput.value = 'https://';
     textInput.value = selected || '';
     modal.style.display = 'flex';
@@ -16601,7 +16725,7 @@ ${selector} .arrowheadPath {
       const replacement = '[' + linkText + '](' + url + ')';
       modal.style.display = 'none';
       cleanup();
-      replaceEditorRange(start, end, replacement, start + replacement.length, start + replacement.length);
+      replaceMarkdownEditorRange(editor, start, end, replacement, start + replacement.length, start + replacement.length);
     }
 
     function closeModal() {
@@ -18437,7 +18561,7 @@ ${selector} .arrowheadPath {
     }
 
     if (action === 'bold') toggleMarkdownSelection(markdownEditor, '**', '**', 'bold text');
-    else if (action === 'strike') wrapEditorSelection('~~', '~~', 'struck text');
+    else if (action === 'strike') toggleMarkdownSelection(markdownEditor, '~~', '~~', 'struck text');
     else if (action === 'italic') toggleMarkdownSelection(markdownEditor, '*', '*', 'italic text');
     else if (action === 'quote') transformEditorLines(function(line) { return line ? '> ' + line.replace(/^>\s?/, '') : '>'; });
     else if (action === 'align-left') insertAlignmentBlock('left');
@@ -18461,7 +18585,7 @@ ${selector} .arrowheadPath {
     else if (action === 'link') insertMarkdownLink();
     else if (action === 'reference') insertMarkdownReference();
     else if (action === 'image') insertMarkdownImage();
-    else if (action === 'inline-code') wrapEditorSelection('`', '`', 'code');
+    else if (action === 'inline-code') toggleMarkdownSelection(markdownEditor, '`', '`', 'code');
     else if (action === 'code-block') insertMarkdownBlock('```js\n' + (markdownEditor.value.slice(markdownEditor.selectionStart, markdownEditor.selectionEnd) || 'console.log("Hello, Markdown!");') + '\n```\n');
     else if (action === 'table') openTableModal();
     else if (action === 'date-time') {
@@ -19268,7 +19392,7 @@ ${selector} .arrowheadPath {
     const isFullscreen = Boolean(document.fullscreenElement);
     const label = isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen';
     const icon = fullscreenButton.querySelector('i');
-    fullscreenButton.setAttribute('title', label);
+    fullscreenButton.setAttribute('title', label + ' (F11 / Cmd+Option+F)');
     fullscreenButton.setAttribute('aria-label', label);
     if (icon) icon.className = isFullscreen ? 'lucide lucide-minimize' : 'lucide lucide-maximize';
   });
@@ -19281,32 +19405,8 @@ ${selector} .arrowheadPath {
   if (documentSplitEditor) documentSplitEditor.addEventListener('keydown', handleMarkdownFormatShortcut);
 
   // Editor key handlers for list continuation and indentation
-  markdownEditor.addEventListener("keydown", function(e) {
-    if (!canMutateEditor()) return;
-    if (handleListEnter(e)) {
-      return;
-    }
-
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      
-      const start = this.selectionStart;
-      const end = this.selectionEnd;
-      const value = this.value;
-      
-      // Insert 2 spaces
-      const indent = '  '; // 2 spaces
-      
-      // Update textarea value
-      this.value = value.substring(0, start) + indent + value.substring(end);
-      
-      // Update cursor position
-      this.selectionStart = this.selectionEnd = start + indent.length;
-      
-      // Trigger input event to update preview
-      this.dispatchEvent(new Event('input'));
-    }
-  });
+  markdownEditor.addEventListener('keydown', handleMarkdownEditorStructureKeydown);
+  if (documentSplitEditor) documentSplitEditor.addEventListener('keydown', handleMarkdownEditorStructureKeydown);
   
   markdownEditor.addEventListener("scroll", function() {
     cachedScrollTop = this.scrollTop;
@@ -24324,8 +24424,94 @@ ${selector} .arrowheadPath {
   }
 
   document.addEventListener("keydown", function (e) {
+    if (e.defaultPrevented) return;
+    const isCmdOrCtrl = e.ctrlKey || e.metaKey;
+    const isDesktop = typeof Neutralino !== 'undefined';
+    const key = e.key.toLowerCase();
+
+    if (e.key === 'F3') {
+      e.preventDefault();
+      if (!isFindModalOpen) openFindReplaceModal();
+      requestAnimationFrame(function() { cycleFindMatch(e.shiftKey ? -1 : 1); });
+      return;
+    }
+
+    if (isCmdOrCtrl && !e.shiftKey && !e.altKey && key === 'p') {
+      e.preventDefault();
+      openDocumentSidebar();
+      requestAnimationFrame(function() {
+        const searchInput = document.getElementById('document-sidebar-search');
+        if (searchInput) {
+          searchInput.focus();
+          searchInput.select();
+        }
+      });
+      return;
+    }
+
+    if (isCmdOrCtrl && !e.shiftKey && !e.altKey && (e.code === 'Comma' || key === ',')) {
+      e.preventDefault();
+      const settingsToggle = document.getElementById('workspaceSettingsDropdown');
+      if (settingsToggle) settingsToggle.click();
+      return;
+    }
+
+    if (isCmdOrCtrl && !e.shiftKey && !e.altKey && key === 'e') {
+      e.preventDefault();
+      setViewMode(currentViewMode === 'preview' ? 'editor' : 'preview');
+      return;
+    }
+
+    if (isCmdOrCtrl && !e.shiftKey && !e.altKey && key === 'o') {
+      e.preventDefault();
+      if (isDesktop) nativeImportMarkdown();
+      else fileInput.click();
+      return;
+    }
+
+    if (isCmdOrCtrl && e.shiftKey && !e.altKey && key === 'c') {
+      e.preventDefault();
+      const focusedEditor = document.activeElement === documentSplitEditor ? documentSplitEditor : markdownEditor;
+      const selected = focusedEditor.value.slice(focusedEditor.selectionStart, focusedEditor.selectionEnd);
+      copyTextToClipboard(selected || focusedEditor.value)
+        .then(function() { announceToScreenReader(selected ? 'Selected Markdown copied.' : 'Markdown copied.'); })
+        .catch(function(error) { console.warn('Copy Markdown shortcut failed:', error); });
+      return;
+    }
+
+    if (isCmdOrCtrl && e.shiftKey && !e.altKey && key === 'l') {
+      e.preventDefault();
+      toggleDocumentSidebarFromTabBar();
+      return;
+    }
+
+    if (e.key === 'F11' || (isMacShortcutPlatform() && e.metaKey && e.altKey && !e.shiftKey && key === 'f')) {
+      e.preventDefault();
+      runMarkdownTool('fullscreen');
+      return;
+    }
+
+    if (isDesktop && isCmdOrCtrl && !e.shiftKey && !e.altKey && key === 'n') {
+      e.preventDefault();
+      newTab();
+      return;
+    }
+
+    const switchWithControlTab = isDesktop && e.ctrlKey && !e.metaKey && !e.altKey && e.code === 'Tab';
+    const switchWithCommandBackquote = isDesktop && isMacShortcutPlatform() && e.metaKey && !e.ctrlKey && !e.altKey && e.code === 'Backquote';
+    if (switchWithControlTab || switchWithCommandBackquote) {
+      e.preventDefault();
+      const openTabs = getOpenTabs();
+      const activeIndex = openTabs.findIndex(function(tab) { return tab.id === activeTabId; });
+      if (openTabs.length > 1 && activeIndex !== -1) {
+        const direction = e.shiftKey ? -1 : 1;
+        const nextIndex = (activeIndex + direction + openTabs.length) % openTabs.length;
+        switchTab(openTabs[nextIndex].id);
+      }
+      return;
+    }
+
     if (document.activeElement === markdownEditor) {
-      const isCmdOrCtrl = e.ctrlKey || e.metaKey;
       if (!canMutateEditor() && isCmdOrCtrl && ['z', 'y'].indexOf(e.key.toLowerCase()) !== -1) {
         e.preventDefault();
         announceToScreenReader(getEditorReadOnlyMessage());
@@ -24342,11 +24528,11 @@ ${selector} .arrowheadPath {
       }
     }
 
-    if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+    if (isCmdOrCtrl && !e.shiftKey && key === 's') {
       e.preventDefault();
       exportMd.click();
     }
-    if ((e.ctrlKey || e.metaKey) && e.key === "c") {
+    if (isCmdOrCtrl && key === 'c') {
       const activeEl = document.activeElement;
       const isTextControl = activeEl && (activeEl.tagName === "TEXTAREA" || activeEl.tagName === "INPUT");
       const hasSelection = window.getSelection && window.getSelection().toString().trim().length > 0;
@@ -24357,20 +24543,19 @@ ${selector} .arrowheadPath {
       }
     }
     // Story 1.2: Only allow sync toggle shortcut when in split view
-    if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "s") {
+    if (isCmdOrCtrl && e.shiftKey && key === 's') {
       e.preventDefault();
       if (currentViewMode === 'split') {
         toggleSyncScrolling();
       }
     }
-    const isDesktop = typeof Neutralino !== 'undefined';
     // New tab (Ctrl+T on desktop, Alt+Shift+T on web/desktop)
-    if ((isDesktop && (e.ctrlKey || e.metaKey) && e.key === "t") || (e.altKey && e.shiftKey && e.key.toLowerCase() === "t")) {
+    if ((isDesktop && isCmdOrCtrl && key === 't') || (e.altKey && e.shiftKey && key === 't')) {
       e.preventDefault();
       newTab();
     }
     // Close tab (Ctrl+W on desktop, Alt+Shift+W on web/desktop)
-    if ((isDesktop && (e.ctrlKey || e.metaKey) && e.key === "w") || (e.altKey && e.shiftKey && e.key.toLowerCase() === "w")) {
+    if ((isDesktop && isCmdOrCtrl && key === 'w') || (e.altKey && e.shiftKey && key === 'w')) {
       e.preventDefault();
       closeTab(activeTabId);
     }
@@ -26540,9 +26725,9 @@ ${selector} .arrowheadPath {
     if (mTabResetLabel) mTabResetLabel.textContent = translateUiString('Reset workspace');
 
     // View toggle buttons title tooltips
-    document.querySelectorAll('[data-view-mode="editor"]').forEach(b => b.title = translateUiString('Edit Markdown'));
+    document.querySelectorAll('[data-view-mode="editor"]').forEach(b => b.title = translateUiString('Edit Markdown') + ' (Ctrl/Cmd+E toggles Edit/Preview)');
     document.querySelectorAll('[data-view-mode="split"]').forEach(b => b.title = translateUiString('Split editor and live preview'));
-    document.querySelectorAll('[data-view-mode="preview"]').forEach(b => b.title = translateUiString('Markdown preview only'));
+    document.querySelectorAll('[data-view-mode="preview"]').forEach(b => b.title = translateUiString('Markdown preview only') + ' (Ctrl/Cmd+E toggles Edit/Preview)');
     document.querySelectorAll('.mobile-view-mode-btn[data-mode="editor"] span').forEach(s => s.textContent = translateUiString('Edit'));
     document.querySelectorAll('.mobile-view-mode-btn[data-mode="split"] span').forEach(s => s.textContent = translateUiString('Split'));
     document.querySelectorAll('.mobile-view-mode-btn[data-mode="preview"] span').forEach(s => s.textContent = translateUiString('Preview'));

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -445,6 +445,8 @@ Common shortcuts:
 | Save/export Markdown | `Ctrl+S` / `Cmd+S` |
 | Find | `Ctrl+F` / `Cmd+F` |
 | Replace | `Ctrl+H` / `Cmd+H` |
+| Toggle bold | `Ctrl+B` / `Cmd+B` |
+| Toggle italic | `Ctrl+I` / `Cmd+I` |
 | Toggle scroll sync | `Ctrl+Shift+S` / `Cmd+Shift+S` in Split view |
 | Undo | `Ctrl+Z` / `Cmd+Z` |
 | Redo | `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` |

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -438,23 +438,36 @@ Reading time is based on a simple words-per-minute estimate. Counts update as th
 
 ## Keyboard and Accessibility
 
-Common shortcuts:
+Supported shortcuts are grouped below. `Ctrl` applies to Windows/Linux and `Cmd` applies to macOS unless noted.
 
 | Action | Shortcut |
 | :--- | :--- |
-| Save/export Markdown | `Ctrl+S` / `Cmd+S` |
-| Find | `Ctrl+F` / `Cmd+F` |
-| Replace | `Ctrl+H` / `Cmd+H` |
-| Toggle bold | `Ctrl+B` / `Cmd+B` |
-| Toggle italic | `Ctrl+I` / `Cmd+I` |
-| Toggle scroll sync | `Ctrl+Shift+S` / `Cmd+Shift+S` in Split view |
 | Undo | `Ctrl+Z` / `Cmd+Z` |
 | Redo | `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` |
+| Bold, italic, or link | `Ctrl/Cmd+B`, `Ctrl/Cmd+I`, or `Ctrl/Cmd+K` |
+| Strikethrough | `Alt+Shift+5`; macOS also supports ``Ctrl+Shift+` `` |
+| Inline code | Windows/Linux: ``Ctrl+Shift+` ``; macOS: ``Cmd+Shift+` `` |
+| Clear Markdown formatting | `Ctrl+\` / `Cmd+\` |
+| Paragraph or Heading 1&ndash;6 | Desktop: `Ctrl/Cmd+0` or `Ctrl/Cmd+1`&ndash;`6` |
+| Code block or blockquote | Windows/Linux: `Ctrl+Shift+K/Q`; macOS: `Cmd+Option+C/Q` |
+| Numbered or bulleted list | Windows/Linux: `Ctrl+Shift+[/]`; macOS: `Cmd+Option+O/U` |
+| Indent/outdent | `Tab` / `Shift+Tab` in an editor |
+| Find/replace | `Ctrl/Cmd+F` / `Ctrl/Cmd+H` |
+| Next/previous find result | `F3` / `Shift+F3` |
+| Quick open / import Markdown | `Ctrl/Cmd+P` / `Ctrl/Cmd+O` |
+| Save/export Markdown | `Ctrl+S` / `Cmd+S` |
+| Copy / copy raw Markdown | `Ctrl/Cmd+C` / `Ctrl/Cmd+Shift+C` |
+| Toggle Edit/Preview / Explorer | `Ctrl/Cmd+E` / `Ctrl/Cmd+Shift+L` |
+| Open Workspace settings | `Ctrl+,` / `Cmd+,` |
+| Toggle scroll sync | `Ctrl+Shift+S` / `Cmd+Shift+S` in Split view |
+| Fullscreen | `F11`; macOS also supports `Cmd+Option+F` |
+| New document | Desktop: `Ctrl+N` / `Cmd+N` |
 | New tab | Desktop: `Ctrl+T` / `Cmd+T`; web and desktop: `Alt+Shift+T` |
 | Close tab | Desktop: `Ctrl+W` / `Cmd+W`; web and desktop: `Alt+Shift+W` |
-| Indent | `Tab` in the editor |
-| Outdent | `Shift+Tab` in the editor |
+| Next/previous document | Windows/Linux desktop: `Ctrl+Tab` / `Ctrl+Shift+Tab`; macOS desktop: ``Cmd+` `` / ``Cmd+Shift+` `` |
 | Close modals/panels | `Escape` |
+
+The [Usage Guide](Usage-Guide.md#keyboard-shortcuts) lists every shortcut individually, including platform-specific variants and web/desktop notes.
 
 Accessibility behavior:
 

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -194,6 +194,8 @@ Mermaid, Markmap, maps, STL, ABC, and MathJax use client-side libraries. PlantUM
 | Toggle scroll sync in Split view | `Ctrl+Shift+S` / `Cmd+Shift+S` |
 | Find | `Ctrl+F` / `Cmd+F` |
 | Replace | `Ctrl+H` / `Cmd+H` |
+| Toggle bold | `Ctrl+B` / `Cmd+B` |
+| Toggle italic | `Ctrl+I` / `Cmd+I` |
 | Undo | `Ctrl+Z` / `Cmd+Z` |
 | Redo | `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` |
 | New tab | Desktop: `Ctrl+T` / `Cmd+T`; web and desktop: `Alt+Shift+T` |

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -187,23 +187,55 @@ Mermaid, Markmap, maps, STL, ABC, and MathJax use client-side libraries. PlantUM
 
 ## Keyboard Shortcuts
 
+Markdown Viewer follows familiar Typora-style formatting shortcuts and Obsidian-style application navigation where the app has an equivalent command. `Ctrl` applies to Windows/Linux and `Cmd` applies to macOS unless a row says otherwise.
+
+### Editing
+
 | Action | Shortcut |
 | :--- | :--- |
-| Save/export Markdown | `Ctrl+S` / `Cmd+S` |
-| Copy selected text, or whole Markdown when nothing is selected | `Ctrl+C` / `Cmd+C` |
-| Toggle scroll sync in Split view | `Ctrl+Shift+S` / `Cmd+Shift+S` |
-| Find | `Ctrl+F` / `Cmd+F` |
-| Replace | `Ctrl+H` / `Cmd+H` |
-| Toggle bold | `Ctrl+B` / `Cmd+B` |
-| Toggle italic | `Ctrl+I` / `Cmd+I` |
 | Undo | `Ctrl+Z` / `Cmd+Z` |
 | Redo | `Ctrl+Shift+Z`, `Cmd+Shift+Z`, `Ctrl+Y`, or `Cmd+Y` |
-| New tab | Desktop: `Ctrl+T` / `Cmd+T`; web and desktop: `Alt+Shift+T` |
-| Close tab | Desktop: `Ctrl+W` / `Cmd+W`; web and desktop: `Alt+Shift+W` |
+| Toggle bold | `Ctrl+B` / `Cmd+B` |
+| Toggle italic | `Ctrl+I` / `Cmd+I` |
+| Toggle strikethrough | `Alt+Shift+5`; macOS also supports ``Ctrl+Shift+` `` |
+| Toggle inline code | Windows/Linux: ``Ctrl+Shift+` ``; macOS: ``Cmd+Shift+` `` |
+| Insert link | `Ctrl+K` / `Cmd+K` |
+| Clear Markdown formatting from the selection/current line | `Ctrl+\` / `Cmd+\` |
+| Apply paragraph style | Desktop: `Ctrl+0` / `Cmd+0` |
+| Apply Heading 1 through Heading 6 | Desktop: `Ctrl+1`&ndash;`Ctrl+6` / `Cmd+1`&ndash;`Cmd+6` |
+| Insert code block | Windows/Linux: `Ctrl+Shift+K`; macOS: `Cmd+Option+C` |
+| Apply blockquote | Windows/Linux: `Ctrl+Shift+Q`; macOS: `Cmd+Option+Q` |
+| Apply numbered list | Windows/Linux: `Ctrl+Shift+[`; macOS: `Cmd+Option+O` |
+| Apply bulleted list | Windows/Linux: `Ctrl+Shift+]`; macOS: `Cmd+Option+U` |
 | Indent | `Tab` |
 | Outdent | `Shift+Tab` |
+
+### Find and application navigation
+
+| Action | Shortcut |
+| :--- | :--- |
+| Find | `Ctrl+F` / `Cmd+F` |
+| Replace | `Ctrl+H` / `Cmd+H` |
+| Next find result | `F3` |
+| Previous find result | `Shift+F3` |
+| Quick open: show Explorer and focus file search | `Ctrl+P` / `Cmd+P` |
+| Import/open Markdown | `Ctrl+O` / `Cmd+O` |
+| Save/export Markdown | `Ctrl+S` / `Cmd+S` |
+| Copy selected text, or whole Markdown when nothing is selected | `Ctrl+C` / `Cmd+C` |
+| Copy raw Markdown directly | `Ctrl+Shift+C` / `Cmd+Shift+C` |
+| Toggle Edit/Preview | `Ctrl+E` / `Cmd+E` |
+| Toggle Explorer | `Ctrl+Shift+L` / `Cmd+Shift+L` |
+| Open Workspace settings | `Ctrl+,` / `Cmd+,` |
+| Toggle scroll sync in Split view | `Ctrl+Shift+S` / `Cmd+Shift+S` |
+| Toggle fullscreen | `F11`; macOS also supports `Cmd+Option+F` |
+| New document | Desktop: `Ctrl+N` / `Cmd+N` |
+| New tab | Desktop: `Ctrl+T` / `Cmd+T`; web and desktop: `Alt+Shift+T` |
+| Close tab | Desktop: `Ctrl+W` / `Cmd+W`; web and desktop: `Alt+Shift+W` |
+| Next/previous open document | Windows/Linux desktop: `Ctrl+Tab` / `Ctrl+Shift+Tab`; macOS desktop: ``Cmd+` `` / ``Cmd+Shift+` `` |
 | Close modals, panels, tab menus, and diagram modals | `Escape` |
 
-Browser shortcuts are intentionally not all intercepted on the web. For example, web tab creation/closing uses `Alt+Shift+T/W` so the app does not hijack browser tab shortcuts.
+When keyboard focus is on the tab bar, `ArrowLeft`, `ArrowRight`, `Home`, and `End` move focus; `Enter` or `Space` activates the focused tab.
+
+Browser shortcuts are intentionally not all intercepted on the web. For example, document heading shortcuts and `Ctrl/Cmd+T/W` are desktop-only so the app does not hijack browser tab controls; web tab creation/closing uses `Alt+Shift+T/W`.
 
 Related pages: [Features](Features.md), [Markdown Reference](Markdown-Reference.md), [Privacy and Security](Privacy-and-Security.md), and [Troubleshooting](Troubleshooting.md).


### PR DESCRIPTION
## What changed

- Add Typora-style Markdown editing shortcuts for bold, italic, strikethrough, inline code, links, clear formatting, paragraph/headings, code blocks, blockquotes, and ordered/unordered lists.
- Add Obsidian-style productivity navigation for Quick Open, Edit/Preview, Explorer, import, settings, Markdown copy, fullscreen, new/close/switch document, and find-result navigation.
- Support both the primary editor and the secondary two-document editor while respecting read-only documents.
- Make toolbar strikethrough and inline-code actions true toggles.
- Fix Shift+Tab outdent and prevent Ctrl/Cmd+Shift+S from also triggering Markdown export.
- Expose shortcuts in tooltips, `aria-keyshortcuts`, Help, Features, and the Usage Guide.
- Keep browser-reserved tab and heading shortcuts desktop-only where appropriate.

## Why

Issue #237 requested keyboard-first Markdown formatting. This expands that fix into a consistent shortcut system based on familiar Typora and Obsidian conventions, while mapping only commands that have a real equivalent in Markdown Viewer.

## User impact

The app now documents 35 shortcut categories covering 41 individual editing and application actions. Users can format selections, navigate documents, open app surfaces, and control the editor without leaving the keyboard.

## Validation

- `node --check script.js`
- `npm.cmd run build` — passed
- Targeted Playwright shortcut tests — 3 passed
- Full editor regression file — 9 passed; 1 known local tab-count fixture failure because an extra stored/release tab is present at startup

Closes #237