### PR TITLE
fix(review): stabilize highlights, links, and image comments

### DIFF
--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -8981,6 +8981,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     textNodes.forEach(function(entry) {
+      const intersectsHighlight = entries.some(function(highlight) {
+        return highlight.start < entry.end && highlight.end > entry.start;
+      });
+      if (!intersectsHighlight) return;
       const boundaries = new Set([0, entry.node.nodeValue.length]);
       entries.forEach(function(highlight) {
         const start = Math.max(entry.start, highlight.start);
@@ -8991,7 +8995,6 @@ document.addEventListener("DOMContentLoaded", async function () {
         }
       });
       const cuts = Array.from(boundaries).sort(function(a, b) { return a - b; });
-      if (cuts.length <= 2) return;
       const fragment = document.createDocumentFragment();
       for (let index = 0; index < cuts.length - 1; index += 1) {
         const localStart = cuts[index];

--- a/desktop-app/resources/js/script.js
+++ b/desktop-app/resources/js/script.js
@@ -30720,7 +30720,16 @@ ${selector} .arrowheadPath {
 
   // Intercept all link clicks in the preview pane to open them securely and prevent page navigation
   if (markdownPreview) {
+    function preventReviewLinkNavigation(event) {
+      const link = event.target && event.target.closest ? event.target.closest('a') : null;
+      if (!reviewModeActive || !link || !markdownPreview.contains(link)) return false;
+      event.preventDefault();
+      return true;
+    }
+
+    markdownPreview.addEventListener('auxclick', preventReviewLinkNavigation);
     markdownPreview.addEventListener('click', function(e) {
+      if (preventReviewLinkNavigation(e)) return;
       const link = e.target.closest('a');
       if (link) {
         const href = link.getAttribute('href');

--- a/desktop-app/resources/styles.css
+++ b/desktop-app/resources/styles.css
@@ -11428,6 +11428,29 @@ html[data-theme="dark"] .mermaid svg {
   }
 }
 
+/* Comments v2 has no block-side action buttons, so legacy review gutters must
+   not change the dimensions or alignment of rendered content. */
+#markdown-preview .review-target:not(.review-target--diagram):not(.review-target--table),
+#markdown-preview .review-target.has-review-thread:not(.review-target--diagram):not(.review-target--table) {
+  padding-inline-end: 0;
+}
+
+#markdown-preview .review-target--heading.has-review-thread,
+#markdown-preview .review-target--heading.is-review-target-active,
+#markdown-preview .review-target--paragraph.has-review-thread,
+#markdown-preview .review-target--paragraph.is-review-target-active {
+  padding-inline-start: 0;
+}
+
+#markdown-preview .review-target--table,
+#markdown-preview .review-target--table.has-review-thread {
+  max-width: 100%;
+}
+
+#markdown-preview .review-target--diagram {
+  padding-block-end: 0;
+}
+
 /* ========================================
    COMPACT APPLICATION OVERLAYS & MOBILE MENU
    ======================================== */

--- a/script.js
+++ b/script.js
@@ -8981,6 +8981,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     textNodes.forEach(function(entry) {
+      const intersectsHighlight = entries.some(function(highlight) {
+        return highlight.start < entry.end && highlight.end > entry.start;
+      });
+      if (!intersectsHighlight) return;
       const boundaries = new Set([0, entry.node.nodeValue.length]);
       entries.forEach(function(highlight) {
         const start = Math.max(entry.start, highlight.start);
@@ -8991,7 +8995,6 @@ document.addEventListener("DOMContentLoaded", async function () {
         }
       });
       const cuts = Array.from(boundaries).sort(function(a, b) { return a - b; });
-      if (cuts.length <= 2) return;
       const fragment = document.createDocumentFragment();
       for (let index = 0; index < cuts.length - 1; index += 1) {
         const localStart = cuts[index];

--- a/script.js
+++ b/script.js
@@ -30720,7 +30720,16 @@ ${selector} .arrowheadPath {
 
   // Intercept all link clicks in the preview pane to open them securely and prevent page navigation
   if (markdownPreview) {
+    function preventReviewLinkNavigation(event) {
+      const link = event.target && event.target.closest ? event.target.closest('a') : null;
+      if (!reviewModeActive || !link || !markdownPreview.contains(link)) return false;
+      event.preventDefault();
+      return true;
+    }
+
+    markdownPreview.addEventListener('auxclick', preventReviewLinkNavigation);
     markdownPreview.addEventListener('click', function(e) {
+      if (preventReviewLinkNavigation(e)) return;
       const link = e.target.closest('a');
       if (link) {
         const href = link.getAttribute('href');

--- a/styles.css
+++ b/styles.css
@@ -11428,6 +11428,29 @@ html[data-theme="dark"] .mermaid svg {
   }
 }
 
+/* Comments v2 has no block-side action buttons, so legacy review gutters must
+   not change the dimensions or alignment of rendered content. */
+#markdown-preview .review-target:not(.review-target--diagram):not(.review-target--table),
+#markdown-preview .review-target.has-review-thread:not(.review-target--diagram):not(.review-target--table) {
+  padding-inline-end: 0;
+}
+
+#markdown-preview .review-target--heading.has-review-thread,
+#markdown-preview .review-target--heading.is-review-target-active,
+#markdown-preview .review-target--paragraph.has-review-thread,
+#markdown-preview .review-target--paragraph.is-review-target-active {
+  padding-inline-start: 0;
+}
+
+#markdown-preview .review-target--table,
+#markdown-preview .review-target--table.has-review-thread {
+  max-width: 100%;
+}
+
+#markdown-preview .review-target--diagram {
+  padding-block-end: 0;
+}
+
 /* ========================================
    COMPACT APPLICATION OVERLAYS & MOBILE MENU
    ======================================== */

--- a/tests/e2e/comments-redesign.spec.js
+++ b/tests/e2e/comments-redesign.spec.js
@@ -281,6 +281,50 @@ Intro ${mixedMarkdown}`);
   }).toBe(mixedText);
 });
 
+test('blocks hyperlinks and linked badges only while Comments mode is active', async ({ page }) => {
+  await setEditorContent(page, `[External link](https://example.com)
+
+[Jump to target](#review-link-target)
+
+<a href="https://github.com/ThisIs-Developer/Markdown-Viewer"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" alt="GitHub badge" width="120" height="24"></a>
+
+<h2 id="review-link-target">Target heading</h2>`);
+  await expect(page.locator('#markdown-preview img[alt="GitHub badge"]')).toBeVisible();
+  await page.evaluate(() => {
+    window.__reviewOpenedUrls = [];
+    window.__reviewAnchorScrolls = 0;
+    window.open = url => {
+      window.__reviewOpenedUrls.push(url);
+      return null;
+    };
+    document.querySelector('#review-link-target').scrollIntoView = () => {
+      window.__reviewAnchorScrolls += 1;
+    };
+  });
+  await page.locator('#review-toggle').click();
+
+  await page.getByRole('link', { name: 'External link' }).click();
+  await page.getByRole('link', { name: 'Jump to target' }).click();
+  await page.locator('#markdown-preview img[alt="GitHub badge"]').click();
+  expect(await page.getByRole('link', { name: 'External link' }).evaluate(link => {
+    return !link.dispatchEvent(new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 }));
+  })).toBe(true);
+  await expect(page.locator('#markdown-preview img[alt="GitHub badge"]')).toHaveClass(/is-review-element-selected/);
+  await expect(page.locator('#review-new-comment')).toBeEnabled();
+  expect(await page.evaluate(() => ({
+    openedUrls: window.__reviewOpenedUrls,
+    anchorScrolls: window.__reviewAnchorScrolls
+  }))).toEqual({ openedUrls: [], anchorScrolls: 0 });
+
+  await page.locator('#review-panel-close').click();
+  await page.getByRole('link', { name: 'External link' }).click();
+  await page.getByRole('link', { name: 'Jump to target' }).click();
+  expect(await page.evaluate(() => ({
+    openedUrls: window.__reviewOpenedUrls,
+    anchorScrolls: window.__reviewAnchorScrolls
+  }))).toEqual({ openedUrls: ['https://example.com'], anchorScrolls: 1 });
+});
+
 test('synchronizes hover and click states in both directions', async ({ page }) => {
   await page.locator('#review-toggle').click();
   await selectPreviewText(page, '#markdown-preview p', 'precise phrase');

--- a/tests/e2e/comments-redesign.spec.js
+++ b/tests/e2e/comments-redesign.spec.js
@@ -217,6 +217,70 @@ test('uses selection → New → Submit and keeps comment metadata compact', asy
   expect(JSON.stringify(await storedDocuments(page))).toContain('This wording is clear.');
 });
 
+test('highlights complete and cross-format inline text-node selections after submit and reload', async ({ page }) => {
+  const leadText = 'A local-first Markdown editor and viewer with live preview.';
+  const mixedText = 'Plain bold italic linked code struck.';
+  const mixedMarkdown = 'Plain **bold** *italic* [linked](https://example.com) `code` ~~struck~~.';
+  await setEditorContent(page, `<div align="center">
+
+  **${leadText}**
+
+  Open, write, organize, review, render, export, and optionally share Markdown.
+
+</div>
+
+${mixedMarkdown}`);
+  await expect(page.locator('#markdown-preview strong').filter({ hasText: leadText })).toBeVisible();
+  await page.locator('#review-toggle').click();
+
+  await addTextComment(page, '#markdown-preview p', leadText, 'Whole bold-node comment.');
+  const leadParagraph = page.locator('#markdown-preview p').filter({ hasText: leadText });
+  await expect(leadParagraph.locator('strong > .review-comment-highlight')).toHaveText(leadText);
+
+  await addTextComment(page, '#markdown-preview p', mixedText, 'Cross-format comment.');
+  const mixedParagraph = page.locator('#markdown-preview p').filter({ hasText: mixedText });
+  await expect.poll(async () => {
+    return (await mixedParagraph.locator('.review-comment-highlight').allTextContents()).join('');
+  }).toBe(mixedText);
+  expect(await mixedParagraph.evaluate(element => ({
+    bold: Boolean(element.querySelector('strong > .review-comment-highlight')),
+    italic: Boolean(element.querySelector('em > .review-comment-highlight')),
+    link: Boolean(element.querySelector('a > .review-comment-highlight')),
+    code: Boolean(element.querySelector('code > .review-comment-highlight')),
+    struck: Boolean(element.querySelector('del > .review-comment-highlight'))
+  }))).toEqual({ bold: true, italic: true, link: true, code: true, struck: true });
+
+  await page.locator('#review-panel-close').click();
+  await setEditorContent(page, `<div align="center">
+
+  ***${leadText}***
+
+  Open, write, organize, review, render, export, and optionally share Markdown.
+
+</div>
+
+Intro ${mixedMarkdown}`);
+  await expect(page.locator('#markdown-preview p').filter({ hasText: `Intro ${mixedText}` })).toBeVisible();
+  await page.locator('#review-toggle').click();
+  await expect(page.locator('#markdown-preview p').filter({ hasText: leadText })
+    .locator('em > strong > .review-comment-highlight')).toHaveText(leadText);
+  await expect.poll(async () => {
+    return (await page.locator('#markdown-preview p').filter({ hasText: `Intro ${mixedText}` })
+      .locator('.review-comment-highlight').allTextContents()).join('');
+  }).toBe(mixedText);
+
+  await page.locator('#review-panel-close').click();
+  await page.reload();
+  await page.locator('#review-toggle').click();
+  await expect(page.locator('.review-thread')).toHaveCount(2);
+  await expect(page.locator('#markdown-preview p').filter({ hasText: leadText })
+    .locator('strong > .review-comment-highlight')).toHaveText(leadText);
+  await expect.poll(async () => {
+    return (await page.locator('#markdown-preview p').filter({ hasText: mixedText })
+      .locator('.review-comment-highlight').allTextContents()).join('');
+  }).toBe(mixedText);
+});
+
 test('synchronizes hover and click states in both directions', async ({ page }) => {
   await page.locator('#review-toggle').click();
   await selectPreviewText(page, '#markdown-preview p', 'precise phrase');

--- a/tests/e2e/comments-redesign.spec.js
+++ b/tests/e2e/comments-redesign.spec.js
@@ -3,7 +3,8 @@ const {
   openApp,
   setEditorContent,
   stubLazyRendererLibraries,
-  storedDocuments
+  storedDocuments,
+  waitForAppReady
 } = require('../helpers/app');
 
 async function selectPreviewText(page, selector, selectedText, clickAfterMouseup = false) {
@@ -200,6 +201,7 @@ test('uses selection → New → Submit and keeps comment metadata compact', asy
 
   await page.locator('#review-panel-close').click();
   await page.reload();
+  await waitForAppReady(page);
   await page.locator('#review-toggle').click();
   await expect(page.locator('.review-thread')).toContainText('This wording is clear.');
   await expect(page.locator('.review-thread-dates')).toBeVisible();
@@ -271,6 +273,7 @@ Intro ${mixedMarkdown}`);
 
   await page.locator('#review-panel-close').click();
   await page.reload();
+  await waitForAppReady(page);
   await page.locator('#review-toggle').click();
   await expect(page.locator('.review-thread')).toHaveCount(2);
   await expect(page.locator('#markdown-preview p').filter({ hasText: leadText })
@@ -323,6 +326,53 @@ test('blocks hyperlinks and linked badges only while Comments mode is active', a
     openedUrls: window.__reviewOpenedUrls,
     anchorScrolls: window.__reviewAnchorScrolls
   }))).toEqual({ openedUrls: ['https://example.com'], anchorScrolls: 1 });
+});
+
+test('keeps image dimensions and visual alignment stable after adding a comment', async ({ page }) => {
+  await setEditorContent(page, `<div align="center">
+
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" alt="Review logo" width="100" height="100">
+
+</div>`);
+  const image = page.locator('#markdown-preview img[alt="Review logo"]');
+  await expect(image).toBeVisible();
+  const readGeometry = () => image.evaluate(element => {
+    const rect = element.getBoundingClientRect();
+    const parentRect = element.parentElement.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    const paddingLeft = parseFloat(style.paddingLeft) || 0;
+    const paddingRight = parseFloat(style.paddingRight) || 0;
+    const borderLeft = parseFloat(style.borderLeftWidth) || 0;
+    const borderRight = parseFloat(style.borderRightWidth) || 0;
+    const contentWidth = rect.width - paddingLeft - paddingRight - borderLeft - borderRight;
+    const contentCenter = rect.left + borderLeft + paddingLeft + (contentWidth / 2);
+    return {
+      width: rect.width,
+      height: rect.height,
+      paddingLeft,
+      paddingRight,
+      contentCenterOffset: contentCenter - (parentRect.left + (parentRect.width / 2))
+    };
+  });
+  const beforeComment = await readGeometry();
+
+  await page.locator('#review-toggle').click();
+  await image.click();
+  expect(await readGeometry()).toEqual(beforeComment);
+  await page.locator('#review-new-comment').click();
+  expect(await readGeometry()).toEqual(beforeComment);
+  await page.locator('#review-feedback-input').fill('Logo comment.');
+  await page.locator('#review-feedback-submit').click();
+  await expect(image).toHaveClass(/review-comment-element/);
+  const afterComment = await readGeometry();
+  expect(afterComment).toEqual(beforeComment);
+
+  await page.locator('#review-panel-close').click();
+  await page.reload();
+  await waitForAppReady(page);
+  await page.locator('#review-toggle').click();
+  await expect(page.locator('.review-thread')).toContainText('Logo comment.');
+  expect(await readGeometry()).toEqual(beforeComment);
 });
 
 test('synchronizes hover and click states in both directions', async ({ page }) => {
@@ -450,6 +500,7 @@ test('adds nested replies and persists their author and timestamp', async ({ pag
   await expect(card.locator('.review-reply')).toHaveCount(2);
 
   await page.reload();
+  await waitForAppReady(page);
   await expect(page.locator('#markdown-preview h1')).toHaveText('Comments redesign');
   await page.locator('#review-toggle').click();
   await expect(page.locator('#review-panel')).toBeVisible();


### PR DESCRIPTION
## What changed
- Treat every rendered text node intersecting a saved review range as highlightable, including selections that cover the entire node.
- Preserve continuous persistent highlights across bold, italic, link, inline-code, and strikethrough boundaries.
- Suppress external links, internal anchors, linked badges, and auxiliary-click navigation while Comments mode is active.
- Keep linked images selectable as comment targets and restore normal link behavior after Comments mode closes.
- Remove obsolete legacy review gutters so image, table, diagram, heading, and paragraph geometry remains unchanged during selection and after comments are added.
- Regenerate the desktop application script and style mirrors.
- Add regressions for the README highlighting structure, submit/re-render/reload persistence, Comments-mode link handling, and before/after image geometry.

## Why
The highlight segmenter used the number of split boundaries to decide whether a text node needed work. A whole-node selection has only its existing start and end boundaries, so it was incorrectly treated as non-intersecting and skipped. This affected fully selected inline nodes and could leave gaps in selections spanning multiple formatted nodes.

Preview links were also handled independently after Review Mode click handling. That allowed hyperlinks and linked badges to open or scroll even during comment selection.

Finally, legacy block-side action styles still reserved 76 px after a commented image even though Comments v2 no longer renders those actions. A 100 px image therefore expanded to a 176 px box and its visible content shifted 38 px off center.

## Testing
- `npm run check:static`
- Focused Review Mode suites: 15 passed in Chromium
- Whole-node/cross-format regression: passed in Chromium, Firefox, and WebKit
- Link and linked-badge regression: passed in Chromium, Firefox, and WebKit
- Image geometry regression (selection, composer, submit, reload): passed in Chromium, Firefox, and WebKit
- Full Chromium suite: 168 passed; one unrelated timing-sensitive encrypted-journal test timed out under the full parallel run and passed independently on retry (1 passed)