### PR TITLE
fix(stats): refresh word/char/reading-time on every render

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -11188,6 +11188,10 @@ ${selector} .arrowheadPath {
     options = options || {};
     const rawVal = markdownEditor.value;
     const force = options.force === true;
+    // Stats must reflect the current editor content on every render call, even when
+    // the preview HTML itself is skipped below because it's already up to date
+    // (e.g. switching back to a tab whose content didn't change).
+    updateDocumentStats();
     const previewDocumentId = getActivePreviewDocumentId();
     const hasCurrentPreview =
       previewHasCommittedRender &&

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -11139,7 +11139,6 @@ ${selector} .arrowheadPath {
     renderMathJaxNodes(roots, rawVal, context, { snapshotReviewTargets: true });
 
     decorateReviewTargets();
-    updateDocumentStats();
     updateFindHighlights();
     scheduleLineNumberUpdate();
     scheduleAdvancedPostProcessRecovery(rawVal, context);

--- a/script.js
+++ b/script.js
@@ -11188,6 +11188,10 @@ ${selector} .arrowheadPath {
     options = options || {};
     const rawVal = markdownEditor.value;
     const force = options.force === true;
+    // Stats must reflect the current editor content on every render call, even when
+    // the preview HTML itself is skipped below because it's already up to date
+    // (e.g. switching back to a tab whose content didn't change).
+    updateDocumentStats();
     const previewDocumentId = getActivePreviewDocumentId();
     const hasCurrentPreview =
       previewHasCommittedRender &&

--- a/script.js
+++ b/script.js
@@ -11139,7 +11139,6 @@ ${selector} .arrowheadPath {
     renderMathJaxNodes(roots, rawVal, context, { snapshotReviewTargets: true });
 
     decorateReviewTargets();
-    updateDocumentStats();
     updateFindHighlights();
     scheduleLineNumberUpdate();
     scheduleAdvancedPostProcessRecovery(rawVal, context);

--- a/tests/e2e/tab-split-sidebar-update.spec.js
+++ b/tests/e2e/tab-split-sidebar-update.spec.js
@@ -257,6 +257,24 @@ test('closing a tab keeps the document in Files and reopening restores the tab',
   await expect(reopenedRow).toHaveCount(0);
 });
 
+test('reopening the only closed tab restores the word/char/reading-time stats', async ({ page }) => {
+  const closedTabId = await page.locator('#tab-list .tab-item.active').getAttribute('data-tab-id');
+  await setEditorContent(page, '# Kept document\n\nSome words to count here.');
+
+  await expect(page.locator('#word-count')).toHaveText('8');
+  await expect(page.locator('#char-count')).toHaveText('42');
+
+  await page.locator('#tab-list .tab-item.active .tab-close-btn').click();
+  await expect(page.locator('#word-count')).toHaveText('0');
+  await expect(page.locator('#char-count')).toHaveText('0');
+
+  await page.locator(`.document-tree-row[data-document-id="${closedTabId}"] .document-tree-main`).click();
+  await expect(page.locator('#markdown-editor')).toHaveValue('# Kept document\n\nSome words to count here.');
+  await expect(page.locator('#word-count')).toHaveText('8');
+  await expect(page.locator('#char-count')).toHaveText('42');
+  await expect(page.locator('#reading-time')).toHaveText('1');
+});
+
 test('format toolbar consolidates heading, case, alignment, and insert actions', async ({ page }) => {
   await expect(page.locator('[data-md-action="clear-formatting"]')).toHaveCount(0);
   await expect(page.locator('[data-md-action="help"]')).toHaveCount(0);


### PR DESCRIPTION
The word/char/reading-time counters in the footer (and mobile menu) go stale once you close a document and reopen it from Files, without a page reload — they get stuck showing 0 even though the editor has content.

The cause: `updateDocumentStats()` only ran as part of the preview post-processing step, and `renderMarkdown()` skips that step whenever it thinks the preview HTML is already up to date for the active tab (a caching optimization). Closing the only open tab resets the stats to zero. Reopening the same tab hits that cache and returns early before the stats ever get recalculated, so they stay at zero until something forces a full re-render (like reloading the page).

Fix is small: call `updateDocumentStats()` unconditionally at the top of `renderMarkdown()`, so the counters always reflect the current editor content whether or not the preview HTML itself needs regenerating.

Added an e2e test that reproduces it directly — type some content, close the tab, reopen it from Files, and check the counters come back instead of staying at 0. Confirmed it fails on the old code and passes with the fix.

Also ran `npm run check:static` and the full Playwright suite (`--project=chromium`): 109/110 passed. The one failure was an unrelated clipboard-paste test for the secret workspace flow, which is flaky under full parallel load but passes consistently on its own — not something this change touches.

Regenerated `desktop-app/resources/js/script.js` via `node desktop-app/prepare.js` since it bundles a copy of `script.js`.