### PR TITLE
fix(preview): isolate scroll state per document

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -5133,6 +5133,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     tab.lastEditedAt = Number.isFinite(Number(tab.lastEditedAt)) ? Number(tab.lastEditedAt) : tab.createdAt;
     tab.favorite = tab.favorite === true;
     tab.isOpen = tab.isOpen !== false;
+    tab.previewScrollPos = normalizePreviewScrollValue(tab.previewScrollPos);
+    tab.previewScrollLeft = normalizePreviewScrollLeftValue(tab.previewScrollLeft);
 
     if (isTemporaryDocument(tab)) {
       delete tab.workspaceId;
@@ -10947,6 +10949,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       title: title || 'Untitled',
       content: content,
       scrollPos: 0,
+      previewScrollPos: 0,
+      previewScrollLeft: 0,
       viewMode: viewMode,
       reviewThreads: [],
       favorite: false,
@@ -11767,6 +11771,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     tab.content = markdownEditor.value;
     tab.contentLoaded = true;
     tab.scrollPos = markdownEditor.scrollTop;
+    if (
+      previewHasCommittedRender &&
+      previewLastRenderedTabId === tab.id &&
+      !previewContainsSkeleton()
+    ) {
+      savePreviewScrollSnapshot(tab.id, capturePreviewScroll());
+    }
     tab.viewMode = reviewModeActive && reviewPreviousViewModes.has(activeTabId)
       ? reviewPreviousViewModes.get(activeTabId)
       : (currentViewMode || 'split');
@@ -12109,6 +12120,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const previousActiveTabId = activeTabId;
     const swapSplitPanes = tabId === secondarySplitTabId;
     cancelReviewDeleteConfirmation();
+    cancelPendingMainScrollSync();
     saveCurrentTabState();
     saveSecondarySplitState();
     closeReviewComposer();
@@ -12805,12 +12817,49 @@ document.addEventListener("DOMContentLoaded", async function () {
     };
   }
 
-  function restorePreviewScroll(snapshot) {
+  function normalizePreviewScrollValue(value) {
+    const position = Number(value);
+    return Number.isFinite(position) && position >= 0 ? position : 0;
+  }
+
+  function normalizePreviewScrollLeftValue(value) {
+    const position = Number(value);
+    return Number.isFinite(position) ? position : 0;
+  }
+
+  function getPreviewScrollSnapshot(documentId) {
+    const tab = tabs.find(function(item) { return item.id === documentId; });
+    return {
+      top: normalizePreviewScrollValue(tab && tab.previewScrollPos),
+      left: normalizePreviewScrollLeftValue(tab && tab.previewScrollLeft),
+    };
+  }
+
+  function savePreviewScrollSnapshot(documentId, snapshot) {
+    if (!documentId || !snapshot) return;
+    const tab = tabs.find(function(item) { return item.id === documentId; });
+    if (!tab) return;
+    tab.previewScrollPos = normalizePreviewScrollValue(snapshot.top);
+    tab.previewScrollLeft = normalizePreviewScrollLeftValue(snapshot.left);
+  }
+
+  function restorePreviewScroll(snapshot, context) {
     if (!snapshot || !previewPane) return;
     requestAnimationFrame(function() {
+      if (
+        context &&
+        (
+          context.renderId !== previewRenderGeneration ||
+          context.previewDocumentId !== previewLastRenderedTabId ||
+          context.previewDocumentId !== getActivePreviewDocumentId()
+        )
+      ) {
+        return;
+      }
       const maxTop = Math.max(0, previewPane.scrollHeight - previewPane.clientHeight);
-      previewPane.scrollTop = Math.min(maxTop, snapshot.top);
-      previewPane.scrollLeft = snapshot.left;
+      previewPane.scrollTop = Math.min(maxTop, normalizePreviewScrollValue(snapshot.top));
+      previewPane.scrollLeft = normalizePreviewScrollLeftValue(snapshot.left);
+      if (context) savePreviewScrollSnapshot(context.previewDocumentId, capturePreviewScroll());
     });
   }
 
@@ -12949,8 +12998,16 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function commitPreviewHtml(sanitizedHtml, referenceData, rawVal, context) {
-    const shouldRestoreScroll = previewHasCommittedRender && !previewContainsSkeleton();
-    const scrollSnapshot = shouldRestoreScroll ? capturePreviewScroll() : null;
+    const renderedDocumentId = previewLastRenderedTabId;
+    const renderedScrollSnapshot = previewHasCommittedRender && !previewContainsSkeleton()
+      ? capturePreviewScroll()
+      : null;
+    if (renderedScrollSnapshot) {
+      savePreviewScrollSnapshot(renderedDocumentId, renderedScrollSnapshot);
+    }
+    const scrollSnapshot = renderedDocumentId === context.previewDocumentId && renderedScrollSnapshot
+      ? renderedScrollSnapshot
+      : getPreviewScrollSnapshot(context.previewDocumentId);
 
     mathJaxTypesetRunId += 1;
     clearMathJaxPreviewState(markdownPreview);
@@ -12969,7 +13026,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     markdownPreview.removeAttribute('aria-busy');
     markdownPreview.dataset.renderState = 'ready';
 
-    restorePreviewScroll(scrollSnapshot);
+    restorePreviewScroll(scrollSnapshot, context);
     return patchResult;
   }
 
@@ -16669,10 +16726,17 @@ ${selector} .arrowheadPath {
 
   function syncEditorToPreview() {
     if (!syncScrollingEnabled || isPreviewScrolling || isProgrammaticScrolling) return;
+    const sourceDocumentId = activeTabId;
+    if (!sourceDocumentId || previewLastRenderedTabId !== sourceDocumentId) return;
     isEditorScrolling = true;
 
     if (scrollSyncTimeout) cancelAnimationFrame(scrollSyncTimeout);
     scrollSyncTimeout = requestAnimationFrame(function() {
+      scrollSyncTimeout = null;
+      if (activeTabId !== sourceDocumentId || previewLastRenderedTabId !== sourceDocumentId) {
+        isEditorScrolling = false;
+        return;
+      }
       const editorScrollRange = markdownEditor.scrollHeight - markdownEditor.clientHeight;
       const editorScrollRatio =
         editorScrollRange > 0 ? markdownEditor.scrollTop / editorScrollRange : 0;
@@ -16692,10 +16756,17 @@ ${selector} .arrowheadPath {
 
   function syncPreviewToEditor() {
     if (!syncScrollingEnabled || isEditorScrolling || isProgrammaticScrolling) return;
+    const sourceDocumentId = previewLastRenderedTabId;
+    if (!sourceDocumentId || activeTabId !== sourceDocumentId) return;
     isPreviewScrolling = true;
 
     if (scrollSyncTimeout) cancelAnimationFrame(scrollSyncTimeout);
     scrollSyncTimeout = requestAnimationFrame(function() {
+      scrollSyncTimeout = null;
+      if (activeTabId !== sourceDocumentId || previewLastRenderedTabId !== sourceDocumentId) {
+        isPreviewScrolling = false;
+        return;
+      }
       const previewScrollRange = previewPane.scrollHeight - previewPane.clientHeight;
       const previewScrollRatio =
         previewScrollRange > 0 ? previewPane.scrollTop / previewScrollRange : 0;
@@ -16712,6 +16783,15 @@ ${selector} .arrowheadPath {
         isPreviewScrolling = false;
       }, 50);
     });
+  }
+
+  function cancelPendingMainScrollSync() {
+    if (scrollSyncTimeout) {
+      cancelAnimationFrame(scrollSyncTimeout);
+      scrollSyncTimeout = null;
+    }
+    isEditorScrolling = false;
+    isPreviewScrolling = false;
   }
 
   function toggleSyncScrolling() {
@@ -23005,6 +23085,11 @@ ${selector} .arrowheadPath {
     scheduleEditorOverlayScrollSync();
   });
   previewPane.addEventListener("scroll", function() {
+    const renderedDocumentId = previewLastRenderedTabId;
+    if (renderedDocumentId) {
+      savePreviewScrollSnapshot(renderedDocumentId, capturePreviewScroll());
+    }
+    if (renderedDocumentId !== activeTabId) return;
     if (secondarySplitTabId && currentViewMode === 'preview') {
       syncDocumentSplitScroll(previewPane, documentSplitPreview);
     } else {
@@ -26958,19 +27043,32 @@ ${selector} .arrowheadPath {
 
   function captureLiveTabSnapshot() {
     const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
+    const previewSnapshot = previewLastRenderedTabId === activeTabId
+      ? capturePreviewScroll()
+      : getPreviewScrollSnapshot(activeTabId);
     return {
       content: markdownEditor.value || '',
       scrollPos: markdownEditor.scrollTop || 0,
+      previewScrollPos: previewSnapshot ? previewSnapshot.top : 0,
+      previewScrollLeft: previewSnapshot ? previewSnapshot.left : 0,
       viewMode: currentViewMode || (activeTab && activeTab.viewMode) || 'split'
     };
   }
 
   function restoreLiveOriginalTabState(tabId, snapshot) {
-    const restored = snapshot || { content: '', scrollPos: 0, viewMode: 'split' };
+    const restored = snapshot || {
+      content: '',
+      scrollPos: 0,
+      previewScrollPos: 0,
+      previewScrollLeft: 0,
+      viewMode: 'split'
+    };
     const tab = tabs.find(function(t) { return t.id === tabId; });
     if (tab) {
       tab.content = restored.content || '';
       tab.scrollPos = restored.scrollPos || 0;
+      tab.previewScrollPos = normalizePreviewScrollValue(restored.previewScrollPos);
+      tab.previewScrollLeft = normalizePreviewScrollLeftValue(restored.previewScrollLeft);
       tab.viewMode = restored.viewMode || 'split';
     }
 
@@ -27008,6 +27106,8 @@ ${selector} .arrowheadPath {
       tab.content = markdown;
       tab.viewMode = 'split';
       tab.scrollPos = 0;
+      tab.previewScrollPos = 0;
+      tab.previewScrollLeft = 0;
     }
 
     restoreViewMode('split');
@@ -27472,9 +27572,14 @@ ${selector} .arrowheadPath {
       removeTabOnLeave = true;
     } else {
       const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
+      const previewSnapshot = previewLastRenderedTabId === activeTabId
+        ? capturePreviewScroll()
+        : getPreviewScrollSnapshot(activeTabId);
       originalTabSnapshot = options.originalTabSnapshot || (activeTab ? {
         content: typeof markdownEditor.value === 'string' ? markdownEditor.value : activeTab.content,
         scrollPos: typeof markdownEditor.scrollTop === 'number' ? markdownEditor.scrollTop : activeTab.scrollPos,
+        previewScrollPos: previewSnapshot ? previewSnapshot.top : activeTab.previewScrollPos,
+        previewScrollLeft: previewSnapshot ? previewSnapshot.left : activeTab.previewScrollLeft,
         viewMode: currentViewMode || activeTab.viewMode
       } : captureLiveTabSnapshot());
     }

--- a/script.js
+++ b/script.js
@@ -5133,6 +5133,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     tab.lastEditedAt = Number.isFinite(Number(tab.lastEditedAt)) ? Number(tab.lastEditedAt) : tab.createdAt;
     tab.favorite = tab.favorite === true;
     tab.isOpen = tab.isOpen !== false;
+    tab.previewScrollPos = normalizePreviewScrollValue(tab.previewScrollPos);
+    tab.previewScrollLeft = normalizePreviewScrollLeftValue(tab.previewScrollLeft);
 
     if (isTemporaryDocument(tab)) {
       delete tab.workspaceId;
@@ -10947,6 +10949,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       title: title || 'Untitled',
       content: content,
       scrollPos: 0,
+      previewScrollPos: 0,
+      previewScrollLeft: 0,
       viewMode: viewMode,
       reviewThreads: [],
       favorite: false,
@@ -11767,6 +11771,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     tab.content = markdownEditor.value;
     tab.contentLoaded = true;
     tab.scrollPos = markdownEditor.scrollTop;
+    if (
+      previewHasCommittedRender &&
+      previewLastRenderedTabId === tab.id &&
+      !previewContainsSkeleton()
+    ) {
+      savePreviewScrollSnapshot(tab.id, capturePreviewScroll());
+    }
     tab.viewMode = reviewModeActive && reviewPreviousViewModes.has(activeTabId)
       ? reviewPreviousViewModes.get(activeTabId)
       : (currentViewMode || 'split');
@@ -12109,6 +12120,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const previousActiveTabId = activeTabId;
     const swapSplitPanes = tabId === secondarySplitTabId;
     cancelReviewDeleteConfirmation();
+    cancelPendingMainScrollSync();
     saveCurrentTabState();
     saveSecondarySplitState();
     closeReviewComposer();
@@ -12805,12 +12817,49 @@ document.addEventListener("DOMContentLoaded", async function () {
     };
   }
 
-  function restorePreviewScroll(snapshot) {
+  function normalizePreviewScrollValue(value) {
+    const position = Number(value);
+    return Number.isFinite(position) && position >= 0 ? position : 0;
+  }
+
+  function normalizePreviewScrollLeftValue(value) {
+    const position = Number(value);
+    return Number.isFinite(position) ? position : 0;
+  }
+
+  function getPreviewScrollSnapshot(documentId) {
+    const tab = tabs.find(function(item) { return item.id === documentId; });
+    return {
+      top: normalizePreviewScrollValue(tab && tab.previewScrollPos),
+      left: normalizePreviewScrollLeftValue(tab && tab.previewScrollLeft),
+    };
+  }
+
+  function savePreviewScrollSnapshot(documentId, snapshot) {
+    if (!documentId || !snapshot) return;
+    const tab = tabs.find(function(item) { return item.id === documentId; });
+    if (!tab) return;
+    tab.previewScrollPos = normalizePreviewScrollValue(snapshot.top);
+    tab.previewScrollLeft = normalizePreviewScrollLeftValue(snapshot.left);
+  }
+
+  function restorePreviewScroll(snapshot, context) {
     if (!snapshot || !previewPane) return;
     requestAnimationFrame(function() {
+      if (
+        context &&
+        (
+          context.renderId !== previewRenderGeneration ||
+          context.previewDocumentId !== previewLastRenderedTabId ||
+          context.previewDocumentId !== getActivePreviewDocumentId()
+        )
+      ) {
+        return;
+      }
       const maxTop = Math.max(0, previewPane.scrollHeight - previewPane.clientHeight);
-      previewPane.scrollTop = Math.min(maxTop, snapshot.top);
-      previewPane.scrollLeft = snapshot.left;
+      previewPane.scrollTop = Math.min(maxTop, normalizePreviewScrollValue(snapshot.top));
+      previewPane.scrollLeft = normalizePreviewScrollLeftValue(snapshot.left);
+      if (context) savePreviewScrollSnapshot(context.previewDocumentId, capturePreviewScroll());
     });
   }
 
@@ -12949,8 +12998,16 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   function commitPreviewHtml(sanitizedHtml, referenceData, rawVal, context) {
-    const shouldRestoreScroll = previewHasCommittedRender && !previewContainsSkeleton();
-    const scrollSnapshot = shouldRestoreScroll ? capturePreviewScroll() : null;
+    const renderedDocumentId = previewLastRenderedTabId;
+    const renderedScrollSnapshot = previewHasCommittedRender && !previewContainsSkeleton()
+      ? capturePreviewScroll()
+      : null;
+    if (renderedScrollSnapshot) {
+      savePreviewScrollSnapshot(renderedDocumentId, renderedScrollSnapshot);
+    }
+    const scrollSnapshot = renderedDocumentId === context.previewDocumentId && renderedScrollSnapshot
+      ? renderedScrollSnapshot
+      : getPreviewScrollSnapshot(context.previewDocumentId);
 
     mathJaxTypesetRunId += 1;
     clearMathJaxPreviewState(markdownPreview);
@@ -12969,7 +13026,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     markdownPreview.removeAttribute('aria-busy');
     markdownPreview.dataset.renderState = 'ready';
 
-    restorePreviewScroll(scrollSnapshot);
+    restorePreviewScroll(scrollSnapshot, context);
     return patchResult;
   }
 
@@ -16669,10 +16726,17 @@ ${selector} .arrowheadPath {
 
   function syncEditorToPreview() {
     if (!syncScrollingEnabled || isPreviewScrolling || isProgrammaticScrolling) return;
+    const sourceDocumentId = activeTabId;
+    if (!sourceDocumentId || previewLastRenderedTabId !== sourceDocumentId) return;
     isEditorScrolling = true;
 
     if (scrollSyncTimeout) cancelAnimationFrame(scrollSyncTimeout);
     scrollSyncTimeout = requestAnimationFrame(function() {
+      scrollSyncTimeout = null;
+      if (activeTabId !== sourceDocumentId || previewLastRenderedTabId !== sourceDocumentId) {
+        isEditorScrolling = false;
+        return;
+      }
       const editorScrollRange = markdownEditor.scrollHeight - markdownEditor.clientHeight;
       const editorScrollRatio =
         editorScrollRange > 0 ? markdownEditor.scrollTop / editorScrollRange : 0;
@@ -16692,10 +16756,17 @@ ${selector} .arrowheadPath {
 
   function syncPreviewToEditor() {
     if (!syncScrollingEnabled || isEditorScrolling || isProgrammaticScrolling) return;
+    const sourceDocumentId = previewLastRenderedTabId;
+    if (!sourceDocumentId || activeTabId !== sourceDocumentId) return;
     isPreviewScrolling = true;
 
     if (scrollSyncTimeout) cancelAnimationFrame(scrollSyncTimeout);
     scrollSyncTimeout = requestAnimationFrame(function() {
+      scrollSyncTimeout = null;
+      if (activeTabId !== sourceDocumentId || previewLastRenderedTabId !== sourceDocumentId) {
+        isPreviewScrolling = false;
+        return;
+      }
       const previewScrollRange = previewPane.scrollHeight - previewPane.clientHeight;
       const previewScrollRatio =
         previewScrollRange > 0 ? previewPane.scrollTop / previewScrollRange : 0;
@@ -16712,6 +16783,15 @@ ${selector} .arrowheadPath {
         isPreviewScrolling = false;
       }, 50);
     });
+  }
+
+  function cancelPendingMainScrollSync() {
+    if (scrollSyncTimeout) {
+      cancelAnimationFrame(scrollSyncTimeout);
+      scrollSyncTimeout = null;
+    }
+    isEditorScrolling = false;
+    isPreviewScrolling = false;
   }
 
   function toggleSyncScrolling() {
@@ -23005,6 +23085,11 @@ ${selector} .arrowheadPath {
     scheduleEditorOverlayScrollSync();
   });
   previewPane.addEventListener("scroll", function() {
+    const renderedDocumentId = previewLastRenderedTabId;
+    if (renderedDocumentId) {
+      savePreviewScrollSnapshot(renderedDocumentId, capturePreviewScroll());
+    }
+    if (renderedDocumentId !== activeTabId) return;
     if (secondarySplitTabId && currentViewMode === 'preview') {
       syncDocumentSplitScroll(previewPane, documentSplitPreview);
     } else {
@@ -26958,19 +27043,32 @@ ${selector} .arrowheadPath {
 
   function captureLiveTabSnapshot() {
     const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
+    const previewSnapshot = previewLastRenderedTabId === activeTabId
+      ? capturePreviewScroll()
+      : getPreviewScrollSnapshot(activeTabId);
     return {
       content: markdownEditor.value || '',
       scrollPos: markdownEditor.scrollTop || 0,
+      previewScrollPos: previewSnapshot ? previewSnapshot.top : 0,
+      previewScrollLeft: previewSnapshot ? previewSnapshot.left : 0,
       viewMode: currentViewMode || (activeTab && activeTab.viewMode) || 'split'
     };
   }
 
   function restoreLiveOriginalTabState(tabId, snapshot) {
-    const restored = snapshot || { content: '', scrollPos: 0, viewMode: 'split' };
+    const restored = snapshot || {
+      content: '',
+      scrollPos: 0,
+      previewScrollPos: 0,
+      previewScrollLeft: 0,
+      viewMode: 'split'
+    };
     const tab = tabs.find(function(t) { return t.id === tabId; });
     if (tab) {
       tab.content = restored.content || '';
       tab.scrollPos = restored.scrollPos || 0;
+      tab.previewScrollPos = normalizePreviewScrollValue(restored.previewScrollPos);
+      tab.previewScrollLeft = normalizePreviewScrollLeftValue(restored.previewScrollLeft);
       tab.viewMode = restored.viewMode || 'split';
     }
 
@@ -27008,6 +27106,8 @@ ${selector} .arrowheadPath {
       tab.content = markdown;
       tab.viewMode = 'split';
       tab.scrollPos = 0;
+      tab.previewScrollPos = 0;
+      tab.previewScrollLeft = 0;
     }
 
     restoreViewMode('split');
@@ -27472,9 +27572,14 @@ ${selector} .arrowheadPath {
       removeTabOnLeave = true;
     } else {
       const activeTab = tabs.find(function(t) { return t.id === activeTabId; });
+      const previewSnapshot = previewLastRenderedTabId === activeTabId
+        ? capturePreviewScroll()
+        : getPreviewScrollSnapshot(activeTabId);
       originalTabSnapshot = options.originalTabSnapshot || (activeTab ? {
         content: typeof markdownEditor.value === 'string' ? markdownEditor.value : activeTab.content,
         scrollPos: typeof markdownEditor.scrollTop === 'number' ? markdownEditor.scrollTop : activeTab.scrollPos,
+        previewScrollPos: previewSnapshot ? previewSnapshot.top : activeTab.previewScrollPos,
+        previewScrollLeft: previewSnapshot ? previewSnapshot.left : activeTab.previewScrollLeft,
         viewMode: currentViewMode || activeTab.viewMode
       } : captureLiveTabSnapshot());
     }

--- a/tests/e2e/tab-split-sidebar-update.spec.js
+++ b/tests/e2e/tab-split-sidebar-update.spec.js
@@ -5,6 +5,60 @@ test.beforeEach(async ({ page }) => {
   await openApp(page);
 });
 
+function scrollableMarkdown(label, sectionCount) {
+  return `# ${label}\n\n` + Array.from({ length: sectionCount }, (_, index) =>
+    `## ${label} section ${index + 1}\n\n${label} paragraph ${index + 1} is long enough to make each Preview document independently scrollable.`
+  ).join('\n\n');
+}
+
+async function waitForPreviewDocument(page, label) {
+  await expect(page.locator('#markdown-preview')).toHaveAttribute('data-render-state', 'ready');
+  await expect(page.locator('#markdown-preview h1')).toHaveText(label);
+  await page.evaluate(() => new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+}
+
+async function switchToPreviewDocument(page, documentId, label) {
+  const tab = page.locator(`#tab-list .tab-item[data-tab-id="${documentId}"]`);
+  if (await tab.getAttribute('aria-selected') !== 'true') await tab.click();
+  await waitForPreviewDocument(page, label);
+}
+
+async function setPreviewScrollRatio(page, ratio) {
+  const position = await page.locator('.preview-pane').evaluate((preview, targetRatio) => {
+    const max = preview.scrollHeight - preview.clientHeight;
+    preview.scrollTop = max * targetRatio;
+    preview.dispatchEvent(new Event('scroll'));
+    return { top: preview.scrollTop, max };
+  }, ratio);
+  expect(position.max).toBeGreaterThan(1000);
+  await page.evaluate(() => new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+  return position.top;
+}
+
+async function expectPreviewScroll(page, expectedTop) {
+  await expect.poll(async () => {
+    const actualTop = await page.locator('.preview-pane').evaluate(preview => preview.scrollTop);
+    return Math.abs(actualTop - expectedTop);
+  }).toBeLessThanOrEqual(3);
+}
+
+async function createPreviewDocuments(page, documents) {
+  const ids = [];
+  for (let index = 0; index < documents.length; index += 1) {
+    if (index > 0) await page.locator('#tab-new-btn').click();
+    await setEditorContent(page, scrollableMarkdown(documents[index].label, documents[index].sections));
+    await page.locator('.view-toolbar [data-view-mode="preview"]').click();
+    const activeTab = page.locator('#tab-list .tab-item.active');
+    ids.push(await activeTab.getAttribute('data-tab-id'));
+    await waitForPreviewDocument(page, documents[index].label);
+  }
+  return ids;
+}
+
 test('tab bar uses standard file, menu, and close controls', async ({ page }) => {
   const tab = page.locator('#tab-list .tab-item.active');
   await expect(tab.locator('.tab-file-icon')).toHaveClass(/lucide-file-text/);
@@ -117,6 +171,115 @@ test('split view uses one combined tab and offers only edit or preview modes', a
   await page.getByRole('menuitem', { name: 'Exit split view' }).click();
   await expect(page.locator('#document-split-pane')).toBeHidden();
   await expect(page.locator('.view-toolbar [data-view-mode="split"]')).toBeEnabled();
+});
+
+test('Preview scroll positions stay isolated per document with sync enabled', async ({ page }) => {
+  const [documentA, documentB] = await createPreviewDocuments(page, [
+    { label: 'Preview document A', sections: 75 },
+    { label: 'Preview document B', sections: 35 }
+  ]);
+
+  await switchToPreviewDocument(page, documentA, 'Preview document A');
+  const positionA = await setPreviewScrollRatio(page, 0.23);
+  await switchToPreviewDocument(page, documentB, 'Preview document B');
+  await expectPreviewScroll(page, 0);
+  const positionB = await setPreviewScrollRatio(page, 0.74);
+  expect(Math.abs(positionA - positionB)).toBeGreaterThan(300);
+
+  await switchToPreviewDocument(page, documentA, 'Preview document A');
+  await expectPreviewScroll(page, positionA);
+  await page.locator('.view-toolbar [data-view-mode="editor"]').click();
+  await expect(page.locator('#markdown-editor')).toBeVisible();
+  await page.locator('.view-toolbar [data-view-mode="preview"]').click();
+  await waitForPreviewDocument(page, 'Preview document A');
+  await expectPreviewScroll(page, positionA);
+  await page.locator('.view-toolbar [data-view-mode="split"]').click();
+  await expect(page.locator('#markdown-editor')).toBeVisible();
+  await expect(page.locator('#markdown-preview')).toBeVisible();
+  await page.locator('.view-toolbar [data-view-mode="preview"]').click();
+  await waitForPreviewDocument(page, 'Preview document A');
+  await expectPreviewScroll(page, positionA);
+
+  await switchToPreviewDocument(page, documentB, 'Preview document B');
+  await expectPreviewScroll(page, positionB);
+});
+
+test('Preview scroll positions stay isolated per document with sync disabled', async ({ page }) => {
+  await page.locator('#toggle-sync').click();
+  await expect(page.locator('#toggle-sync')).toHaveAttribute('aria-pressed', 'false');
+  const [documentA, documentB] = await createPreviewDocuments(page, [
+    { label: 'Independent Preview A', sections: 60 },
+    { label: 'Independent Preview B', sections: 90 }
+  ]);
+
+  await switchToPreviewDocument(page, documentA, 'Independent Preview A');
+  const positionA = await setPreviewScrollRatio(page, 0.67);
+  await switchToPreviewDocument(page, documentB, 'Independent Preview B');
+  const positionB = await setPreviewScrollRatio(page, 0.31);
+
+  await switchToPreviewDocument(page, documentA, 'Independent Preview A');
+  await expectPreviewScroll(page, positionA);
+  await page.locator('.view-toolbar [data-view-mode="editor"]').click();
+  await expect.poll(() => page.locator('#markdown-editor').evaluate(editor => editor.scrollTop)).toBe(0);
+  await page.locator('.view-toolbar [data-view-mode="preview"]').click();
+  await waitForPreviewDocument(page, 'Independent Preview A');
+  await expectPreviewScroll(page, positionA);
+
+  await switchToPreviewDocument(page, documentB, 'Independent Preview B');
+  await expectPreviewScroll(page, positionB);
+});
+
+test('three Preview documents retain positions after tab reordering and repeated switching', async ({ page }) => {
+  const labels = ['Preview sequence A', 'Preview sequence B', 'Preview sequence C'];
+  const ids = await createPreviewDocuments(page, [
+    { label: labels[0], sections: 45 },
+    { label: labels[1], sections: 75 },
+    { label: labels[2], sections: 105 }
+  ]);
+  const expectedPositions = [];
+  const targetRatios = [0.2, 0.5, 0.8];
+
+  for (let index = 0; index < ids.length; index += 1) {
+    await switchToPreviewDocument(page, ids[index], labels[index]);
+    expectedPositions[index] = await setPreviewScrollRatio(page, targetRatios[index]);
+  }
+
+  await page.locator(`#tab-list .tab-item[data-tab-id="${ids[2]}"]`).dragTo(
+    page.locator(`#tab-list .tab-item[data-tab-id="${ids[0]}"]`)
+  );
+  await expect.poll(() => page.locator('#tab-list .tab-item').evaluateAll(tabs =>
+    tabs.map(tab => tab.getAttribute('data-tab-id'))
+  )).toEqual([ids[2], ids[0], ids[1]]);
+
+  for (const index of [0, 1, 2, 0, 2, 1]) {
+    await switchToPreviewDocument(page, ids[index], labels[index]);
+    await expectPreviewScroll(page, expectedPositions[index]);
+  }
+});
+
+test('newly opened and reopened documents do not inherit another Preview position', async ({ page }) => {
+  const [documentA, documentB] = await createPreviewDocuments(page, [
+    { label: 'Preview reopen A', sections: 80 },
+    { label: 'Preview reopen B', sections: 40 }
+  ]);
+
+  await expectPreviewScroll(page, 0);
+  const positionB = await setPreviewScrollRatio(page, 0.57);
+  await page.locator(`#tab-list .tab-item[data-tab-id="${documentB}"] .tab-close-btn`).click();
+  await switchToPreviewDocument(page, documentA, 'Preview reopen A');
+  const positionA = await setPreviewScrollRatio(page, 0.82);
+  expect(Math.abs(positionA - positionB)).toBeGreaterThan(300);
+
+  await page.locator(`.document-tree-row[data-document-id="${documentB}"] .document-tree-main`).click();
+  await waitForPreviewDocument(page, 'Preview reopen B');
+  await expectPreviewScroll(page, positionB);
+
+  await switchToPreviewDocument(page, documentA, 'Preview reopen A');
+  await page.locator('#tab-new-btn').click();
+  await setEditorContent(page, scrollableMarkdown('Brand new Preview document', 55));
+  await page.locator('.view-toolbar [data-view-mode="preview"]').click();
+  await waitForPreviewDocument(page, 'Brand new Preview document');
+  await expectPreviewScroll(page, 0);
 });
 
 test('header groups document actions before application preferences', async ({ page }) => {


### PR DESCRIPTION
## What changed

- Store main Preview scroll coordinates on each stable document/tab object.
- Save the outgoing rendered document's Preview position before the shared Preview DOM is replaced.
- Restore the incoming document's own position after its Preview commit, clamped to the rendered range and guarded by render/document identity.
- Prevent pending editor/Preview synchronization work and stale Preview scroll events from crossing a document activation boundary.
- Preserve Preview coordinates through Live Share tab snapshots.
- Regenerate the tracked Neutralino desktop resource from the root web source.
- Add Playwright coverage for two documents with Sync on/off, three documents, repeated switching, tab reordering, view-mode transitions, new documents, closing/reopening, and Explorer activation.

## Why

The main Preview uses one DOM scroll container for every document. The render pipeline captured that container's current raw scroll position and restored it after every commit, including commits for a different document. Tabs stored editor scroll state but had no document-owned main Preview state, so switching A → B restored A's pixels into B and switching back restored B's pixels into A.

Issue: #247

## How it was tested

- `npm run check:static` — passed; web and prepared desktop resources match.
- Focused issue regressions — 4/4 passed.
- Full tab/Preview/Split/Files spec — 17/17 passed.
- Editor, Files sidebar, smoke, and rich-renderer group — 37/37 passed.
- Final focused Split + issue regressions + unrelated flake rerun — 6/6 passed.
- Full Chromium suite (`npm test`) — 167/168 passed; one unrelated alert-modal focus assertion was intermittent under suite load and passed both its isolated rerun and the final concurrent focused rerun.
- Standalone browser reproduction with Sync enabled and disabled — A and B restored their own raw pixel positions with no leakage.
- Workspace reload probe — A restored 1811 → 1811 px and B restored 2824 → 2824 px.

## Documentation

No user-facing documentation changes are required; this restores the intended per-document Preview behavior.